### PR TITLE
feat(rules): add reader-side CHANGELOG-as-archive guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Rules
 
-- **context-writing-style** — Adds reader-side complement to "What to Cut → move to CHANGELOG". Writer-side directives strip motivation, incidents, and worked examples from rule bodies; the reader-side `## Reader-Side — Consult the CHANGELOGs` section now tells agents where to find that content when they need it. Four bullets: (1) the relevant tile's `CHANGELOG.md` is the archive for cut motivation/incident/worked-example content; (2) cross-tile rules have motivation spread across multiple CHANGELOGs — read each, don't stop at one; (3) CHANGELOGs are read-on-demand, not auto-loaded — consult when judging an edge case, debugging a directive, or auditing rule-vs-reality drift; (4) silence on rationale in rule bodies is by design, not omission — don't infer incompleteness, consult the archive. Closes the writer/reader asymmetry where rule bodies were being aggressively pruned without a complementary signal telling agents where the cut content went.
+- **context-writing-style** — Adds `## Reader-Side — Consult the CHANGELOGs` section telling agents where to find motivation cut from rule bodies. Closes the writer/reader asymmetry created by "What to Cut → move to CHANGELOG".
 
 ### Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Rules
+
+- **context-writing-style** — Adds reader-side complement to "What to Cut → move to CHANGELOG". Writer-side directives strip motivation, incidents, and worked examples from rule bodies; the reader-side `## Reader-Side — Consult the CHANGELOGs` section now tells agents where to find that content when they need it. Four bullets: (1) the relevant tile's `CHANGELOG.md` is the archive for cut motivation/incident/worked-example content; (2) cross-tile rules have motivation spread across multiple CHANGELOGs — read each, don't stop at one; (3) CHANGELOGs are read-on-demand, not auto-loaded — consult when judging an edge case, debugging a directive, or auditing rule-vs-reality drift; (4) silence on rationale in rule bodies is by design, not omission — don't infer incompleteness, consult the archive. Closes the writer/reader asymmetry where rule bodies were being aggressively pruned without a complementary signal telling agents where the cut content went.
+
 ### Skills
 
 - **release** — Step 1 (Verify Readiness) gains a pre-push self-audit bullet alongside the existing tests + linter gates: audit the diff against every governing rule or skill whose domain covers the touched paths, grep the diff for the markers each one names, run any local check it prescribes, and recognize the paired cross-family reviewer as a backstop rather than the first read.

--- a/rules/context-writing-style.md
+++ b/rules/context-writing-style.md
@@ -33,6 +33,13 @@ description: Prose discipline for rules, skills, and READMEs — what to cut, wh
 - Constraint-bearing words: required, optional, mandatory, forbidden, deprecated
 - Carve-out preconditions in full (preconditions are the rule for edge cases)
 
+## Reader-Side — Consult the CHANGELOGs
+
+- When you need the motivation, incident, or worked example behind a rule's directive — the rule itself won't carry it; the relevant tile's `CHANGELOG.md` is the archive
+- A rule that touches multiple tiles has motivation spread across multiple CHANGELOGs; read each tile's archive, don't stop at one
+- Read on demand only: CHANGELOGs are not auto-loaded; pull them up when judging an edge case, debugging an unexpected directive, or auditing whether a rule still describes current reality
+- The rule body's silence on rationale is by design — not an omission. Don't infer the rule is incomplete; consult the archive instead
+
 ## Structure
 
 - Atomic bullets — one directive per bullet

--- a/rules/context-writing-style.md
+++ b/rules/context-writing-style.md
@@ -36,11 +36,12 @@ description: Prose discipline for rules, skills, and READMEs — what to cut, wh
 ## Reader-Side — Consult the CHANGELOGs
 
 - The relevant tile's `CHANGELOG.md` is the archive for motivation, incidents, and worked examples cut from rule bodies
-- Read each tile's archive when a rule spans tiles; one tile's CHANGELOG won't carry another tile's cut content
+- Read each tile's archive when a rule spans tiles
+- Do not stop after one tile's CHANGELOG
 - Pull a CHANGELOG when judging an edge case
 - Pull a CHANGELOG when debugging an unexpected directive
 - Pull a CHANGELOG when auditing whether a rule still describes current reality
-- Silence on rationale in rule bodies is by design — never infer the rule is incomplete
+- Never infer that missing rationale in a rule body means the rule is incomplete
 
 ## Structure
 

--- a/rules/context-writing-style.md
+++ b/rules/context-writing-style.md
@@ -35,10 +35,12 @@ description: Prose discipline for rules, skills, and READMEs — what to cut, wh
 
 ## Reader-Side — Consult the CHANGELOGs
 
-- When you need the motivation, incident, or worked example behind a rule's directive — the rule itself won't carry it; the relevant tile's `CHANGELOG.md` is the archive
-- A rule that touches multiple tiles has motivation spread across multiple CHANGELOGs; read each tile's archive, don't stop at one
-- Read on demand only: CHANGELOGs are not auto-loaded; pull them up when judging an edge case, debugging an unexpected directive, or auditing whether a rule still describes current reality
-- The rule body's silence on rationale is by design — not an omission. Don't infer the rule is incomplete; consult the archive instead
+- The relevant tile's `CHANGELOG.md` is the archive for motivation, incidents, and worked examples cut from rule bodies
+- Read each tile's archive when a rule spans tiles; one tile's CHANGELOG won't carry another tile's cut content
+- Pull a CHANGELOG when judging an edge case
+- Pull a CHANGELOG when debugging an unexpected directive
+- Pull a CHANGELOG when auditing whether a rule still describes current reality
+- Silence on rationale in rule bodies is by design — never infer the rule is incomplete
 
 ## Structure
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

`context-writing-style`'s `What to Cut → move to CHANGELOG` directive is writer-side: it tells rule authors to strip motivation/incidents/worked-examples and archive them in CHANGELOG. This PR adds the reader-side complement — a `## Reader-Side — Consult the CHANGELOGs` section telling agents where to look for that cut content when they need it.

## Why now

The nanoclaw-* tile fleet just shipped a conciseness pass against four `nanoclaw-host` rules and five `nanoclaw-trusted` rules (≈1,516 tokens cut from per-invocation context). Each PR's CHANGELOG entry captures the cut content per the rule's writer-side directive. But there's no current signal telling readers — agents reading a pruned rule — that the motivation moved to the tile's CHANGELOG and is retrievable on demand. Without that signal, agents may misread the pruned rule as incomplete or under-specified, and either re-derive the rationale (expensive) or treat the silence as license to deviate (worse).

## What this PR adds

Four atomic bullets in a new `## Reader-Side — Consult the CHANGELOGs` H2:

1. The relevant tile's `CHANGELOG.md` is the archive for motivation/incident/worked-example content stripped from rule bodies.
2. Cross-tile rules have motivation spread across multiple tile CHANGELOGs; read each, don't stop at one.
3. CHANGELOGs are read-on-demand, not auto-loaded — consult when judging an edge case, debugging a directive, or auditing rule-vs-reality drift.
4. Silence on rationale in rule bodies is by design, not omission — don't infer incompleteness; consult the archive.

## Budget impact

`context-writing-style.md` goes from 4 to 5 H2 sections (within the 3–6 budget) and 39 to 47 body lines (within the ~25–40 single-concept budget plus the "rules covering one coherent policy area with several sub-aspects may run larger" carve-out — this rule covers writer-side discipline + structure + reader-side complement).

## Test plan
- [ ] CI passes on this PR (reviewer workflows).
- [ ] After merge, post-merge publish-tile lands `success` and registry `latestVersion` advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)