### PR TITLE
docs(rules): scope CHANGELOG Hygiene to the release model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+### Rules
+
+- **CHANGELOG Hygiene rewritten for publish-on-merge vs manual release** — `rules/context-artifacts.md` now matches the CHANGELOG's top-of-file convention to the release model. Publish-on-merge projects (every merge auto-publishes) drop the `Unreleased` bucket: authors add un-headed `### ` entries at the top and the publish pipeline stamps a `## <version> — <date>` heading before publish; an `Unreleased` heading is forbidden because merged work is already published. Manual-release projects keep `Unreleased` and consolidate on release. Prompted by the Tessl registry "what's new" surfacing already-published entries as unreleased. This entry itself follows the new convention (un-headed, above the stamped `## 0.3.49` section). Follow-ups: this repo's publish pipeline must adopt the stamp step (port `scripts/stamp-changelog.py` + the workflow step from `jbaruch/speaker-toolkit#60`) so un-headed entries get versioned; `skills/eval-curation/SKILL.md`'s "under Unreleased" wording needs a model-agnostic tweak.
+
+## 0.3.49 — 2026-06-03
 
 ### Rules
 

--- a/rules/context-artifacts.md
+++ b/rules/context-artifacts.md
@@ -62,9 +62,13 @@ When you add, remove, or rename a rule or skill, update **all** of these:
 
 ## CHANGELOG Hygiene
 
-- On version release, consolidate Unreleased entries into the new version section: group related entries, collapse redundant detail, retain load-bearing facts (what changed, references)
-- CHANGELOG is archive but bounded — a PR's full motivation lives in the PR body and commit messages; the Unreleased entry can be one or two sentences when the broader context lives elsewhere
-- During consolidation, audit Unreleased for duplication — multiple PRs reworking the same rule become one entry with the final outcome
+- Match the CHANGELOG's top-of-file convention to the project's release model
+- **Publish-on-merge** (every merge auto-publishes, e.g. via `tesslio/patch-version-publish`): no `Unreleased` section. Authors add un-headed `### ` entry blocks at the top of `CHANGELOG.md`; the publish pipeline stamps a `## <version> — <date>` heading above them before publish
+- On a publish-on-merge project an `Unreleased` heading is forbidden — merged work is already published
+- **Manual release** (versions cut deliberately): keep an `## Unreleased` section; consolidate its entries into the new version heading on release
+- Consolidation groups related entries, collapses redundant detail, retains load-bearing facts (what changed, references)
+- CHANGELOG is archive but bounded — a PR's full motivation lives in the PR body and commit messages; an entry can be one or two sentences when the broader context lives elsewhere
+- Audit the top section for duplication — multiple PRs reworking the same rule become one entry with the final outcome
 
 ## Consistency Check
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary
The CHANGELOG Hygiene rule assumed a manual-release model (stage under `## Unreleased`, consolidate on release). For **publish-on-merge** projects — where every merge auto-publishes via `tesslio/patch-version-publish` — that's wrong: merged entries are already shipped, so an `Unreleased` bucket always lies (the Tessl registry "what's new" surfaces published work as unreleased).

The rule now matches the convention to the release model:
- **Publish-on-merge:** no `Unreleased`. Authors add un-headed `### ` entries at the top; the publish pipeline stamps `## <version> — <date>` before publish.
- **Manual release:** keep `Unreleased`, consolidate on release.

This PR also converts **this repo's own** CHANGELOG to the new convention (this repo is publish-on-merge): the previously-`Unreleased` merged entries are stamped as `## 0.3.49 — 2026-06-03`, and the rule-change entry sits un-headed above it.

## Required follow-ups (not in this PR)
1. **This repo must adopt the stamp step** so un-headed entries get versioned on publish — port `scripts/stamp-changelog.py` + the `publish.yml` step from `jbaruch/speaker-toolkit#60` (the reference implementation). Until then, new un-headed entries publish without a version heading. Ideally the script becomes a shared action consumers reference.
2. `skills/eval-curation/SKILL.md` says "note the removal … under Unreleased" — needs a model-agnostic tweak (left out here to keep this PR off the skill-review gate).

## Test plan
- [x] Rule edit is prose; no code/tests. `context-writing-style` checked (atomic bullets, constraint wording, ~9 lines).
- [ ] coding-policy's paired policy reviewers run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)