### PR TITLE
Codify post-edit audit, step continuity, and decline-with-evidence

### DIFF
--- a/rules/context-artifacts.md
+++ b/rules/context-artifacts.md
@@ -65,3 +65,11 @@ After modifying rules, audit for cross-rule alignment:
 - New rules don't contradict existing ones
 - Skills follow the conventions their own rules prescribe
 - Documentation tables match `tile.json` entries exactly
+
+## Post-Edit Rule Audit
+
+After editing a rule, audit the repo itself against the new rule text and fix any drift in the same PR:
+
+- Grep for every instance of the pattern the rule governs (`.env.example` files, `SKILL.md` step headings, secret names, etc.) and update them to satisfy the new wording
+- A rule that doesn't describe what's already committed in the repo erodes trust in every rule
+- If drift can't be fixed in the same PR (e.g., because it touches a frozen branch), file a follow-up issue that references the rule-edit commit

--- a/rules/skill-authoring.md
+++ b/rules/skill-authoring.md
@@ -23,6 +23,13 @@ alwaysApply: true
 - When inserting a step, renumber all subsequent steps
 - Each step is one action — if a step has an "and", split it
 
+## Step Continuity
+
+- The default handoff between steps is "continue immediately" — never "pause and wait for the user"
+- When a step hands off to the next, state the continuation explicitly ("Proceed immediately to Step N"); don't rely on implicit reading order
+- If a step can legitimately end the skill, say so explicitly ("Finish here"); otherwise the agent will keep going
+- Ambiguity at step boundaries is the most common cause of agents stalling mid-skill waiting for a nudge that was never needed
+
 ## Keep Skills Compact
 
 - SKILL.md is the execution plan, not a reference manual

--- a/skills/eval-authoring/SKILL.md
+++ b/skills/eval-authoring/SKILL.md
@@ -24,7 +24,7 @@ tessl scenario generate .
 tessl scenario view <id>
 ```
 
-Poll until completed. If it fails, report the error and stop.
+Poll until completed. If it fails, report the error and finish here. When status is completed, proceed immediately to Step 3.
 
 ## Step 3 — Download Scenarios
 
@@ -68,4 +68,4 @@ Baseline and with-context both high (90%+) on positive cases means the eval test
 
 ## Step 10 — Iterate
 
-Fix the identified issues, then re-run from Step 8. Repeat until with-context scores reflect the skill's guidance.
+Fix the identified issues, then re-run from Step 8. Repeat until with-context scores reflect the skill's guidance. Finish here when scores are stable.

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -79,10 +79,10 @@ Loop until `ci.status` is `success` (or `none` if no checks are configured) and 
 ## Step 6 — Address Feedback; No Re-request Needed
 
 - **CI failures**: Fix every one, no exceptions
-- **Review suggestions**: Apply what's right. Push back with a reply on anything that misreads scope or over-engineers
+- **Review suggestions**: Apply what's right and reasonable. Push back on anything that misreads scope or over-engineers — but cite concrete evidence (file:line, log line, spec quote) when declining; never hand-wave
 - **Reply on EVERY thread** — nothing left dangling:
   - Accepted: "Fixed in `<sha>`"
-  - Declined: "Declining — `<reason>`"
+  - Declined: "Declining — `<reason with cited evidence>`"
 - Push fixes to the same branch
 - **Re-run is automatic**: `pull_request: synchronize` re-triggers the gh-aw workflow on every push — no manual re-request. During the trial, Copilot still needs a re-request via `skills/release/request-copilot-review.sh` (same args as Step 4).
 - Repeat Step 5 until every active bot review is `APPROVED` or `COMMENTED` with no blocking items, and every thread has a reply.

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -34,6 +34,8 @@ Structured workflow for shipping code: PR creation, automated policy review, mer
     - [ ] <verification steps>
     ```
 
+Proceed immediately to Step 3 — do not wait for reviews before reasoning about version.
+
 ## Step 3 — Reason About Versioning
 
 Decide the version bump:
@@ -109,3 +111,5 @@ After merge:
 - Verify the merge landed on main
 - Check that the publish CI workflow was triggered
 - Report the outcome: merged PR URL, version published (if applicable)
+
+Finish here — the skill is complete.


### PR DESCRIPTION
## Summary

Three policy additions that surfaced while dogfooding the tile on the gh-aw review cutover (#3):

- **`rules/context-artifacts.md` — new "Post-Edit Rule Audit" section.** After editing a rule, grep the repo for the pattern it governs and fix any drift in the same PR. Rules that don't describe committed reality erode trust in the whole tile. (Lesson: shipped an `.env.example` that didn't satisfy the rule I'd just updated in the same PR.)
- **`rules/skill-authoring.md` — new "Step Continuity" section.** The default handoff between steps is "continue immediately" — never "pause for a nudge". Skills must state continuations explicitly; ambiguity at step boundaries is the most common cause of agents stalling mid-skill. (Lesson: opened PR #3 and stopped, waiting for "now watch" instead of continuing into Step 5.)
- **`skills/release/SKILL.md` Step 6 — tighten decline convention.** Review pushback must cite concrete evidence (file:line, log line, spec quote); never hand-wave a rejection. (Lesson: declining Copilot's permissions suggestion on #3 felt authoritative only because I quoted the compiled lock file directly — that should be the standard, not the exception.)

All three edits are additive and backward-compatible — existing rules and skills continue to work unchanged. No `tile.json` version bump; the `patch-version-publish` CI will auto-bump on merge.

## Test plan

- [ ] `tessl tile lint` passes
- [ ] `tessl skill review --threshold 85 skills/release` still passes (the Step 6 change is wording-only)
- [ ] Evals still pass (no behavioural change to the release skill)
- [ ] PR policy review (gh-aw) approves once its own quota wall is resolved in #3 — that review will read these new rules from this branch's head, so the new guidance is self-reviewed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)