### PR TITLE
feat(authoring): add executable script guidance

### DIFF
--- a/rules/script-delegation.md
+++ b/rules/script-delegation.md
@@ -29,6 +29,12 @@ alwaysApply: true
 - Parsing natural language dates, extracting meaning from unstructured text, classifying ambiguous input — these are **not** scripting tasks
 - A script should only handle patterns that are fully enumerable
 
+## Scripts Are Real Files
+
+- Scripts are executable files that live in the tile (e.g., `scripts/request-review.sh`) — not code blocks in SKILL.md for the agent to copy-paste
+- The skill references the script and runs it; the script does the work
+- Code blocks in SKILL.md are for showing the agent what command to run, not for embedding logic the agent should reproduce character-by-character
+
 ## Script Requirements
 
 Scripts follow the baseline in `rules/file-hygiene.md` (exit codes, stderr, idempotency) plus these Tessl-specific requirements:

--- a/rules/skill-authoring.md
+++ b/rules/skill-authoring.md
@@ -40,7 +40,8 @@ alwaysApply: true
 
 ## Script References
 
-- Reference scripts via typed code blocks with full paths: `` `scripts/foo.sh` ``
+- Deterministic operations must be executable script files, not inline code blocks for the agent to copy-paste — see `rules/script-delegation.md`
+- Reference scripts with full paths: `` `scripts/foo.sh` ``
 - Include the expected input/output contract in the step description
 
 ## tile.json Manifest Reference


### PR DESCRIPTION
## Summary
- Scripts must be real executable files in the tile, not code blocks in SKILL.md for the agent to copy-paste
- Added "Scripts Are Real Files" section to `script-delegation.md`
- Updated `skill-authoring.md` script references to cross-reference the delegation rule

## Test plan
- [ ] `tessl tile lint` passes
- [ ] `tessl skill review --threshold 85` passes for both skills
- [ ] CI green