### PR TITLE
fix(dependency-management): add runtime-managed-manifest exception clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Rules
+
+- **dependency-management** — Adds a narrow exception clause to the Pinning section for runtime-managed manifests: when a tool rewrites a manifest in-place at runtime AND the resolved-version state is gitignored, pin-or-lock produces silent drift between git and the running deployment, so the manifest may use floating-but-explicit specifiers (e.g. `"version": "latest"`) and skip the lock file. The exception is gated on three preconditions: the consuming project documents an authority-of-record rule in its own tile, a deploy-time check fails the deployment if a literal pin reappears, and the carve-out is narrowly scoped to a single named manifest. Triggered by NanoClaw's `tessl-workspace/tessl.json` 22-day silent-drift incident on 2026-04-27; authority-of-record rule is `nanoclaw-host: tessl-version-floating`.
+
 ## 0.3.0
 
 Second formal minor since 0.1.0 — `install-reviewer` gains an in-place upgrade path (`--override`) so consumers no longer have to manually `git rm` four files (or hand-backport fixes, defeating the managed-scaffold contract) every time a fix lands in this changelog. The skill description's "Use when..." clause now lists upgrade trigger phrases (`upgrade`, `update`, `refresh`, `pull latest reviewer templates`, `override`); each of the five scripts (`preflight.sh`, `branch.sh`, `scaffold.sh`, `commit.sh`, `push.sh`) accepts `--override` and emits an `override: bool` field in its JSON output. Step 3's branch-selection logic moved out of SKILL.md prose into a new `branch.sh` script per `rules/script-delegation.md` (deterministic operations belong in scripts, not embedded decision trees the agent reproduces) and `rules/skill-authoring.md` (flat one-action steps, no sub-step bullets).

--- a/rules/dependency-management.md
+++ b/rules/dependency-management.md
@@ -18,6 +18,7 @@ alwaysApply: true
 
 - Pin versions or use a lock file to ensure reproducible builds
 - Lock files are committed to the repo
+- **Narrow exception for runtime-managed manifests**: if a tool the deployment relies on rewrites a manifest in-place at runtime AND the resolved-version state is gitignored, pin-or-lock produces silent drift where git and the running deployment disagree across every restart. In that one case the manifest may use a floating-but-explicit specifier (e.g. `"version": "latest"`) and skip the lock file, **only when** the project documents an authority-of-record rule in its own tile naming the carve-out (filename, scope, why the rewrite-in-place violates pin/lock semantics); AND a deploy-time check fails the deployment if a literal pin reappears in that manifest; AND the carve-out is narrowly scoped to a single named manifest. Every other manifest in the repo still pins. Reference incident: NanoClaw's `tessl-workspace/tessl.json` accumulated a 22-day silent drift on 2026-04-27 because `tessl update` rewrites the manifest in-place; authority-of-record rule is `nanoclaw-host: tessl-version-floating`.
 
 ## No Vendoring
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Adds a narrow exception clause to `rules/dependency-management.md`'s Pinning section for the case where a tool rewrites a manifest in-place at runtime AND the resolved-version state is gitignored.

## Why

Triggered by NanoClaw's `tessl-workspace/tessl.json` 22-day silent-drift incident on 2026-04-27. `tessl update` rewrites the manifest at three independent points (`scripts/deploy.sh`, the orchestrator's 15-min loop, the `tessl_update` MCP tool); `.tessl/tiles/` (where the resolved versions would otherwise land as a lock file) is gitignored. Result: every successful update produced a working-tree diff that nobody committed, `git pull` rolled the orchestrator backward, and the fleet quietly ran whichever pins were last hand-committed instead of whatever the registry had now.

The pin-or-lock invariant simply doesn't fit when the manifest is itself a runtime side-effect surface. The exception in this PR formalizes that, with three gates so it doesn't become a blanket relaxation.

## What changes

`rules/dependency-management.md` Pinning section: one new bullet under the existing `Pin versions or use a lock file` + `Lock files are committed to the repo` bullets. The bullet:

- Names the trigger condition (rewrite-in-place + gitignored lock state).
- Permits floating-but-explicit specifiers (`"version": "latest"`).
- Gates on three preconditions:
  1. authority-of-record rule in the consuming project's own tile (filename, scope, why pin/lock fails);
  2. deploy-time check fails the deployment if a literal pin reappears;
  3. narrowly scoped to a single named manifest.

References the NanoClaw incident + the `nanoclaw-host: tessl-version-floating` authority-of-record rule by name.

## Why this PR is needed (operational)

Without this clause, the OpenAI policy reviewer flags `nanoclaw#201` (the manifest flip from pinned to `"latest"`) as a `dependency-management` violation, blocking merge. The reviewer keys on `coding-policy` rules — it can't read consumer-tile rules like `nanoclaw-host: tessl-version-floating`. So the exception has to live in `coding-policy` itself for the review gate to recognize the carve-out as legitimate.

## Test plan

- [x] One-line bullet, no other rule edits.
- [x] CHANGELOG entry under Unreleased.
- [ ] Copilot review clean.
- [ ] OpenAI + Anthropic policy reviewers clean (it's not their tile but they sometimes spot-check).
- [ ] CI green.
- [ ] Per `nanoclaw-host: post-merge-publish-watch` (just landed in nanoclaw-host#15) — verify the bumped `tile.json` AND the workflow `success` conclusion before declaring this done.

## Pipeline

Direct PR on `jbaruch/coding-policy` — this tile doesn't have a staging→promote pipeline; rule edits are direct.