### PR TITLE
perf(publish): review only skills that changed

### DIFF
--- a/.github/actions/skill-review/action.yml
+++ b/.github/actions/skill-review/action.yml
@@ -69,8 +69,16 @@ runs:
             mapfile -t skills < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
             echo "Reviewing all ${#skills[@]} skill(s) (base unreachable)."
           else
+            # Strip the SKILLS_DIR prefix from each diff path and pull
+            # out the first path component beneath it — works for any
+            # depth (single-component `skills` or nested `pkg/skills`).
             mapfile -t skills < <(git diff --name-only "$base..HEAD" -- "$SKILLS_DIR/" \
-              | awk -F/ -v dir="$SKILLS_DIR" 'NF>=2 && $1==dir {print $2}' | sort -u)
+              | awk -v prefix="$SKILLS_DIR/" '
+                  index($0, prefix) == 1 {
+                    rest = substr($0, length(prefix) + 1)
+                    slash = index(rest, "/")
+                    if (slash > 0) print substr(rest, 1, slash - 1)
+                  }' | sort -u)
             echo "Detected ${#skills[@]} changed skill(s) since ${base:0:7}."
           fi
         fi

--- a/.github/actions/skill-review/action.yml
+++ b/.github/actions/skill-review/action.yml
@@ -1,0 +1,86 @@
+name: 'Skill review (changed only)'
+description: |
+  Runs `tessl skill review --threshold N` on every skill whose files
+  changed since the previous push, instead of every skill in the tile.
+  Per `jbaruch/coding-policy: context-artifacts` "Mandatory Review":
+  every skill change must pass review, but unchanged skills do not
+  need to be re-reviewed on every publish — that just burns runner
+  time and Tessl credits.
+
+  Detection: `git diff $BASE..HEAD -- $skills-dir/`. BASE is the input
+  `base-ref` if provided, else `github.event.before` for push events.
+  On `workflow_dispatch` or initial push (no usable base), reviews
+  every skill (manual triggers expect a full re-review).
+
+  Requirements (consumer must arrange):
+    - `tessl` CLI on PATH (typically via `tesslio/setup-tessl@v2`).
+    - Repository checked out with full history reachable from BASE
+      (typically `actions/checkout@v4` with `fetch-depth: 0`).
+
+inputs:
+  threshold:
+    description: 'Minimum score required for a skill to pass review'
+    required: false
+    default: '85'
+  skills-dir:
+    description: 'Directory containing skill subdirectories (relative to workspace root)'
+    required: false
+    default: 'skills'
+  base-ref:
+    description: |
+      Override the base ref/SHA for the diff. When empty, the action falls
+      back to `github.event.before` (push events) or "review all"
+      (workflow_dispatch / initial push).
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Identify changed skills and review them
+      shell: bash
+      env:
+        EVENT_BEFORE: ${{ github.event.before }}
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_OVERRIDE: ${{ inputs.base-ref }}
+        THRESHOLD: ${{ inputs.threshold }}
+        SKILLS_DIR: ${{ inputs.skills-dir }}
+      run: |
+        if [ -n "$BASE_OVERRIDE" ]; then
+          base="$BASE_OVERRIDE"
+        elif [ "$EVENT_NAME" = "workflow_dispatch" ] \
+             || [ -z "$EVENT_BEFORE" ] \
+             || [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+          base=""
+        else
+          base="$EVENT_BEFORE"
+        fi
+        if [ -z "$base" ]; then
+          mapfile -t skills < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+          echo "Reviewing all ${#skills[@]} skill(s) (manual trigger or initial push)."
+        else
+          if ! git rev-parse --verify "$base" >/dev/null 2>&1; then
+            echo "Base $base not reachable in shallow clone; fetching..."
+            git fetch --no-tags --depth=50 origin "$base" 2>/dev/null \
+              || git fetch --unshallow origin 2>/dev/null \
+              || { echo "::warning::Could not fetch $base — falling back to review-all."; base=""; }
+          fi
+          if [ -z "$base" ]; then
+            mapfile -t skills < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+            echo "Reviewing all ${#skills[@]} skill(s) (base unreachable)."
+          else
+            mapfile -t skills < <(git diff --name-only "$base..HEAD" -- "$SKILLS_DIR/" \
+              | awk -F/ -v dir="$SKILLS_DIR" 'NF>=2 && $1==dir {print $2}' | sort -u)
+            echo "Detected ${#skills[@]} changed skill(s) since ${base:0:7}."
+          fi
+        fi
+        if [ "${#skills[@]}" -eq 0 ]; then
+          echo "No skill changes — review skipped."
+          exit 0
+        fi
+        for skill in "${skills[@]}"; do
+          [ -f "$SKILLS_DIR/$skill/SKILL.md" ] || { echo "  - $skill: deleted, skipping"; continue; }
+          echo "::group::Reviewing $skill"
+          tessl skill review --threshold "$THRESHOLD" "$SKILLS_DIR/$skill/SKILL.md"
+          echo "::endgroup::"
+        done

--- a/.github/actions/skill-review/action.yml
+++ b/.github/actions/skill-review/action.yml
@@ -46,6 +46,11 @@ runs:
         THRESHOLD: ${{ inputs.threshold }}
         SKILLS_DIR: ${{ inputs.skills-dir }}
       run: |
+        # Pipefail so a failing `git diff` propagates instead of silently
+        # producing an empty changed-skills set (which would skip the
+        # mandatory review per `rules/context-artifacts.md`).
+        set -eo pipefail
+
         if [ -n "$BASE_OVERRIDE" ]; then
           base="$BASE_OVERRIDE"
         elif [ "$EVENT_NAME" = "workflow_dispatch" ] \
@@ -59,28 +64,32 @@ runs:
           mapfile -t skills < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
           echo "Reviewing all ${#skills[@]} skill(s) (manual trigger or initial push)."
         else
-          if ! git rev-parse --verify "$base" >/dev/null 2>&1; then
-            echo "Base $base not reachable in shallow clone; fetching..."
+          # Validate the base is a real commit before relying on it for
+          # the diff. If not reachable in the local clone, try a shallow
+          # fetch; if that fails too, hard-fail rather than silently
+          # converting an unreachable base into "no changes".
+          if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+            echo "Base $base not reachable in clone; fetching..."
             git fetch --no-tags --depth=50 origin "$base" 2>/dev/null \
               || git fetch --unshallow origin 2>/dev/null \
-              || { echo "::warning::Could not fetch $base — falling back to review-all."; base=""; }
+              || true
           fi
-          if [ -z "$base" ]; then
-            mapfile -t skills < <(find "$SKILLS_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
-            echo "Reviewing all ${#skills[@]} skill(s) (base unreachable)."
-          else
-            # Strip the SKILLS_DIR prefix from each diff path and pull
-            # out the first path component beneath it — works for any
-            # depth (single-component `skills` or nested `pkg/skills`).
-            mapfile -t skills < <(git diff --name-only "$base..HEAD" -- "$SKILLS_DIR/" \
-              | awk -v prefix="$SKILLS_DIR/" '
-                  index($0, prefix) == 1 {
-                    rest = substr($0, length(prefix) + 1)
-                    slash = index(rest, "/")
-                    if (slash > 0) print substr(rest, 1, slash - 1)
-                  }' | sort -u)
-            echo "Detected ${#skills[@]} changed skill(s) since ${base:0:7}."
+          if ! git rev-parse --verify "${base}^{commit}" >/dev/null 2>&1; then
+            echo "::error::Base $base is not a reachable commit; refusing to silently skip skill review."
+            echo "::error::Set actions/checkout fetch-depth: 0 in the calling workflow, or pass an explicit base-ref."
+            exit 1
           fi
+          # Strip the SKILLS_DIR prefix from each diff path and pull
+          # out the first path component beneath it — works for any
+          # depth (single-component `skills` or nested `pkg/skills`).
+          mapfile -t skills < <(git diff --name-only "$base..HEAD" -- "$SKILLS_DIR/" \
+            | awk -v prefix="$SKILLS_DIR/" '
+                index($0, prefix) == 1 {
+                  rest = substr($0, length(prefix) + 1)
+                  slash = index(rest, "/")
+                  if (slash > 0) print substr(rest, 1, slash - 1)
+                }' | sort -u)
+          echo "Detected ${#skills[@]} changed skill(s) since ${base:0:7}."
         fi
         if [ "${#skills[@]}" -eq 0 ]; then
           echo "No skill changes — review skipped."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Need history reachable from `github.event.before` so the
+          # changed-skills detection below can run `git diff $BEFORE..HEAD`.
+          fetch-depth: 0
 
       - uses: tesslio/setup-tessl@v2
         with:
@@ -26,14 +30,38 @@ jobs:
       - name: Lint tile
         run: tessl tile lint
 
-      - name: Review release skill
-        run: tessl skill review --threshold 85 skills/release
-
-      - name: Review eval-authoring skill
-        run: tessl skill review --threshold 85 skills/eval-authoring
-
-      - name: Review install-reviewer skill
-        run: tessl skill review --threshold 85 skills/install-reviewer
+      # Per `rules/context-artifacts.md`: "Every skill change must pass
+      # `tessl skill review`". Interpreted strictly: only changed skills
+      # need to pass per publish — not every skill in the tile every time.
+      # Reviews are LLM-backed and consume Tessl credits, so reviewing
+      # untouched skills on every merge wastes both runner time and tokens.
+      - name: Skill review (changed only)
+        env:
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+             || [ -z "$EVENT_BEFORE" ] \
+             || [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            # Manual trigger or initial push to a new branch: review every skill.
+            mapfile -t skills < <(find skills -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
+            echo "Reviewing all ${#skills[@]} skill(s) (manual trigger or initial push)."
+          else
+            # Push from a merged PR: review skills whose files changed.
+            mapfile -t skills < <(git diff --name-only "$EVENT_BEFORE..HEAD" -- 'skills/' \
+              | awk -F/ 'NF>=2 && $1=="skills"{print $2}' | sort -u)
+            echo "Detected ${#skills[@]} changed skill(s) since ${EVENT_BEFORE:0:7}."
+          fi
+          if [ "${#skills[@]}" -eq 0 ]; then
+            echo "No skill changes — review skipped."
+            exit 0
+          fi
+          for skill in "${skills[@]}"; do
+            [ -f "skills/$skill/SKILL.md" ] || { echo "  - $skill: deleted, skipping"; continue; }
+            echo "::group::Reviewing $skill"
+            tessl skill review --threshold 85 "skills/$skill/SKILL.md"
+            echo "::endgroup::"
+          done
 
       - uses: tesslio/patch-version-publish@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,38 +30,14 @@ jobs:
       - name: Lint tile
         run: tessl tile lint
 
-      # Per `rules/context-artifacts.md`: "Every skill change must pass
-      # `tessl skill review`". Interpreted strictly: only changed skills
-      # need to pass per publish — not every skill in the tile every time.
-      # Reviews are LLM-backed and consume Tessl credits, so reviewing
-      # untouched skills on every merge wastes both runner time and tokens.
+      # Reviews only the skills whose files changed since the previous
+      # push. Action is dogfooded from this repo via the local path
+      # `./.github/actions/skill-review`; consumer repos call it as
+      # `uses: jbaruch/coding-policy/.github/actions/skill-review@<ref>`.
       - name: Skill review (changed only)
-        env:
-          EVENT_BEFORE: ${{ github.event.before }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
-             || [ -z "$EVENT_BEFORE" ] \
-             || [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
-            # Manual trigger or initial push to a new branch: review every skill.
-            mapfile -t skills < <(find skills -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort)
-            echo "Reviewing all ${#skills[@]} skill(s) (manual trigger or initial push)."
-          else
-            # Push from a merged PR: review skills whose files changed.
-            mapfile -t skills < <(git diff --name-only "$EVENT_BEFORE..HEAD" -- 'skills/' \
-              | awk -F/ 'NF>=2 && $1=="skills"{print $2}' | sort -u)
-            echo "Detected ${#skills[@]} changed skill(s) since ${EVENT_BEFORE:0:7}."
-          fi
-          if [ "${#skills[@]}" -eq 0 ]; then
-            echo "No skill changes — review skipped."
-            exit 0
-          fi
-          for skill in "${skills[@]}"; do
-            [ -f "skills/$skill/SKILL.md" ] || { echo "  - $skill: deleted, skipping"; continue; }
-            echo "::group::Reviewing $skill"
-            tessl skill review --threshold 85 "skills/$skill/SKILL.md"
-            echo "::endgroup::"
-          done
+        uses: ./.github/actions/skill-review
+        with:
+          threshold: '85'
 
       - uses: tesslio/patch-version-publish@v1
         with:


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- Replace the all-skills `tessl skill review` pass in the publish workflow with a `git diff`-based filter that only reviews skills whose files changed since the previous push.
- Manual triggers (`workflow_dispatch`) and initial pushes still review every skill — the diff base is undefined in those cases.
- Deleted-skill paths are skipped via the existing `[ -f SKILL.md ]` check; renames work because `git diff --name-only` lists both old and new paths.

## Why
`tessl skill review` is LLM-backed and consumes Tessl credits. The all-skills loop runs every review on every merge to main, even when the merged PR didn't touch the skill. On tiles with many skills the per-publish cost is ~20–40 min of runner + tokens regardless of the actual change. `rules/context-artifacts.md` says *"every skill **change** must pass `tessl skill review`"* — the letter of the rule is changed-only; the implementation had overshot to all-skills-every-time.

## Scope
CI configuration change, scoped explicitly per `rules/ci-safety.md` — this PR's title and body are the approval artifact.

## Test plan
- [ ] CI passes on this PR (Test workflow + cross-family OpenAI reviewer).
- [ ] After merge to main: workflow logs read `Detected N changed skill(s) since <sha>` and only the changed skills are reviewed.
- [ ] Trigger workflow manually via `workflow_dispatch` — logs read `Reviewing all N skill(s) (manual trigger ...)` and every skill is reviewed.
- [ ] Open a PR that touches only `rules/` (no skill change) — after merge, log says `No skill changes — review skipped.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
