### PR TITLE
feat(rules): add stateful-artifacts rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Rules
 
 - **author-model-declaration** — Every PR declares its author model via a `**Author-Model:**` line in the body (preferred) or a `Co-authored-by:` git trailer (fallback). Defines model families (anthropic, openai, google), plus a special `human` value that maps to no family, and mixed-authorship semantics so the paired reviewers can pick a cross-family reviewer and dodge self-review bias. Missing declaration blocks the PR via early `REQUEST_CHANGES` before the diff is read.
+- **stateful-artifacts** — Cross-invocation JSON state files a skill writes and reads between runs. Every artifact has a documented schema, a single owner skill, a `schema_version` field, and a writer/reader contract. Artifacts are hints, not authority — verify against the live source before acting on a recalled value. Migrations happen under the owner skill, not as a side effect of unrelated runs.
 
 ### Skills
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Coding policy tile for Baruch's AI agents. Language-agnostic code quality rules 
 
 ## What's New
 
-- 13 always-on steering rules: 8 covering code quality, 4 covering plugin authoring, 1 covering author-model declaration
+- 14 always-on steering rules: 8 covering code quality, 5 covering plugin authoring, 1 covering author-model declaration
 - `release` skill — structured PR + merge workflow with Copilot review
 - `eval-authoring` skill — generate, review, and curate eval scenarios
 - Language-agnostic: works with any stack, no Python/JS assumptions
@@ -35,6 +35,7 @@ tessl install jbaruch/coding-policy
 | Authoring | [skill-authoring](rules/skill-authoring.md) | SKILL.md structure, step numbering, typed calls, tile.json reference |
 | Authoring | [script-delegation](rules/script-delegation.md) | Deterministic → script, reasoning → LLM, the regex trap |
 | Authoring | [plugin-evals](rules/plugin-evals.md) | No bleeding, no leaking, persistent eval coverage |
+| Authoring | [stateful-artifacts](rules/stateful-artifacts.md) | Cross-invocation state: schema, owner skill, schema_version, hints-not-authority, migration |
 | Review | [author-model-declaration](rules/author-model-declaration.md) | PRs declare author model; paired reviewers pick the cross-family one |
 
 ### Skills

--- a/rules/stateful-artifacts.md
+++ b/rules/stateful-artifacts.md
@@ -26,8 +26,8 @@ alwaysApply: true
 ## Migration Policy
 
 - Bump `schema_version` for any shape change — don't repurpose a field silently
-- Ship the migration step in the owner skill: on read, detect old `schema_version`, upgrade the record, rewrite
-- Migrations happen under the owner's control, not as a side effect of an unrelated run
+- Only the owner skill migrates: on its own read, detect old `schema_version`, upgrade the record, rewrite
+- Reader skills (non-owners) must not migrate — on encountering an old version, treat it as "no usable prior state" (read-only) and let the next owner-skill run perform the upgrade
 
 ## Rename / Removal
 

--- a/rules/stateful-artifacts.md
+++ b/rules/stateful-artifacts.md
@@ -8,7 +8,7 @@ alwaysApply: true
 
 - JSON (or similar) state files a skill writes and/or reads across invocations to maintain continuity between runs
 - Distinct from the tile's static context artifacts (rules, skills, scripts per `rules/context-artifacts.md`) — those don't change between runs; these do
-- Packaged as part of the plugin, not dropped ad-hoc — artifacts ship with the tile and inherit the same lifecycle guarantees as rules and skills (versioned, reviewed, tested)
+- Lifecycle and packaging expectations come from `rules/context-artifacts.md`; this rule adds the stateful-specific requirements below
 
 ## Required Attributes
 

--- a/rules/stateful-artifacts.md
+++ b/rules/stateful-artifacts.md
@@ -1,0 +1,35 @@
+---
+alwaysApply: true
+---
+
+# Stateful Artifacts
+
+## What Counts
+
+- JSON (or similar) state files a skill writes and/or reads across invocations to maintain continuity between runs
+- Distinct from the tile's static context artifacts (rules, skills, scripts per `rules/context-artifacts.md`) — those don't change between runs; these do
+- Packaged as part of the plugin, not dropped ad-hoc — artifacts ship with the tile and inherit the same lifecycle guarantees as rules and skills (versioned, reviewed, tested)
+
+## Required Attributes
+
+- A **schema** documented next to the owner skill (e.g., `skills/<name>/state-schema.md` or a JSON Schema file); no schema, no artifact
+- A single **owner skill** responsible for shape changes — shared ownership means no one owns the migration
+- A `schema_version` field on every record so migrations are auditable
+- A **writer / reader contract** — which skills write, which read, what each promises about field presence, defaults, and format
+
+## Hints, Not Authority
+
+- Artifacts are last-seen snapshots, not ground truth — before acting on a recalled value, verify against the live source (API, DB, filesystem)
+- Stale state is the default; assume it until proven fresh
+- A skill that recalls a value from an artifact and mutates the world without verifying is the textbook cause of "worked yesterday, wrong today" bugs
+
+## Migration Policy
+
+- Bump `schema_version` for any shape change — don't repurpose a field silently
+- Ship the migration step in the owner skill: on read, detect old `schema_version`, upgrade the record, rewrite
+- Migrations happen under the owner's control, not as a side effect of an unrelated run
+
+## Rename / Removal
+
+- Renaming or removing an artifact follows surface sync (see `rules/context-artifacts.md`): update the owner skill's schema doc, update every reader skill, add a CHANGELOG entry
+- Keep reader skills tolerant of missing artifacts — an artifact that was never written (first run) is indistinguishable from one that was removed; both mean "no prior state"

--- a/tile.json
+++ b/tile.json
@@ -74,6 +74,10 @@
     "author-model-declaration": {
       "rules": "rules/author-model-declaration.md",
       "alwaysApply": true
+    },
+    "stateful-artifacts": {
+      "rules": "rules/stateful-artifacts.md",
+      "alwaysApply": true
     }
   }
 }


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

- New rule `rules/stateful-artifacts.md` (35 lines, within the 25–40 target) covering cross-invocation JSON state files a skill writes and reads between runs.
- Defines required attributes: documented schema, single owner skill, `schema_version` field, explicit writer/reader contract.
- Codifies the "hints, not authority" principle — verify against the live source before acting on a recalled value.
- Migration policy: bump `schema_version`, ship migration step in the owner skill, no silent in-place mutation.
- Surface sync: registered in `tile.json` steering, added to the README rules table under "Authoring", rule count 13 → 14, CHANGELOG entry under Unreleased.

Closes part A of #1 (§C Context artifacts). §A/§D/§E minor gaps (`user-invocable: false` frontmatter, precheck-gating JSON contract, review rubric element enumeration) land in a follow-up PR.

## Test plan

- [ ] In-repo gh-aw reviewer enforces new `rules/author-model-declaration.md` gate and reviews this PR against all rules/*.md including the new one
- [ ] `rules/stateful-artifacts.md` line count is 35 (within 25–40 per `rules/context-artifacts.md` Rule Format)
- [ ] `tile.json` remains valid JSON with the new steering entry
- [ ] README rule count (14) matches `tile.json` steering count