### PR TITLE
chore: import script-as-black-box.md in maintainer context

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -15,6 +15,7 @@ This repo IS `jbaruch/coding-policy`. The rule files below are the source-of-tru
 @../rules/rule-frontmatter.md
 @../rules/skill-authoring.md
 @../rules/script-delegation.md
+@../rules/script-as-black-box.md
 @../rules/plugin-evals.md
 @../rules/author-model-declaration.md
 @../rules/stateful-artifacts.md


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
- Add the missing `@../rules/script-as-black-box.md` import to `.claude/CLAUDE.md`, restoring tile-to-dogfood parity.
- Placed in the Authoring group between `script-delegation` and `plugin-evals`, matching `tile.json` steering order.

## Why
`.claude/CLAUDE.md` exists so the maintainer reads the live source rules via `@-`imports rather than a vendored tile copy. The `script-as-black-box` rule landed its steering entry, README row, and `tile.json` surface, but the CLAUDE.md import was never added — leaving the maintainer context one rule short.

## Acceptance
- [x] `.claude/CLAUDE.md` imports all rules listed in `tile.json` steering
- [x] `grep -c '^@\.\./rules/' .claude/CLAUDE.md` (20) matches `jq '.steering | length' tile.json` (20)

Closes #99