### PR TITLE
feat(ci): provide reusable stamp-changelog action (closes #134)

### DIFF
--- a/.github/actions/stamp-changelog/action.yml
+++ b/.github/actions/stamp-changelog/action.yml
@@ -51,7 +51,9 @@ inputs:
     required: false
     default: 'true'
   commit-message:
-    description: 'Commit message for the stamp commit'
+    description: |
+      Commit message for the stamp commit. `[skip ci]` is appended if absent
+      — loop-prevention requires it, so it cannot be overridden away.
     required: false
     default: 'Stamp CHANGELOG for the published version [skip ci]'
 
@@ -80,8 +82,8 @@ runs:
           exit 1
         fi
 
-        # Build args without `&&` chaining: under `set -e` a false `[ -n ]`
-        # test would abort the step before the script ever runs.
+        # Append optional flags with explicit `if` blocks — clearer than
+        # `&&` one-liners and unambiguous to read.
         args=(--changelog "$CHANGELOG")
         if [ -n "$MANIFEST" ]; then args+=(--manifest "$MANIFEST"); fi
         if [ -n "$LATEST" ]; then args+=(--latest "$LATEST"); fi
@@ -94,7 +96,16 @@ runs:
           exit 0
         fi
 
+        # Loop-prevention is non-negotiable: the stamp commit MUST carry
+        # `[skip ci]` or it re-triggers the publish workflow. Enforce it even
+        # when a caller overrode `commit-message` without it.
+        msg="$COMMIT_MESSAGE"
+        case "$msg" in
+          *"[skip ci]"*) ;;
+          *) msg="$msg [skip ci]" ;;
+        esac
+
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add "$CHANGELOG"
-        git diff --cached --quiet || git commit -m "$COMMIT_MESSAGE"
+        git diff --cached --quiet || git commit -m "$msg"

--- a/.github/actions/stamp-changelog/action.yml
+++ b/.github/actions/stamp-changelog/action.yml
@@ -1,0 +1,100 @@
+name: 'Stamp CHANGELOG with the published version'
+description: |
+  Stamps the CHANGELOG's newest (un-headed) entries with the version the
+  publish step is about to assign, then commits the result with `[skip ci]`
+  (no push — the publish step's own commit carries it along).
+
+  For publish-on-merge repos per `jbaruch/coding-policy: context-artifacts`
+  "CHANGELOG Hygiene": PR authors add un-headed `### ` entry blocks at the
+  top of `CHANGELOG.md`; this step inserts the `## <version> — <date>`
+  heading above them before publish, so the published artifact and the
+  registry "what's new" show them under their real version instead of
+  "Unreleased". Wire it immediately before `tesslio/patch-version-publish`.
+
+  Idempotent: if the top section already carries a `## ` heading there is
+  nothing un-headed to stamp and the step is a no-op (no commit).
+
+  Requirements (consumer must arrange):
+    - `python3` on PATH (stdlib only — the script needs no packages).
+    - `tessl` CLI on PATH (typically via `tesslio/setup-tessl@v2`) so the
+      script can read the registry's latest version. Skip this by passing
+      `latest:` explicitly.
+    - The consumer repo checked out (`actions/checkout@v4`) with a writable
+      working tree; the step runs against `$GITHUB_WORKSPACE`.
+
+inputs:
+  changelog:
+    description: 'Path to the CHANGELOG, relative to the workspace root'
+    required: false
+    default: 'CHANGELOG.md'
+  manifest:
+    description: |
+      Path to the plugin manifest the version is read from. When empty the
+      script auto-detects `.tessl-plugin/plugin.json`, then `tile.json`.
+    required: false
+    default: ''
+  latest:
+    description: |
+      Latest published version (X.Y.Z) to compute against. When empty the
+      script queries the registry via `tessl plugin info`. Set it to skip
+      the registry query (testing / offline runs).
+    required: false
+    default: ''
+  date:
+    description: 'Heading date (YYYY-MM-DD). When empty, today in UTC.'
+    required: false
+    default: ''
+  commit:
+    description: |
+      When 'true' (default), commit the stamped CHANGELOG with `[skip ci]`
+      and no push. Set 'false' to leave it staged for the caller to commit.
+    required: false
+    default: 'true'
+  commit-message:
+    description: 'Commit message for the stamp commit'
+    required: false
+    default: 'Stamp CHANGELOG for the published version [skip ci]'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Stamp CHANGELOG and commit
+      shell: bash
+      env:
+        CHANGELOG: ${{ inputs.changelog }}
+        MANIFEST: ${{ inputs.manifest }}
+        LATEST: ${{ inputs.latest }}
+        DATE: ${{ inputs.date }}
+        DO_COMMIT: ${{ inputs.commit }}
+        COMMIT_MESSAGE: ${{ inputs.commit-message }}
+      run: |
+        set -eo pipefail
+
+        # The script is the single source of truth; it lives in the plugin
+        # tree, not this action dir. `uses: <owner>/coding-policy/.github/
+        # actions/stamp-changelog@<ref>` checks out the whole repo, so it
+        # resolves three levels up from the action path.
+        script="$GITHUB_ACTION_PATH/../../../skills/release/stamp-changelog.py"
+        if [ ! -f "$script" ]; then
+          echo "::error::stamp-changelog.py not found at $script — the coding-policy action repo did not check out fully."
+          exit 1
+        fi
+
+        # Build args without `&&` chaining: under `set -e` a false `[ -n ]`
+        # test would abort the step before the script ever runs.
+        args=(--changelog "$CHANGELOG")
+        if [ -n "$MANIFEST" ]; then args+=(--manifest "$MANIFEST"); fi
+        if [ -n "$LATEST" ]; then args+=(--latest "$LATEST"); fi
+        if [ -n "$DATE" ]; then args+=(--date "$DATE"); fi
+
+        python3 "$script" "${args[@]}"
+
+        if [ "$DO_COMMIT" != "true" ]; then
+          echo "commit=false — leaving the stamped CHANGELOG uncommitted."
+          exit 0
+        fi
+
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add "$CHANGELOG"
+        git diff --cached --quiet || git commit -m "$COMMIT_MESSAGE"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,20 +39,12 @@ jobs:
         with:
           threshold: '85'
 
+      # Dogfoods the reusable action consumers call as
+      # `uses: jbaruch/coding-policy/.github/actions/stamp-changelog@<ref>`.
+      # Commit only, no push — patch-version-publish's own commit/push
+      # carries it along; [skip ci] guards the re-trigger.
       - name: Stamp CHANGELOG with the version being published
-        # Publish-on-merge has no "Unreleased" bucket: PR authors add un-headed
-        # `### ` entries at the top of CHANGELOG.md. This stamps them with the
-        # version patch-version-publish is about to assign (same registry-latest
-        # +1 computation), so the published artifact and registry "what's new"
-        # show them under their real version. Commit only, no push — the publish
-        # step's own commit/push carries this commit along. [skip ci] guards the
-        # bump commits from re-triggering this workflow.
-        run: |
-          python3 skills/release/stamp-changelog.py
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "Stamp CHANGELOG for the published version [skip ci]"
+        uses: ./.github/actions/stamp-changelog
 
       - uses: tesslio/patch-version-publish@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Rules
+
+- **context-artifacts — CHANGELOG Hygiene points at the reusable stamp action (#134)** — The "Publish-on-merge" sub-list now names the concrete step consumers wire — `.github/actions/stamp-changelog`, called as `uses: jbaruch/coding-policy/.github/actions/stamp-changelog@<ref>` before `tesslio/patch-version-publish` — instead of leaving "a separate step the repo wires itself" abstract. Closes the #124 follow-up asking the rule to point at the shipped automation rather than assert the bump action stamps.
+
+### Build
+
+- **Reusable `stamp-changelog` composite action (closes #134)** — Packages the CHANGELOG auto-stamp as `.github/actions/stamp-changelog/action.yml`, the consumer-facing form of the logic 0.3.59 wired only into this repo's own `publish.yml`. A publish-on-merge consumer adds one step before `tesslio/patch-version-publish` (`uses: jbaruch/coding-policy/.github/actions/stamp-changelog@<ref>`) and its un-headed `### ` entries get a `## <version> — <date>` heading at publish instead of rendering as "Unreleased" in the registry "what's new" — the exact failure `jbaruch/speaker-toolkit` had to hand-backfill for 0.18.20–0.18.26. The action wraps the existing `skills/release/stamp-changelog.py` (single source of truth — already general: auto-detects `.tessl-plugin/plugin.json` then `tile.json`, exposes `--changelog`/`--manifest`/`--latest`/`--date`) and resolves it three levels up from the action path, so no script is copied into the action dir. Inputs cover changelog/manifest/latest/date plus `commit` (default `true`) and `commit-message`; it commits with `[skip ci]` and no push per the `ci-safety` Publish-Pipeline Loop-Prevention Carve-Out, letting the publish step's own commit carry it. This repo's `publish.yml` now dogfoods it via `uses: ./.github/actions/stamp-changelog`, replacing the inline python+commit block. `.github/` is `.tesslignore`d, so the action ships from GitHub via `uses:`, not the published plugin — no `plugin.json` change.
+
 ## 0.3.62 — 2026-06-08
 
 ### Rules

--- a/rules/context-artifacts.md
+++ b/rules/context-artifacts.md
@@ -67,6 +67,7 @@ When you add, remove, or rename a rule or skill, update **all** of these:
   - No `Unreleased` section; the heading is forbidden
   - `tesslio/patch-version-publish` does NOT stamp `CHANGELOG.md` (it only bumps the manifest version and publishes)
   - Stamping a `## <version> — <date>` heading is a separate step the repo wires itself
+  - Reusable stamp step: `.github/actions/stamp-changelog` (consumers `uses: jbaruch/coding-policy/.github/actions/stamp-changelog@<ref>`, wired before `tesslio/patch-version-publish`)
   - **With a wired stamp step:** authors add un-headed `### ` entry blocks at the top of `CHANGELOG.md`
   - The stamp step writes the `## <version> — <date>` heading above those blocks before publish
   - **Without a stamp step:** authors write the `## <version> — <date>` heading manually above their entries


### PR DESCRIPTION
**Author-Model:** claude-opus-4-7

## Summary

Closes #134 — ships the consumer-facing form of the CHANGELOG auto-stamp that 0.3.59 wired only into this repo's own `publish.yml`. Consumer publish-on-merge repos couldn't adopt it turnkey (no `uses:`-able action existed, only `skill-review`), so they kept emitting an **"Unreleased"** section in the registry "what's new" — either on an old coding-policy pin (the pre-0.3.57 rule told them to drop their `## version` headings on a false auto-stamp promise) or, even up to date, because the rule put the burden on them with no tool to automate it.

- **New reusable action** `.github/actions/stamp-changelog/action.yml` (composite, mirrors `skill-review`). A consumer adds one step before `tesslio/patch-version-publish`:
  ```yaml
  - uses: jbaruch/coding-policy/.github/actions/stamp-changelog@<ref>
  ```
  Their un-headed `### ` entries get a `## <version> — <date>` heading at publish instead of "Unreleased".
- **Wraps the existing `skills/release/stamp-changelog.py`** (single source of truth — already general: auto-detects `.tessl-plugin/plugin.json` then `tile.json`, exposes `--changelog`/`--manifest`/`--latest`/`--date`). Resolved three levels up from the action path, so no script is copied into the action dir.
- Inputs: `changelog`, `manifest`, `latest`, `date`, `commit` (default `true`), `commit-message`. Commits with `[skip ci]` and no push per the `ci-safety` Publish-Pipeline Loop-Prevention Carve-Out; `[skip ci]` is enforced even if a caller overrides `commit-message` without it.
- **Dogfooded**: this repo's `publish.yml` now calls `uses: ./.github/actions/stamp-changelog`, replacing the inline python+commit block.
- **Rule pointer**: `context-artifacts.md` CHANGELOG Hygiene now names the action (the #124 follow-up that asked the rule to point at shipped automation rather than assert the bump action stamps).

`.github/` is `.tesslignore`d, so the action ships from GitHub via `uses:`, not the published plugin — no `plugin.json` change.

## Review feedback

Copilot review on the first push flagged two items, both fixed in `ec7e5a1`:
- Enforce `[skip ci]` even when a consumer overrides `commit-message` (loop-prevention is non-negotiable).
- Corrected a misleading `set -e`/`&&` comment (commands before `&&` are exempt from errexit; the `if` form is kept for clarity).

## Test plan

- [x] `python3 skills/release/tests/test_stamp_changelog.py` — 10/10 pass (script unchanged)
- [x] `action.yml` + `publish.yml` validate as YAML
- [x] Dry-run via the action's exact path resolution stamps this PR's un-headed entries as `## 0.3.63 — <date>`, leaving `## 0.3.62` below
- [x] `[skip ci]` enforcement verified (appends only when absent)
- [x] `tessl plugin lint` passes
- [ ] On merge: publish.yml dogfoods the action and stamps this PR's CHANGELOG entries on its own publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)