### PR TITLE
feat(rules): add sync-before-work rule

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -13,6 +13,7 @@
   ],
   "rules": [
     "rules/commit-conventions.md",
+    "rules/sync-before-work.md",
     "rules/testing-standards.md",
     "rules/error-handling.md",
     "rules/dependency-management.md",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **sync-before-work — fetch and sync the local checkout before the first read (#141)** — New always-on rule. An agent was asked to fix two issues that referenced skills by name (`vault-ingress`, `vault-clarification`) and step number. It read the local tree, found a *monolithic* `rhetoric-knowledge-vault/SKILL.md`, mapped the issues onto it, implemented the fix, wrote tests, committed, pushed, and opened a PR — which came back `CONFLICTING`. Local `main` was ~410 commits behind `origin/main` (0.10.1 vs 0.18.x); upstream had long since refactored that one skill into six (`vault-ingress`/`vault-clarification`/`vault-profile`/…), so the file the agent edited had been *deleted upstream* and the issues' names/step-numbers matched the current structure exactly. The whole first implementation landed on a tombstone — thrown away, rebased onto real `origin/main`, redone against the actual files. Cost: a wasted implementation pass, a force-push, a rewritten PR, all avoidable by a `git fetch` at minute zero. The agent even had the clue (issues naming files absent locally) and still didn't check freshness first. The rule encodes: fetch before the first read, fast-forward/rebase/reset the default onto `origin/<default>`, branch from the fresh tip, treat "this file looks like X" as suspect when the local default is behind, and honor an explicitly-pinned older ref as the only exception. Rule body carries the directives; this entry holds the incident.
+
 ## 0.3.66 — 2026-06-11
 
 ### Rules

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Coding policy plugin for Baruch's AI agents. Language-agnostic code quality rule
 
 ## What's New
 
-- 20 rules — 13 always-on, 7 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 8 covering code quality, 8 covering plugin authoring, 1 covering author-model declaration, 1 covering concurrency, 1 covering review discipline, 1 covering external-repo action scope
+- 21 rules — 14 always-on, 7 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 9 covering code quality, 8 covering plugin authoring, 1 covering author-model declaration, 1 covering concurrency, 1 covering review discipline, 1 covering external-repo action scope
 - `release` skill — structured PR + merge workflow with Copilot review and paired-reviewer cross-family enforcement
 - `eval-authoring` skill — generate, review, and curate eval scenarios with score-driven iteration
 - `install-reviewer` skill — scaffold the paired gh-aw PR review workflows (OpenAI + Anthropic) into a consumer repo
@@ -28,6 +28,7 @@ tessl install jbaruch/coding-policy
 | Category | Rule | Summary |
 |----------|------|---------|
 | Git | [commit-conventions](rules/commit-conventions.md) | Imperative mood, one change per commit, PR hygiene |
+| Git | [sync-before-work](rules/sync-before-work.md) | Fetch and sync the local checkout to the remote default before reading, planning, or editing; branch from the fresh default |
 | Testing | [testing-standards](rules/testing-standards.md) | Outcome-based, deterministic, no binary fixtures |
 | Errors | [error-handling](rules/error-handling.md) | Specific exceptions (with outer-boundary process-contract carve-out), actionable messages, structured logging |
 | Deps | [dependency-management](rules/dependency-management.md) | Stdlib-first, pinned versions, lock files |

--- a/rules/sync-before-work.md
+++ b/rules/sync-before-work.md
@@ -1,0 +1,29 @@
+---
+alwaysApply: true
+description: Sync the local checkout with the remote default branch before reading, planning, or editing
+---
+
+# Sync Before Work
+
+## Sync Before Reading
+
+- At the start of any task that will read or modify a repo, sync the local checkout with the remote default branch
+- Run `git fetch origin` before the first read — not after the first failure
+- The default branch you start from must match what the remote currently has, not whatever the local clone was left at
+
+## Land on the Fresh Default
+
+- On the default branch: fast-forward to `origin/<default>`
+- Local default diverged or stale: rebase or reset onto `origin/<default>` before branching
+- Cut the feature branch from the synced default, never from a stale local tip
+
+## Staleness Poisons Conclusions
+
+- Local default behind `origin/<default>` by more than a trivial amount: treat every "this file looks like X" conclusion as suspect until re-derived against the fresh tree
+- An issue naming files, skills, or steps absent from the local tree is a staleness tell — fetch and re-derive before mapping the work onto what you see
+
+## Working Against a Pinned Ref
+
+- Narrow exception when the user explicitly wants a specific older ref or commit
+- Honor that ref, and state you are starting from it rather than the fresh default
+- Every other task starts from the synced remote default

--- a/rules/sync-before-work.md
+++ b/rules/sync-before-work.md
@@ -24,6 +24,8 @@ description: Sync the local checkout with the remote default branch before readi
 
 ## Working Against a Pinned Ref
 
-- Narrow exception when the user explicitly wants a specific older ref or commit
-- Honor that ref, and state you are starting from it rather than the fresh default
+- Narrow exception for starting work from a specific older ref instead of the fresh default
+- Preconditions (all required):
+  1. The user explicitly names the older ref or commit to work against
+  2. You state you are starting from that pinned ref rather than `origin/<default>`
 - Every other task starts from the synced remote default


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

Closes #141.

## What

New always-on rule `rules/sync-before-work.md`: fetch and sync the local checkout with the remote default branch *before* reading, planning, or editing — not after the first failure. Branch from the fresh default; treat stale-tree conclusions as suspect; honor an explicitly-pinned older ref as the only exception.

## Why

An agent edited a `SKILL.md` that had been **deleted upstream** — local `main` was ~410 commits behind `origin/main`, the skill had been refactored into six, and the PR came back `CONFLICTING`. The whole first implementation landed on a tombstone and was thrown away. A `git fetch` at minute zero avoids the wasted pass, the force-push, and the rewritten PR. Full incident in the CHANGELOG entry.

## Surface sync

- `rules/sync-before-work.md` — new rule (always-on, 4 sections)
- `.tessl-plugin/plugin.json` — added to `rules`
- `README.md` — rules table row (Git) + count 20→21 / always-on 13→14 / code-quality 8→9
- `CHANGELOG.md` — un-headed `### Rules` block (stamp step versions it at publish)

`tessl plugin lint` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)