### PR TITLE
fix(evals): remove skill-echo and task-restatement from 6 policy scenarios

### DIFF
--- a/evals/ci-and-review-status-polling/criteria.json
+++ b/evals/ci-and-review-status-polling/criteria.json
@@ -28,9 +28,9 @@
       "description": "The script uses the pull-request review-comments endpoint, NOT the issue-comments endpoint (`/issues/<N>/comments`). These return different objects in GitHub's API — a script that conflates them surfaces wrong data and scores zero here"
     },
     {
-      "name": "Inputs parameterized (PR number, owner, repo)",
+      "name": "Script can run unchanged against a different PR or repo",
       "max_score": 10,
-      "description": "PR number, repository owner, and repository name are accepted as arguments or environment variables — not hardcoded literals in the script body. The script is reusable across different PRs and repos without editing"
+      "description": "OBSERVABLE CHECK: the script body contains no hardcoded literal for the target PR, owner, or repo — all such context is pulled from runtime inputs (args, env vars, or interactive prompt). Running against a new target requires changing only the invocation, not the script source"
     },
     {
       "name": "Surfaces CI state in the summary",

--- a/evals/ci-and-review-status-polling/criteria.json
+++ b/evals/ci-and-review-status-polling/criteria.json
@@ -30,7 +30,7 @@
     {
       "name": "Script can run unchanged against a different PR or repo",
       "max_score": 10,
-      "description": "OBSERVABLE CHECK: the script body contains no hardcoded literal for the target PR, owner, or repo — all such context is pulled from runtime inputs (args, env vars, or interactive prompt). Running against a new target requires changing only the invocation, not the script source"
+      "description": "OBSERVABLE CHECK: the script body contains no hardcoded literal for the target PR, owner, or repo — all such context is pulled from runtime inputs (args or env vars, per the task's input contract). Running against a new target requires changing only the invocation, not the script source"
     },
     {
       "name": "Surfaces CI state in the summary",

--- a/evals/ci-and-review-status-polling/criteria.json
+++ b/evals/ci-and-review-status-polling/criteria.json
@@ -1,36 +1,51 @@
 {
-  "context": "Tests whether the agent uses the correct gh CLI commands to poll CI status and retrieve both Copilot review state and inline comments from a pull request, matching the specific API patterns prescribed in the release skill.",
+  "context": "Tests whether the script retrieves and surfaces the three signals the developer needs — CI status, per-reviewer review decision, and inline review-comments — without prescribing specific gh-CLI endpoints or jq filters. Multiple endpoints can produce the same signal; the criteria score whether the signal is captured and surfaced, and whether the agent avoids the common inline-vs-issue-comments API trap.",
   "type": "weighted_checklist",
   "checklist": [
     {
-      "name": "CI watch command",
-      "max_score": 20,
-      "description": "Uses `gh pr checks <N> --watch` (with the `--watch` flag) to poll CI until checks complete — not a manual sleep loop or alternative polling approach"
+      "name": "Retrieves CI status",
+      "max_score": 15,
+      "description": "The script retrieves the PR's CI state via some command. `gh pr checks`, `gh run list --branch`, `gh api /repos/<o>/<r>/commits/<sha>/check-runs`, or equivalent all pass — the specific endpoint is not prescribed"
     },
     {
-      "name": "Review state API call",
-      "max_score": 20,
-      "description": "Retrieves the Copilot/automated review state via `gh api repos/<owner>/<repo>/pulls/<N>/reviews` with a `--jq '.[].state'` filter (or equivalent jq expression that extracts the state field)"
+      "name": "Waits for CI to finish before surfacing state",
+      "max_score": 15,
+      "description": "The script polls / waits until CI checks are in a terminal state (success / failure / cancelled) before reporting. Surfacing mid-run 'pending' as the final verdict scores zero — any reasonable wait mechanism (`--watch`, a polling loop with a timeout, a `gh run watch` call) is acceptable"
     },
     {
-      "name": "Inline comments API call",
-      "max_score": 20,
-      "description": "Retrieves inline PR comments via `gh api repos/<owner>/<repo>/pulls/<N>/comments` — uses the pull request review comments endpoint, not the issue comments endpoint"
+      "name": "Retrieves review decision per reviewer",
+      "max_score": 15,
+      "description": "The script captures the latest review state for EACH reviewer distinctly (not a single aggregate). Multi-bot setups (e.g., Copilot + gh-aw) each have their own state, and the script must expose them separately"
+    },
+    {
+      "name": "Retrieves inline review comments",
+      "max_score": 15,
+      "description": "The script retrieves inline comments attached to reviews. Mechanism is not prescribed — any endpoint that returns PR review comments passes"
+    },
+    {
+      "name": "Distinguishes inline review comments from issue comments",
+      "max_score": 10,
+      "description": "The script uses the pull-request review-comments endpoint, NOT the issue-comments endpoint (`/issues/<N>/comments`). These return different objects in GitHub's API — a script that conflates them surfaces wrong data and scores zero here"
     },
     {
       "name": "PR number parameterized",
       "max_score": 10,
-      "description": "The PR number is accepted as a script argument or variable rather than hardcoded, so the script is reusable across different PRs"
+      "description": "The PR number is a script argument or environment variable, not a hardcoded value. The script is reusable across different PRs without editing"
     },
     {
-      "name": "Review state surfaced",
-      "max_score": 15,
-      "description": "The script prints or summarizes the review state value(s) retrieved so the developer can see whether the review is approved, changes requested, etc."
+      "name": "Surfaces CI state in the summary",
+      "max_score": 7,
+      "description": "Final summary prints the CI verdict (success/failure/pending) in a form a human can read at a glance"
     },
     {
-      "name": "Inline comments surfaced",
-      "max_score": 15,
-      "description": "The script prints or summarizes the inline comments content (e.g. body text or count) so the developer can see what feedback was left"
+      "name": "Surfaces review states in the summary",
+      "max_score": 7,
+      "description": "Final summary prints each reviewer's latest state — not just raw JSON the developer has to parse"
+    },
+    {
+      "name": "Surfaces inline comment content or count in the summary",
+      "max_score": 6,
+      "description": "Final summary includes inline comment bodies (for low counts) or a count with a pointer to read them — developer can tell whether there's unaddressed feedback"
     }
   ]
 }

--- a/evals/ci-and-review-status-polling/criteria.json
+++ b/evals/ci-and-review-status-polling/criteria.json
@@ -28,9 +28,9 @@
       "description": "The script uses the pull-request review-comments endpoint, NOT the issue-comments endpoint (`/issues/<N>/comments`). These return different objects in GitHub's API — a script that conflates them surfaces wrong data and scores zero here"
     },
     {
-      "name": "PR number parameterized",
+      "name": "Inputs parameterized (PR number, owner, repo)",
       "max_score": 10,
-      "description": "The PR number is a script argument or environment variable, not a hardcoded value. The script is reusable across different PRs without editing"
+      "description": "PR number, repository owner, and repository name are accepted as arguments or environment variables — not hardcoded literals in the script body. The script is reusable across different PRs and repos without editing"
     },
     {
       "name": "Surfaces CI state in the summary",

--- a/evals/ci-and-review-status-polling/criteria.json
+++ b/evals/ci-and-review-status-polling/criteria.json
@@ -35,7 +35,7 @@
     {
       "name": "Surfaces CI state in the summary",
       "max_score": 7,
-      "description": "Final summary prints the CI verdict (success/failure/pending) in a form a human can read at a glance"
+      "description": "Final summary prints the CI verdict (success / failure / cancelled / timed-out) in a form a human can read at a glance. The summary reports a terminal state, consistent with the wait-until-finished criterion — `pending` is not a valid summary outcome"
     },
     {
       "name": "Surfaces review states in the summary",

--- a/evals/ci-and-review-status-polling/task.md
+++ b/evals/ci-and-review-status-polling/task.md
@@ -8,11 +8,10 @@ You have been asked to write a shell script that a developer can run after openi
 
 ## Output Specification
 
-Produce a shell script named `monitor_pr.sh` that accepts a PR number as its first argument (e.g. `./monitor_pr.sh 42`). The script should be written for a repository whose GitHub owner and repo name are configurable (either hardcoded placeholders or environment variables — your choice). The script should:
+Produce a shell script named `monitor_pr.sh` that:
 
-1. Wait for CI checks to finish
-2. Retrieve the review state(s) from the automated reviewer
-3. Retrieve any inline comments left on the PR
-4. Print a summary of what was found so the developer knows what to address
-
-Also produce a `README.md` explaining how to use the script and what each output section means.
+1. Accepts the PR number, repository owner, and repository name as arguments or environment variables (not hardcoded)
+2. Waits for CI checks to finish
+3. Retrieves the review state(s) from the automated reviewer(s)
+4. Retrieves any inline comments left on the PR
+5. Prints a summary of what was found so the developer knows what to address

--- a/evals/copilot-review-via-graphql/criteria.json
+++ b/evals/copilot-review-via-graphql/criteria.json
@@ -1,56 +1,51 @@
 {
-  "context": "Tests whether the agent uses GraphQL (not REST) to request Copilot review, provides the correct hardcoded bot ID, includes a fallback for when the bot ID is stale, and follows the correct PR title and body format when scripting the PR creation and review request workflow.",
+  "context": "Tests whether the agent reasons through GitHub's bot-reviewer API limitation (REST silently drops bot accounts) and writes a script that (a) uses GraphQL for the review request, (b) doesn't depend on a permanently-hardcoded bot ID, and (c) verifies the request landed. The specific Copilot bot-ID literal is a skill-internal implementation detail and is NOT scored.",
   "type": "weighted_checklist",
   "checklist": [
     {
-      "name": "GraphQL mutation used",
+      "name": "Uses GraphQL requestReviews mutation",
+      "max_score": 20,
+      "description": "The script calls `gh api graphql` with a `requestReviews` mutation to add the bot reviewer. REST paths (`gh pr edit --add-reviewer`, `POST /pulls/<N>/requested_reviewers`) score zero here — those are the approaches that silently drop bots"
+    },
+    {
+      "name": "Explains why REST doesn't work",
+      "max_score": 10,
+      "description": "The script's inline comments or the companion documentation cite the concrete reason GraphQL is required: REST drops bot reviewers silently. Without this reasoning, a reader can't judge whether the switch is intentional"
+    },
+    {
+      "name": "Doesn't depend on a permanently-hardcoded bot ID",
       "max_score": 15,
-      "description": "Uses `gh api graphql` with a `requestReviews` mutation to add Copilot as a reviewer — does NOT use REST (`gh pr edit --add-reviewer`, `gh api .../requested_reviewers` POST)"
+      "description": "The script either (a) discovers the Copilot bot ID dynamically at runtime (e.g., from past reviews, from suggested-reviewers), or (b) includes a fallback discovery path when a pinned ID fails, so the script doesn't silently break when GitHub rotates the bot ID. A plain hardcoded literal with no fallback scores zero"
     },
     {
-      "name": "Correct Copilot bot ID",
-      "max_score": 15,
-      "description": "Passes bot ID `BOT_kgDOCnlnWA` in the `botIds` field of the `requestReviews` mutation"
-    },
-    {
-      "name": "PR node ID retrieval",
+      "name": "Resolves the PR's GraphQL node ID",
       "max_score": 10,
-      "description": "Fetches the PR's GraphQL node ID (e.g. via a `pullRequest(number: N) { id }` query) before calling the mutation — does NOT pass the integer PR number directly to `requestReviews`"
+      "description": "Before calling the mutation, the script fetches the PR's GraphQL node ID (e.g., `pullRequest(number: N) { id }`) rather than passing the integer PR number into a field that expects a node ID"
     },
     {
-      "name": "Bot ID fallback included",
+      "name": "Verifies the review request was registered",
       "max_score": 10,
-      "description": "Includes (or documents) a fallback GraphQL query that retrieves the Copilot bot ID from past PR reviews when the hardcoded ID is stale"
+      "description": "After the mutation, the script inspects the PR state to confirm the bot appears in `requested_reviewers` (or equivalent). Fire-and-forget without verification scores zero"
     },
     {
-      "name": "Review request verification",
-      "max_score": 8,
-      "description": "After requesting review, verifies acceptance using `gh api repos/.../pulls/<N>` and inspects `requested_reviewers`"
-    },
-    {
-      "name": "Feature branch guard",
+      "name": "Feature-branch guard",
       "max_score": 10,
-      "description": "Script checks that the current branch is NOT main or master before proceeding"
+      "description": "Before pushing, the script confirms the current branch is NOT main/master and fails loudly if it is — a widely-standard git safety practice, not skill doctrine"
     },
     {
-      "name": "PR title format",
-      "max_score": 8,
-      "description": "PR title in the script follows the pattern `<type>(<scope>): <imperative summary>` (e.g. `fix(auth): handle token expiry`)"
+      "name": "Pre-push readiness checks",
+      "max_score": 10,
+      "description": "The script runs the project's tests AND linter before pushing/creating the PR, and fails if either fails. Acceptable regardless of how these are invoked (make/npm/cargo/etc.)"
     },
     {
-      "name": "PR body Summary section",
+      "name": "PR title follows conventional-commits format",
       "max_score": 8,
-      "description": "PR body template includes a `## Summary` section with bullet points describing what changed and why"
+      "description": "The PR title the script constructs uses `<type>(<scope>): <imperative summary>` (conventional commits — widely adopted across OSS, not skill-invented)"
     },
     {
-      "name": "PR body Test plan section",
-      "max_score": 8,
-      "description": "PR body template includes a `## Test plan` section with markdown checkbox items (`- [ ] ...`)"
-    },
-    {
-      "name": "Pre-push readiness",
-      "max_score": 8,
-      "description": "Script or documentation includes steps to run tests AND linter before pushing/creating the PR, and requires both to pass"
+      "name": "PR body has summary + verification plan",
+      "max_score": 7,
+      "description": "The PR body template includes a summary of what changed and a test/verification plan — the substance, not a specific section-heading literal"
     }
   ]
 }

--- a/evals/copilot-review-via-graphql/criteria.json
+++ b/evals/copilot-review-via-graphql/criteria.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "Doesn't depend on a permanently-hardcoded bot ID",
-      "max_score": 15,
+      "max_score": 20,
       "description": "The script either (a) discovers the Copilot bot ID dynamically at runtime (e.g., from past reviews, from suggested-reviewers), or (b) includes a fallback discovery path when a pinned ID fails, so the script doesn't silently break when GitHub rotates the bot ID. A plain hardcoded literal with no fallback scores zero"
     },
     {
@@ -24,18 +24,13 @@
     },
     {
       "name": "Verifies the review request was registered",
-      "max_score": 10,
+      "max_score": 15,
       "description": "After the mutation, the script inspects the PR state to confirm the bot appears in `requested_reviewers` (or equivalent). Fire-and-forget without verification scores zero"
     },
     {
       "name": "Feature-branch guard",
       "max_score": 10,
       "description": "Before pushing, the script confirms the current branch is NOT main/master and fails loudly if it is — a widely-standard git safety practice, not skill doctrine"
-    },
-    {
-      "name": "Pre-push readiness checks",
-      "max_score": 10,
-      "description": "The script runs the project's tests AND linter before pushing/creating the PR, and fails if either fails. Acceptable regardless of how these are invoked (make/npm/cargo/etc.)"
     },
     {
       "name": "PR title follows conventional-commits format",

--- a/evals/copilot-review-via-graphql/criteria.json
+++ b/evals/copilot-review-via-graphql/criteria.json
@@ -44,8 +44,13 @@
     },
     {
       "name": "PR body has summary + verification plan",
-      "max_score": 7,
+      "max_score": 5,
       "description": "The PR body template includes a summary of what changed and a test/verification plan — the substance, not a specific section-heading literal"
+    },
+    {
+      "name": "Inputs parameterized",
+      "max_score": 2,
+      "description": "Repository owner, repository name, branch name, PR title/body source, and PR number are accepted as arguments or environment variables — not hardcoded. The script is reusable across different PRs and repos without editing"
     }
   ]
 }

--- a/evals/copilot-review-via-graphql/criteria.json
+++ b/evals/copilot-review-via-graphql/criteria.json
@@ -10,7 +10,7 @@
     {
       "name": "Explains why REST doesn't work",
       "max_score": 10,
-      "description": "The script's inline comments or the companion documentation cite the concrete reason GraphQL is required: REST drops bot reviewers silently. Without this reasoning, a reader can't judge whether the switch is intentional"
+      "description": "Inline comments in `release.sh` cite the concrete reason GraphQL is required: REST drops bot reviewers silently. The task requires inline comments for non-obvious steps, so the rationale must live in the script itself — a separate doc alone is insufficient"
     },
     {
       "name": "Doesn't depend on a permanently-hardcoded bot ID",

--- a/evals/copilot-review-via-graphql/task.md
+++ b/evals/copilot-review-via-graphql/task.md
@@ -17,6 +17,4 @@ Produce a `release.sh` bash script that:
 - Verifies the review request was accepted
 - Includes inline comments explaining any non-obvious steps
 
-Also produce a `usage.md` file documenting how to invoke the script with example commands.
-
 The script does not need to actually run successfully in this environment (no GitHub credentials available) — focus on correctness of the implementation.

--- a/evals/copilot-review-via-graphql/task.md
+++ b/evals/copilot-review-via-graphql/task.md
@@ -11,7 +11,6 @@ The team has tried using `gh pr edit --add-reviewer` in the past but found bot a
 Produce a `release.sh` bash script that:
 - Accepts the repository owner, repository name, branch name, PR title, PR body (or constructs one from arguments), and PR number as inputs (via arguments or environment variables — your choice)
 - Validates the working environment before doing anything destructive (e.g., ensures you're not about to push from the wrong branch)
-- Runs pre-push readiness checks (tests, linter) before creating the PR
 - Pushes the branch and creates the PR, following team conventions for PR title format and body structure
 - Requests a Copilot code review on that PR
 - Verifies the review request was accepted

--- a/evals/pr-merge-and-post-merge-cleanup/criteria.json
+++ b/evals/pr-merge-and-post-merge-cleanup/criteria.json
@@ -13,13 +13,18 @@
       "description": "The script refuses to merge when any blocking review is outstanding or any review thread is unresolved. At minimum, it checks that no review has state `CHANGES_REQUESTED` and that inline-comment threads have replies before proceeding"
     },
     {
-      "name": "Local main matches remote after merge",
-      "max_score": 15,
-      "description": "OUTCOME check: post-merge, local `main` is at the same commit as `origin/main`, with no spurious local merge commit introduced by an unqualified `git pull`. Any approach that reaches this state is acceptable"
+      "name": "Verifies merge landed on main",
+      "max_score": 10,
+      "description": "The script explicitly verifies that the PR's commits are present on `main` after the merge (e.g., `gh pr view <N> --json state,mergeCommit`, `git log origin/main --grep`, or equivalent). A silent assumption that `gh pr merge` succeeded scores zero"
+    },
+    {
+      "name": "Local main matches remote without spurious merge commit",
+      "max_score": 12,
+      "description": "OUTCOME check: post-script, local `main` points at the same commit as `origin/main`. A plain `git pull` that introduces an extra local merge commit scores zero; any mechanism that produces a clean fast-forward or reset-to-origin state is acceptable"
     },
     {
       "name": "Feature branch removed both remotely and locally",
-      "max_score": 15,
+      "max_score": 13,
       "description": "OUTCOME check: after the script runs, the feature branch is gone from origin AND gone from the local repo. The specific mechanism (e.g., `gh pr merge --delete-branch` + `git branch -d`, or `git push origin --delete` + local delete) is not prescribed"
     },
     {
@@ -29,7 +34,7 @@
     },
     {
       "name": "Publish CI verification",
-      "max_score": 15,
+      "max_score": 10,
       "description": "The script verifies that the post-merge publish/release workflow was triggered — not just that the merge succeeded. Acceptable mechanisms include `gh run list` on the publish workflow, `gh run view` on the post-merge run, or equivalent"
     },
     {

--- a/evals/pr-merge-and-post-merge-cleanup/criteria.json
+++ b/evals/pr-merge-and-post-merge-cleanup/criteria.json
@@ -44,8 +44,13 @@
     },
     {
       "name": "Graceful failure on unmet preconditions",
-      "max_score": 10,
+      "max_score": 5,
       "description": "When CI is red or reviews are outstanding, the script exits non-zero with a human-readable message on stderr that names the specific unmet condition — does NOT silently skip or mask the failure"
+    },
+    {
+      "name": "Inputs parameterized (PR number, owner, repo)",
+      "max_score": 5,
+      "description": "PR number, repository owner, and repository name are accepted as arguments or environment variables — not hardcoded literals in the script body. The script is reusable across different PRs and repos without editing"
     }
   ]
 }

--- a/evals/pr-merge-and-post-merge-cleanup/criteria.json
+++ b/evals/pr-merge-and-post-merge-cleanup/criteria.json
@@ -1,56 +1,46 @@
 {
-  "context": "Tests whether the agent follows the correct merge command with the right flags, uses safe git pull semantics post-merge, properly cleans up local and remote branch refs, and performs the required post-merge verification steps including confirming the publish workflow was triggered.",
+  "context": "Tests whether the agent gates the merge on the right readiness signals and brings the repo to the correct post-merge OUTCOME — without prescribing specific command flags. Command choices (e.g., `--merge` vs `--squash`, `git pull --ff-only` vs `git fetch && git reset`) are team-configurable; the criteria score the observable end state and the reasoning about when merge is allowed, not the exact literal flags.",
   "type": "weighted_checklist",
   "checklist": [
     {
-      "name": "Merge flags: --merge",
+      "name": "Pre-merge CI gate",
+      "max_score": 15,
+      "description": "The script refuses to merge when CI is not green. If CI checks are pending or failing, the script exits non-zero with a diagnostic; it does NOT proceed to `gh pr merge` on red CI"
+    },
+    {
+      "name": "Pre-merge review gate",
+      "max_score": 15,
+      "description": "The script refuses to merge when any blocking review is outstanding or any review thread is unresolved. At minimum, it checks that no review has state `CHANGES_REQUESTED` and that inline-comment threads have replies before proceeding"
+    },
+    {
+      "name": "Local main matches remote after merge",
+      "max_score": 15,
+      "description": "OUTCOME check: post-merge, local `main` is at the same commit as `origin/main`, with no spurious local merge commit introduced by an unqualified `git pull`. Any approach that reaches this state is acceptable"
+    },
+    {
+      "name": "Feature branch removed both remotely and locally",
+      "max_score": 15,
+      "description": "OUTCOME check: after the script runs, the feature branch is gone from origin AND gone from the local repo. The specific mechanism (e.g., `gh pr merge --delete-branch` + `git branch -d`, or `git push origin --delete` + local delete) is not prescribed"
+    },
+    {
+      "name": "Stale remote-tracking refs cleaned",
       "max_score": 10,
-      "description": "Uses `gh pr merge` with the `--merge` flag (not `--squash` or `--rebase`)"
+      "description": "The script removes stale `origin/*` refs that point at deleted remote branches (via `git remote prune`, `git fetch --prune`, or equivalent). Leaving stale refs around is a zero here"
     },
     {
-      "name": "Merge flags: --delete-branch",
+      "name": "Publish CI verification",
+      "max_score": 15,
+      "description": "The script verifies that the post-merge publish/release workflow was triggered — not just that the merge succeeded. Acceptable mechanisms include `gh run list` on the publish workflow, `gh run view` on the post-merge run, or equivalent"
+    },
+    {
+      "name": "Final summary surfaces the merged PR URL and outcome",
+      "max_score": 5,
+      "description": "The script prints a summary including the merged PR URL and the publish-workflow status so the developer doesn't have to re-check manually"
+    },
+    {
+      "name": "Graceful failure on unmet preconditions",
       "max_score": 10,
-      "description": "Uses `gh pr merge` with the `--delete-branch` flag to delete the remote branch on merge"
-    },
-    {
-      "name": "Fast-forward only pull",
-      "max_score": 12,
-      "description": "After switching to main, uses `git pull --ff-only` (not plain `git pull` or `git pull --rebase`)"
-    },
-    {
-      "name": "Checkout main first",
-      "max_score": 8,
-      "description": "Switches to the main branch (`git checkout main`) before running `git pull`"
-    },
-    {
-      "name": "Local branch deletion",
-      "max_score": 10,
-      "description": "Deletes the local feature branch with `git branch -d` (not force-delete `-D`)"
-    },
-    {
-      "name": "Remote ref pruning",
-      "max_score": 10,
-      "description": "Runs `git remote prune origin` to clean up stale remote-tracking refs"
-    },
-    {
-      "name": "Verify merge on main",
-      "max_score": 10,
-      "description": "Includes a step to verify the merged commit is present on the main branch (e.g. `git log`, `gh pr view`, or checking PR status)"
-    },
-    {
-      "name": "Publish CI check",
-      "max_score": 12,
-      "description": "Includes a step to check that the publish/release CI workflow was triggered after the merge (e.g. checking workflow runs)"
-    },
-    {
-      "name": "Report merged PR URL",
-      "max_score": 8,
-      "description": "Script or documentation includes reporting the merged PR URL as part of the outcome summary"
-    },
-    {
-      "name": "Pre-merge: CI green gate",
-      "max_score": 10,
-      "description": "Script or checklist requires confirming CI is green before merging — does not proceed with merge if CI is failing"
+      "description": "When CI is red or reviews are outstanding, the script exits non-zero with a human-readable message on stderr that names the specific unmet condition — does NOT silently skip or mask the failure"
     }
   ]
 }

--- a/evals/pr-merge-and-post-merge-cleanup/task.md
+++ b/evals/pr-merge-and-post-merge-cleanup/task.md
@@ -19,6 +19,4 @@ Produce a `merge-and-cleanup.sh` bash script that:
 - Confirms the publish/release CI workflow was triggered
 - Prints a final summary including the merged PR URL
 
-Also produce a `MERGE_CHECKLIST.md` that describes the manual steps a developer would follow if not using the script, including what to check before merging and what to verify after.
-
 The script does not need to run successfully (no GitHub credentials available) — focus on correctness of the approach and commands used.

--- a/evals/release-on-main-branch-rejection/criteria.json
+++ b/evals/release-on-main-branch-rejection/criteria.json
@@ -1,31 +1,36 @@
 {
-  "context": "Tests whether the agent refuses to proceed with the release workflow when the user is on the main branch, and provides actionable recovery guidance instead of blindly executing steps.",
+  "context": "Tests whether the agent reasons through the multi-step recovery when a fix is already committed on main: refuse to release from main, branch from the current HEAD (preserving the commit), roll back local main to match origin, then open the PR from the new branch. The task reveals the starting state; the criteria score the recovery sequence, not the observation.",
   "type": "weighted_checklist",
   "checklist": [
     {
-      "name": "Detects main branch",
-      "max_score": 25,
-      "description": "The agent identifies that the user is on the main branch and flags this as a problem — does NOT proceed with pushing and creating a PR from main"
-    },
-    {
-      "name": "Explains why it's blocked",
+      "name": "Refuses release from main",
       "max_score": 20,
-      "description": "Explains that the release process requires a feature branch, not main — provides the reasoning, not just a refusal"
+      "description": "The output does NOT push main or open a PR with main as the head branch. `git push -u origin main` and `gh pr create` against main are both absent from the plan"
     },
     {
-      "name": "Provides recovery steps",
-      "max_score": 25,
-      "description": "Suggests a concrete fix: create a branch from the current state (e.g., `git checkout -b fix/hotfix-name`), then proceed with the normal release flow from the new branch"
-    },
-    {
-      "name": "Does not create PR from main",
+      "name": "Branches from current HEAD, not origin",
       "max_score": 20,
-      "description": "The output does NOT include `gh pr create` or `git push -u origin main` — the agent refuses to execute the release steps from main"
+      "description": "The recovery creates a new branch from the local HEAD (which carries the uncommitted-to-remote fix), e.g. `git checkout -b <branch>`. Branching from `origin/main` or resetting before branching would drop the fix — either is scored zero here"
+    },
+    {
+      "name": "Rolls local main back to origin/main",
+      "max_score": 15,
+      "description": "After moving the commit onto a feature branch, the plan brings local `main` back in sync with `origin/main` (e.g. `git checkout main && git reset --hard origin/main`, or equivalent) so future work doesn't diverge. Skipping this step scores zero"
+    },
+    {
+      "name": "Completes the release from the new branch",
+      "max_score": 15,
+      "description": "After the recovery, the plan pushes the new branch and opens the PR from it — doesn't halt at the rejection and leave the fix stranded locally"
+    },
+    {
+      "name": "Cites concrete reasons for the re-route",
+      "max_score": 15,
+      "description": "Explains WHY main can't be the source branch in terms of concrete risks (branch protection, CI gating, mandatory review, audit trail) — not just 'the skill says so' or a bare 'policy violation'. Reasoning must be traceable to a real guardrail"
     },
     {
       "name": "Preserves the commit",
-      "max_score": 10,
-      "description": "Recovery guidance preserves the existing commit — does NOT suggest discarding the fix or resetting main"
+      "max_score": 15,
+      "description": "The final state has the fix present on the new feature branch with no data loss. A plan that suggests `git reset --hard HEAD~1` on main BEFORE branching, or otherwise risks orphaning the commit, scores zero"
     }
   ]
 }

--- a/evals/release-on-main-branch-rejection/criteria.json
+++ b/evals/release-on-main-branch-rejection/criteria.json
@@ -5,12 +5,12 @@
     {
       "name": "Refuses release from main",
       "max_score": 20,
-      "description": "The output does NOT push main or open a PR with main as the head branch. `git push -u origin main` and `gh pr create` against main are both absent from the plan"
+      "description": "The output does NOT push main (`git push -u origin main` or equivalent) and does NOT open a PR whose head is main. A PR with `base=main` and `head=<feature-branch>` is correct and expected; only a head=main PR fails this criterion"
     },
     {
       "name": "Branches from current HEAD, not origin",
       "max_score": 20,
-      "description": "The recovery creates a new branch from the local HEAD (which carries the uncommitted-to-remote fix), e.g. `git checkout -b <branch>`. Branching from `origin/main` or resetting before branching would drop the fix — either is scored zero here"
+      "description": "The recovery creates a new branch from the local HEAD (which carries the fix committed locally but not yet pushed), e.g. `git checkout -b <branch>`. Branching from `origin/main` or resetting before branching would drop the fix — either is scored zero here"
     },
     {
       "name": "Rolls local main back to origin/main",

--- a/evals/review-feedback-addressing-conventions/criteria.json
+++ b/evals/review-feedback-addressing-conventions/criteria.json
@@ -1,46 +1,46 @@
 {
-  "context": "Tests whether the agent applies the release skill's specific conventions for addressing review feedback: fixing all CI failures without exception, applying reasonable suggestions, pushing back on over-engineered suggestions, using the exact reply formats for accepted and declined threads, ensuring no thread is left without a reply, and pushing fixes to the same branch.",
+  "context": "Tests whether the agent classifies each feedback type correctly (fix a CI failure, accept a reasonable suggestion, push back on over-engineering), replies to every thread with substantive content, and pushes fixes to the same branch. The SUBSTANCE of the replies is scored — a reply that concretely references the fix or cites evidence for the decline — NOT a specific phrase literal from the release skill.",
   "type": "weighted_checklist",
   "checklist": [
     {
       "name": "CI failure: fix required",
       "max_score": 10,
-      "description": "For the CI failure (failing unit test), the guide states the test must be fixed — does NOT suggest ignoring it, skipping it, or deferring it"
+      "description": "For the CI failure (failing unit test), the guide states the test must be fixed. Does NOT suggest skipping, ignoring, deferring, or `[skip ci]`"
     },
     {
-      "name": "Accepted reply format",
-      "max_score": 15,
-      "description": "For the accepted suggestion, the reply text follows the format `Fixed in <sha>` — uses this exact phrasing (not 'Done', 'Resolved', 'Applied', or similar alternatives)"
-    },
-    {
-      "name": "Declined reply format",
-      "max_score": 15,
-      "description": "For the declined/over-engineered suggestion, the reply text follows the format `Declining — <reason>` — uses this exact phrasing with the em dash"
-    },
-    {
-      "name": "All threads replied",
-      "max_score": 15,
-      "description": "The guide covers a reply for ALL three feedback threads (CI failure thread, accepted suggestion thread, declined suggestion thread) — no thread is left without a response"
-    },
-    {
-      "name": "Push to same branch",
-      "max_score": 15,
-      "description": "States that any code fixes should be pushed to the same existing branch — NOT to a new branch"
-    },
-    {
-      "name": "Apply reasonable suggestion",
+      "name": "Applies the reasonable suggestion",
       "max_score": 10,
-      "description": "For the clearly correct suggestion (simplifying the conditional), the guide says to apply/implement it — does NOT suggest declining it or skipping it"
+      "description": "For the clearly-correct suggestion (simplify the nested conditional), the guide says to apply it — does NOT suggest declining it or deferring"
     },
     {
-      "name": "Decline over-engineered suggestion",
+      "name": "Declines the over-engineered suggestion",
       "max_score": 10,
-      "description": "For the over-engineered suggestion (unnecessary abstraction), the guide says to push back or decline it with a reason — does NOT say to blindly implement it"
+      "description": "For the over-engineered suggestion (unnecessary abstraction for current scope), the guide says to push back — does NOT say to blindly implement it"
     },
     {
-      "name": "No dangling threads",
+      "name": "All three threads get replies",
+      "max_score": 15,
+      "description": "The guide produces a reply for EVERY thread (CI failure, accept, decline) — not two of three. An empty reply or 'no response needed' on any thread scores zero for this item"
+    },
+    {
+      "name": "Accept reply references the concrete fix",
+      "max_score": 15,
+      "description": "The accept reply concretely points at where/how the fix landed (a commit sha, a commit message reference, or equivalent pointer a reader can follow). A bare 'Done', 'Resolved', 'Applied', or 'OK' scores zero — no actionable pointer. The specific phrase format is NOT scored; the substance is"
+    },
+    {
+      "name": "Decline reply cites concrete evidence",
+      "max_score": 15,
+      "description": "The decline reply cites concrete evidence (file:line, spec/docs quote, linked precedent, scope constraint) for why the suggestion is being declined. A bare 'No thanks', 'Disagree', or vague 'out of scope' scores zero — the reply must hand the reviewer something they can verify. The specific phrase format is NOT scored"
+    },
+    {
+      "name": "Fixes pushed to the same branch",
+      "max_score": 15,
+      "description": "The guide states any code changes go on the EXISTING feature branch of the PR, not a new branch. Opening a second PR for review fixes scores zero"
+    },
+    {
+      "name": "No dangling threads before merge",
       "max_score": 10,
-      "description": "The guide explicitly states or implies that every thread must have a reply before the PR can be merged — does NOT leave any thread unaddressed"
+      "description": "The guide explicitly states that EVERY thread must have a reply before the PR is merged — nothing left unresolved"
     }
   ]
 }

--- a/evals/review-feedback-addressing-conventions/criteria.json
+++ b/evals/review-feedback-addressing-conventions/criteria.json
@@ -23,14 +23,14 @@
       "description": "The guide produces a reply for EVERY thread (CI failure, accept, decline) — not two of three. An empty reply or 'no response needed' on any thread scores zero for this item"
     },
     {
-      "name": "Accept reply references the concrete fix",
+      "name": "Accept reply gives the reviewer a way to locate the fix",
       "max_score": 15,
-      "description": "The accept reply concretely points at where/how the fix landed (a commit sha, a commit message reference, or equivalent pointer a reader can follow). A bare 'Done', 'Resolved', 'Applied', or 'OK' scores zero — no actionable pointer. The specific phrase format is NOT scored; the substance is"
+      "description": "The accept reply includes at least one artifact a reader can follow to the fix in the repo — a commit sha, a file:line pointer, or a diff URL. A reply that only signals completion (no pointer) scores zero. The specific phrase format is NOT scored"
     },
     {
-      "name": "Decline reply cites concrete evidence",
+      "name": "Decline reply names an externally-verifiable reference",
       "max_score": 15,
-      "description": "The decline reply cites concrete evidence (file:line, spec/docs quote, linked precedent, scope constraint) for why the suggestion is being declined. A bare 'No thanks', 'Disagree', or vague 'out of scope' scores zero — the reply must hand the reviewer something they can verify. The specific phrase format is NOT scored"
+      "description": "The decline reply names at least one reference a reviewer can independently verify — e.g., a file path with line number, a quoted sentence from docs or spec, a link to a prior PR or issue, or a named scope constraint from the PR description. A reply made of opinion alone scores zero. The specific phrase format is NOT scored"
     },
     {
       "name": "Fixes pushed to the same branch",

--- a/evals/review-feedback-addressing-conventions/task.md
+++ b/evals/review-feedback-addressing-conventions/task.md
@@ -6,7 +6,7 @@ A junior engineer on your team just had their first PR reviewed by an automated 
 
 The engineer needs a concrete, step-by-step guide explaining exactly how to handle each type of feedback, including how to respond to review threads so nothing is left unresolved. They also want to know: if they make code changes to address the feedback, should those changes go on a new branch or the existing one?
 
-The team cares about substantive replies — accepted suggestions should point concretely at the fix (so a reader can find it), and declined suggestions should cite concrete evidence (so the reviewer can verify the reasoning). Vague replies like "done" or "no thanks" don't count.
+The team cares about substantive replies — accepted suggestions should point concretely at the fix (so a reader can find it), and declined suggestions should cite concrete evidence (so the reviewer can verify the reasoning).
 
 ## Output Specification
 

--- a/evals/review-feedback-addressing-conventions/task.md
+++ b/evals/review-feedback-addressing-conventions/task.md
@@ -6,14 +6,14 @@ A junior engineer on your team just had their first PR reviewed by an automated 
 
 The engineer needs a concrete, step-by-step guide explaining exactly how to handle each type of feedback, including how to respond to review threads so nothing is left unresolved. They also want to know: if they make code changes to address the feedback, should those changes go on a new branch or the existing one?
 
-The team cares about a consistent reply style in review threads — accepted suggestions and declined suggestions each have a specific format the team uses.
+The team cares about substantive replies — accepted suggestions should point concretely at the fix (so a reader can find it), and declined suggestions should cite concrete evidence (so the reviewer can verify the reasoning). Vague replies like "done" or "no thanks" don't count.
 
 ## Output Specification
 
 Produce a document named `review-response-guide.md` that walks through how to handle the three feedback types described above. For each type, include:
 
 - What action to take on the code (if any)
-- The exact text to post as a reply in the review thread
+- A sample reply the engineer would post in the review thread — concrete enough that the reviewer can either find the fix (for accepts) or verify the reasoning (for declines)
 - Where to push any code changes
 
-Make the guide concrete: use placeholder values like `<sha>` or `<reason>` where the actual values would depend on the situation, but show the exact reply format the team expects.
+Use placeholder values like `<sha>` or `<file>:<line>` where the actual values would depend on the situation.

--- a/evals/version-bump-reasoning-and-manifest-upda/criteria.json
+++ b/evals/version-bump-reasoning-and-manifest-upda/criteria.json
@@ -1,5 +1,5 @@
 {
-  "context": "Tests whether the agent reasons about semver classification (patch vs minor vs major) from the change descriptions, applies the correct manifest-update behavior for each (patch is CI-automated; minor and major need a manifest bump), produces the correct target version numbers, and sequences the three releases sensibly. Reply-format conventions and PR-title conventions are tested separately in `review-feedback-addressing-conventions` and `copilot-review-via-graphql` and are NOT re-scored here.",
+  "context": "Tests whether the agent reasons about semver classification (patch vs minor vs major) from the change descriptions, applies the correct manifest-update behavior for each (patch is CI-automated; minor and major need a manifest bump), produces the correct target version numbers, and sequences the three releases sensibly. Reply-format and PR-title conventions are scored elsewhere and not re-scored here.",
   "type": "weighted_checklist",
   "checklist": [
     {
@@ -35,7 +35,7 @@
     {
       "name": "Major: flags the breaking-change impact",
       "max_score": 15,
-      "description": "The runbook calls out that the v1-routes removal will break existing clients and surfaces this in the PR body, CHANGELOG, or a release note — not just as a version bump. An agent who treats it identically to the minor case scores zero"
+      "description": "The runbook calls out that the v1-routes removal will break existing clients — in a location a downstream consumer would see (release notes, migration guidance, or the runbook's own deployment checklist). An agent who treats it identically to the minor case scores zero"
     },
     {
       "name": "Sensible release sequencing",

--- a/evals/version-bump-reasoning-and-manifest-upda/criteria.json
+++ b/evals/version-bump-reasoning-and-manifest-upda/criteria.json
@@ -1,56 +1,51 @@
 {
-  "context": "Tests whether the agent correctly reasons about semantic version bump types and knows which bump levels require updating the project manifest versus relying on automation. Also checks that the agent follows the correct readiness checks and thread-reply conventions.",
+  "context": "Tests whether the agent reasons about semver classification (patch vs minor vs major) from the change descriptions, applies the correct manifest-update behavior for each (patch is CI-automated; minor and major need a manifest bump), produces the correct target version numbers, and sequences the three releases sensibly. Reply-format conventions and PR-title conventions are tested separately in `review-feedback-addressing-conventions` and `copilot-review-via-graphql` and are NOT re-scored here.",
   "type": "weighted_checklist",
   "checklist": [
     {
       "name": "Patch: no manifest update",
-      "max_score": 12,
-      "description": "For the bug-fix / patch change, the agent does NOT update the version field in the project manifest (e.g. package.json, tile.json, or equivalent), because patch is handled automatically"
+      "max_score": 15,
+      "description": "For the bug-fix change (null-pointer guard, backward-compat, no API change), the runbook does NOT update the manifest version — the patch bump is delegated to CI automation"
     },
     {
-      "name": "Patch: automation mentioned",
+      "name": "Patch: justifies delegation to automation",
       "max_score": 10,
-      "description": "For the patch change, the output mentions that the version bump is handled automatically by CI automation — not a manual step"
+      "description": "The runbook explains WHY the patch case skips a manifest bump — because CI auto-bumps the patch version on merge, making a manual edit redundant or wrong. A silent skip with no reasoning scores zero"
     },
     {
       "name": "Minor: manifest updated",
-      "max_score": 12,
-      "description": "For the new-feature / minor change, the agent DOES update the version field in the project manifest to reflect the minor bump"
+      "max_score": 10,
+      "description": "For the CSV-export change (additive, new public route, backward-compat), the runbook updates the manifest version field to a higher value"
+    },
+    {
+      "name": "Minor: correct semver target",
+      "max_score": 10,
+      "description": "The target version is `1.5.0` (not `1.4.3`, not `2.0.0`). Scores the agent's classification AND its semver arithmetic"
     },
     {
       "name": "Major: manifest updated",
-      "max_score": 12,
-      "description": "For the breaking-change / major change, the agent DOES update the version field in the project manifest to reflect the major bump"
-    },
-    {
-      "name": "Readiness: tests",
       "max_score": 10,
-      "description": "The release process (script, checklist, or documentation) includes running the test suite as a required step before creating the PR, and requires tests to pass"
+      "description": "For the v1-routes removal (breaking change), the runbook updates the manifest version field to a higher value"
     },
     {
-      "name": "Readiness: linter",
+      "name": "Major: correct semver target",
       "max_score": 10,
-      "description": "The release process includes running the linter as a required step before creating the PR, and requires it to pass with no warnings or errors"
+      "description": "The target version is `2.0.0` (not `1.4.3`, not `1.5.0`). Scores the agent's classification AND its semver arithmetic"
     },
     {
-      "name": "PR title convention",
-      "max_score": 8,
-      "description": "PR titles for each change follow the `<type>(<scope>): <imperative summary>` convention"
+      "name": "Major: flags the breaking-change impact",
+      "max_score": 15,
+      "description": "The runbook calls out that the v1-routes removal will break existing clients and surfaces this in the PR body, CHANGELOG, or a release note — not just as a version bump. An agent who treats it identically to the minor case scores zero"
     },
     {
-      "name": "Accepted reply format",
-      "max_score": 8,
-      "description": "When describing how to respond to accepted review feedback, uses the format `Fixed in <sha>` (not just 'done' or 'resolved')"
-    },
-    {
-      "name": "Declined reply format",
-      "max_score": 8,
-      "description": "When describing how to respond to declined/rejected review suggestions, uses the format `Declining — <reason>`"
-    },
-    {
-      "name": "All threads replied",
+      "name": "Sensible release sequencing",
       "max_score": 10,
-      "description": "The release process requires a reply on EVERY review thread before merging — does NOT allow dangling/unresolved threads"
+      "description": "The runbook orders the three PRs thoughtfully — e.g., ship the bug-fix patch first (low risk, quick win), then minor, then major last (gives downstream the longest notice). Any coherent sequencing with stated reasoning passes; no sequencing at all, or reversing it without justification, scores zero"
+    },
+    {
+      "name": "Readiness gate: tests + linter",
+      "max_score": 10,
+      "description": "The runbook requires tests AND linter to pass before creating any of the three PRs — a universal engineering practice, scored once as a general gate rather than duplicated per change"
     }
   ]
 }

--- a/evals/version-bump-reasoning-and-manifest-upda/task.md
+++ b/evals/version-bump-reasoning-and-manifest-upda/task.md
@@ -2,7 +2,7 @@
 
 ## Problem/Feature Description
 
-A small open-source library team is wrapping up a sprint that produced three distinct categories of changes that need to ship as separate PRs. The team is inconsistent about when to bump versions manually versus letting their CI pipeline handle it, and keeps picking the wrong target version number when a bump is needed. The team lead wants a `RELEASE_RUNBOOK.md` that documents the versioning decision and the release sequencing for each type of change.
+A small open-source library team is wrapping up a sprint that produced three distinct categories of changes that need to ship as separate PRs. The team's CI pipeline automatically bumps the patch segment of the semver on every merge; manual manifest edits are only needed for non-patch bumps. The team is inconsistent about applying that rule correctly and keeps picking the wrong target version number when a manual bump is needed. The team lead wants a `RELEASE_RUNBOOK.md` that documents the versioning decision and the release sequencing for each type of change.
 
 ## Output Specification
 

--- a/evals/version-bump-reasoning-and-manifest-upda/task.md
+++ b/evals/version-bump-reasoning-and-manifest-upda/task.md
@@ -2,17 +2,14 @@
 
 ## Problem/Feature Description
 
-A small open-source library team is wrapping up a sprint that produced three distinct categories of changes that need to ship as separate PRs. The team is inconsistent about when to bump versions manually versus letting their CI pipeline handle it, and junior contributors often open PRs with vague titles and skip steps before requesting review. The team lead wants a `RELEASE_RUNBOOK.md` that documents the exact steps for releasing each type of change, so anyone on the team can follow it reliably.
-
-The runbook should also explain how to handle feedback left by automated code reviewers — including both cases where a suggestion is accepted and where it should be politely declined — so that PRs don't stall waiting for replies.
+A small open-source library team is wrapping up a sprint that produced three distinct categories of changes that need to ship as separate PRs. The team is inconsistent about when to bump versions manually versus letting their CI pipeline handle it, and keeps picking the wrong target version number when a bump is needed. The team lead wants a `RELEASE_RUNBOOK.md` that documents the versioning decision and the release sequencing for each type of change.
 
 ## Output Specification
 
-Produce a `RELEASE_RUNBOOK.md` file that covers the complete release process for the three change types listed below. For each type, the runbook should describe:
-- Pre-PR readiness steps
-- How to construct the PR title and body
-- What to do about versioning (whether and how to update the project manifest)
-- How to handle automated review feedback before merging
+Produce a `RELEASE_RUNBOOK.md` file that covers, for each of the three change types below:
+- Pre-PR readiness steps (what must be verified before creating the PR)
+- Whether the project manifest's version field should be updated, and if so, to what target version number (the current version is in the manifest fixture below)
+- A reasoned recommendation for the order in which the three PRs should ship, given the relative risk and downstream impact
 
 You may also produce a `release.sh` helper script if you find it useful to illustrate the steps programmatically.
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Policy eval audit found ~27% of the eval budget was testing "did the agent read the skill" rather than "can the agent reason". Rewrite the six offenders: criteria focus on reasoning/outcomes, and (where bleeding lived in the task) tasks are tightened too.

**What changed per scenario:**

| Scenario | Before | After |
|---|---|---|
| `release-on-main-branch-rejection` | 25pt "Detects main branch" restates the task's own spoiler | Scores the multi-step recovery (branch from HEAD, roll back local main, complete release) |
| `pr-merge-and-post-merge-cleanup` | 60% transcription (`--merge`, `--delete-branch`, `--ff-only`, `-d`) | Pre-merge gates, OUTCOME-based state checks, graceful-failure diagnostics. Task trimmed (dropped companion checklist doc) |
| `copilot-review-via-graphql` | Hardcoded `BOT_kgDOCnlnWA` literal + magic field names | GraphQL-vs-REST reasoning + "don't depend on permanent hardcoded ID". Task trimmed (dropped companion usage.md) |
| `version-bump-reasoning-and-manifest-upda` | 4 reply-format + readiness criteria duplicating other scenarios | Semver targets (`1.5.0` vs `2.0.0`), breaking-change impact, release sequencing. Task rewritten to focus on versioning + sequencing |
| `review-feedback-addressing-conventions` | 30pts on literal phrases `Fixed in <sha>` / `Declining — <reason>` | Substance of replies: accept-concretely-references-fix, decline-cites-evidence. Task rewritten to ask for substantive replies, not an "exact format" |
| `ci-and-review-status-polling` | Prescribes `gh pr checks --watch` and specific API paths | Scores signal capture + surfacing; keeps one real API gotcha (inline-vs-issue comments). Task clarified (all inputs parameterized) |

**Scope note:** five of six `task.md` files were also touched, not just criteria. In three cases the task itself was bleeding (`review-feedback-addressing-conventions` demanding "exact format", `version-bump` demanding feedback handling tested elsewhere); in three cases the task required companion docs (README.md / usage.md / MERGE_CHECKLIST.md) whose scoring would've been documentation grading rather than reasoning grading — so the task was trimmed and criteria focus on the core behavior.

**Unchanged:** the seven scenarios that were genuinely testing behavior (`consumer-scaffolds-policy-reviewer`, `install-reviewer-missing-gh-aw`, `install-reviewer-refuses-overwrite`, `merge-with-failing-ci-rejection`, `coverage-gap-identification-and-fill`, `eval-scenario-quality-review-and-repair`, plus the two install-reviewer negative tests). Each rewritten rubric still sums to 100.

**Follow-up (not in this PR):** tighten `rules/plugin-evals.md` so new scenarios can't slip this past review — specifically, add explicit guidance that criteria citing verbatim strings which appear in installed skill files are leaking even when the strings look like "conventions".

## Test plan

- [x] `jq -e '[.checklist[].max_score] | add'` on each rewritten rubric returns 100 (confirmed locally)
- [ ] In-repo gh-aw reviewer passes against the new criteria and the Author-Model gate