### PR TITLE
docs(testing-standards): add platform-bound untestable carve-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **testing-standards — Platform-Bound Untestable Carve-Out for code CI cannot host (#116)** — `## Coverage` stated flatly "every module gets tests — no untested code ships" with no escape hatch for code that inherently cannot run on a CI runner. Live case: `jbaruch/speaker-toolkit` PR #54 (merged as 0.18.9) added a deck-editing path implemented as VBA macros driven via AppleScript against Microsoft PowerPoint — it needs the PowerPoint desktop app plus macOS Automation consent, neither available in Linux CI, and the policy reviewer correctly flagged it as "a testing exemption testing-standards does not grant," so it merged only via owner override. Added a narrow carve-out following the repo's established carve-out format (compact "Narrow exception for X" lead, an "Applies when" qualifier, numbered preconditions, a reset line) and mold (error-handling outer-boundary, dependency-management runtime-managed-manifest): the unhostable layer is exempt only when (1) the deterministic CI-runnable pieces are extracted and unit-tested, (2) a manual validation procedure is documented, and (3) the consuming plugin's authority-of-record rule names the carve-out, each exempt artifact, and where its validation lives. An anti-pattern bullet keeps "hard to install" from qualifying (that stays an install task per `rules/ci-safety.md` Install, Don't Skip), and the Coverage bullet now points at the carve-out so a reviewer quoting "no untested code ships" sees the exception. Reference impl already satisfies (1)+(2): speaker-toolkit extracted `backgrounds-manifest-to-spec.py` (unit-tested) out of `apply-backgrounds.sh`, and `rules/deck-editing-rules.md` documents the manual PowerPoint+Keynote validation.
+
 ## 0.3.61 — 2026-06-08
 
 ### Rules

--- a/rules/testing-standards.md
+++ b/rules/testing-standards.md
@@ -6,8 +6,19 @@ alwaysApply: true
 
 ## Coverage
 
-- Every module gets tests — no untested code ships
+- Every module gets tests — no untested code ships (narrow exception: Platform-Bound Untestable Carve-Out below)
 - Test file naming follows the project's convention (e.g., `test_*.py`, `*.test.ts`, `*_test.go`)
+
+## Platform-Bound Untestable Carve-Out
+
+- Narrow exception for code that cannot execute on the project's CI runners
+- Applies when the code drives an external desktop app, OS-level automation, or a proprietary runtime the runners cannot host (VBA macros driven via AppleScript against Microsoft PowerPoint, GUI automation gated on OS consent)
+- Preconditions (all required):
+  1. The deterministic, CI-runnable pieces are extracted and unit-tested — parsing, normalization, and data-shaping helpers split out of the automation wrapper. Only the genuinely-unhostable layer is exempt
+  2. A manual validation procedure for the exempt layer is documented — what to run, what to observe, what counts as a pass
+  3. The consuming plugin's authority-of-record rule names this carve-out, each exempt artifact, and where its validation procedure lives
+- "Hard to install in CI" does NOT qualify — install the tool and test it per `rules/ci-safety.md` Install, Don't Skip
+- Every other module still ships tests that run in CI
 
 ## Assertions
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary

- Adds a `## Platform-Bound Untestable Carve-Out` section to `rules/testing-standards.md` for code that inherently cannot execute on a CI runner (drives an external desktop app, OS-level automation, or a proprietary runtime absent from CI).
- Gates it behind three preconditions: CI-runnable pieces extracted and unit-tested, a documented manual validation procedure, and an authority-of-record rule in the consuming plugin naming the carve-out + each exempt artifact.
- Adds an anti-pattern bullet so "hard to install in CI" does NOT qualify (cross-refs `rules/ci-safety.md` Install, Don't Skip).
- Points the Coverage bullet at the carve-out so a reviewer quoting "no untested code ships" sees the exception.

## Why

`testing-standards` stated "no untested code ships" flat, with no sanctioned way to express "this layer is validated manually because CI can't host it." Concrete case: `jbaruch/speaker-toolkit` PR #54 (VBA macros driven via AppleScript against PowerPoint) needs the desktop app + macOS Automation consent — impossible in Linux CI — and merged only via owner override. The carve-out follows the repo's existing precondition-gated mold (error-handling outer-boundary, dependency-management runtime-managed-manifest).

Closes #116

## Test plan

- [ ] Policy reviewers pass
- [ ] CI green