### PR TITLE
fix(rules): close issue #1 §A/§D/§E gaps (user-invocable, precheck JSON, review rubric)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Rule tightenings
 
 - **skill-authoring** — Document `user-invocable: false` as an optional frontmatter field for background-knowledge skills the runtime loads as context but the user should never invoke directly.
-- **script-delegation** — Spell out the precheck-gating JSON contract (`{"wake_agent": bool, "data": {...}}` on the last line), the zero-token-cost rationale for no-op runs, and the single-fetch gate-and-payload pattern.
+- **script-delegation** — Spell out the precheck-gating JSON contract with `wake_agent` as a boolean and `data` as an object (e.g., `{"wake_agent": true, "data": {}}` on the last line), the zero-token-cost rationale for no-op runs, and the single-fetch gate-and-payload pattern.
 - **context-artifacts** — Enumerate the review rubric: frontmatter validity, sequential-execution preamble, flat step numbering, typed `Skill()` calls, silence-rule compliance, channel-appropriate formatting.
 
 ### Skills

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 - **author-model-declaration** — Every PR declares its author model via a `**Author-Model:**` line in the body (preferred) or a `Co-authored-by:` git trailer (fallback). Defines model families (anthropic, openai, google), plus a special `human` value that maps to no family, and mixed-authorship semantics so the paired reviewers can pick a cross-family reviewer and dodge self-review bias. Missing declaration blocks the PR via early `REQUEST_CHANGES` before the diff is read.
 - **stateful-artifacts** — Cross-invocation JSON state files a skill writes and reads between runs. Every artifact has a documented schema, a single owner skill, a `schema_version` field, and a writer/reader contract. Artifacts are hints, not authority — verify against the live source before acting on a recalled value. Migrations happen under the owner skill, not as a side effect of unrelated runs.
 
+### Rule tightenings
+
+- **skill-authoring** — Document `user-invocable: false` as an optional frontmatter field for background-knowledge skills the runtime loads as context but the user should never invoke directly.
+- **script-delegation** — Spell out the precheck-gating JSON contract (`{"wake_agent": bool, "data": {...}}` on the last line), the zero-token-cost rationale for no-op runs, and the single-fetch gate-and-payload pattern.
+- **context-artifacts** — Enumerate the review rubric: frontmatter validity, sequential-execution preamble, flat step numbering, typed `Skill()` calls, silence-rule compliance, channel-appropriate formatting.
+
 ### Skills
 
 - **install-reviewer** — Scaffold the paired gh-aw PR policy reviewers (OpenAI Codex + Anthropic Claude Code) into a consumer repo. Ships `review-openai.md` and `review-anthropic.md` as packaged templates; the skill copies both into the consumer's `.github/workflows/`, compiles atomically with `gh aw compile`, commits all six artifacts, and opens a PR. Each workflow runs `tessl install jbaruch/coding-policy` as a pre-step, then self-gates on the PR's `Author-Model:` declaration: the same-family reviewer emits a one-line "skipping: self-review-bias" COMMENT and exits; the cross-family reviewer reviews. Three secrets required: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `TESSL_TOKEN`. Clean-verdict reviews use `event: COMMENT` with a pass body (GitHub rejects `APPROVE` from `github-actions[bot]` with HTTP 422).

--- a/rules/context-artifacts.md
+++ b/rules/context-artifacts.md
@@ -40,7 +40,7 @@ alwaysApply: true
 - Every skill change must pass `tessl skill review --threshold 85` before publish
 - Below-threshold scores block the pipeline — no exceptions
 - When adding a skill, add a `tessl skill review --threshold 85 skills/<name>` step to the CI workflow — the review gate is only real if CI enforces it
-- The review rubric verifies frontmatter validity, the sequential-execution preamble, flat step numbering, typed `Skill()` calls (no prose invocations), silence-rule compliance, and channel-appropriate formatting (e.g., no Markdown in HTML-only channels) — all traceable to `rules/skill-authoring.md`
+- The review rubric verifies frontmatter validity, the sequential-execution preamble, flat step numbering, typed `Skill()` calls (no prose invocations), silence-rule compliance (all in `rules/skill-authoring.md`), and channel-appropriate formatting (e.g., no Markdown in HTML-only channels)
 - Read the reviewer's suggestions — the review tool is a development aid, not just a gate. Act on concrete feedback (improve trigger terms, extract reference material, tighten descriptions) and re-review until you've addressed the actionable suggestions
 
 ## Mandatory Evals

--- a/rules/context-artifacts.md
+++ b/rules/context-artifacts.md
@@ -40,6 +40,7 @@ alwaysApply: true
 - Every skill change must pass `tessl skill review --threshold 85` before publish
 - Below-threshold scores block the pipeline — no exceptions
 - When adding a skill, add a `tessl skill review --threshold 85 skills/<name>` step to the CI workflow — the review gate is only real if CI enforces it
+- The review rubric verifies frontmatter validity, the sequential-execution preamble, flat step numbering, typed `Skill()` calls (no prose invocations), silence-rule compliance, and channel-appropriate formatting (e.g., no Markdown in HTML-only channels) — all traceable to `rules/skill-authoring.md`
 - Read the reviewer's suggestions — the review tool is a development aid, not just a gate. Act on concrete feedback (improve trigger terms, extract reference material, tighten descriptions) and re-review until you've addressed the actionable suggestions
 
 ## Mandatory Evals

--- a/rules/script-delegation.md
+++ b/rules/script-delegation.md
@@ -45,5 +45,6 @@ Scripts follow the baseline in `rules/file-hygiene.md` (exit codes, stderr, idem
 
 ## Precheck Gating
 
-- Use last-line JSON payload with `wake_agent` for precheck gating
-- The script runs first; the agent only wakes if the script signals it should
+- For scheduled or recurring tasks where most runs are no-ops, have the script produce a last-line JSON payload of the shape `{"wake_agent": true|false, "data": {...}}`
+- The scheduler runs the script first and only wakes the agent when `wake_agent` is `true` — no-op runs cost zero model tokens because the LLM is never invoked
+- `data` carries the inputs the agent will need if it does wake, so a single precheck run gates activation *and* supplies the payload — no second fetch

--- a/rules/script-delegation.md
+++ b/rules/script-delegation.md
@@ -45,6 +45,6 @@ Scripts follow the baseline in `rules/file-hygiene.md` (exit codes, stderr, idem
 
 ## Precheck Gating
 
-- For scheduled or recurring tasks where most runs are no-ops, have the script produce a last-line JSON payload of the shape `{"wake_agent": true|false, "data": {...}}`
+- For scheduled or recurring tasks where most runs are no-ops, have the script produce a last-line JSON payload such as `{"wake_agent": false, "data": {}}`; `wake_agent` is a boolean and `data` is an object
 - The scheduler runs the script first and only wakes the agent when `wake_agent` is `true` — no-op runs cost zero model tokens because the LLM is never invoked
 - `data` carries the inputs the agent will need if it does wake, so a single precheck run gates activation *and* supplies the payload — no second fetch

--- a/rules/skill-authoring.md
+++ b/rules/skill-authoring.md
@@ -7,7 +7,7 @@ alwaysApply: true
 ## SKILL.md Frontmatter
 
 - Required fields: `name`, `description` (include trigger phrases so the agent knows when to activate)
-- Optional fields: `allowed-tools`, `disable-model-invocation`
+- Optional fields: `allowed-tools`, `disable-model-invocation`, `user-invocable` (set to `false` for background-knowledge skills the runtime loads as context but the user should never invoke directly)
 - The `description` field is your discovery surface — write it for the agent, not a human audience
 
 ## Title and Preamble


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Three targeted rule tightenings that close the remaining issue #1 gaps after the stateful-artifacts rule (#10):

- **skill-authoring.md** — `user-invocable: false` added to the optional-frontmatter list for background-knowledge skills the runtime loads as context but the user should never invoke directly (§A).
- **script-delegation.md** — Precheck gating now spells out the last-line JSON contract (`{"wake_agent": bool, "data": {...}}`), the zero-token-cost rationale for no-op runs, and the single-fetch gate-and-payload pattern (§D).
- **context-artifacts.md** — Mandatory Review now enumerates what the rubric verifies: frontmatter validity, sequential-execution preamble, flat step numbering, typed `Skill()` calls, silence-rule compliance, channel-appropriate formatting. All traceable to `rules/skill-authoring.md` (§E).

Together with #10 (stateful-artifacts rule for §C), this closes #1. §B is already covered by `rules/context-artifacts.md` "Rules Are Prose" + "Rule Format"; §F is already covered by `rules/plugin-evals.md`.

## Test plan

- [ ] In-repo gh-aw reviewer passes the PR against the updated rules and the Author-Model gate
- [ ] No rule grew beyond its prior length-category (skill-authoring unchanged line-count, script-delegation +1 line, context-artifacts +1 line)
- [ ] CHANGELOG Unreleased entry added under a new "Rule tightenings" sub-section