### PR TITLE
fix(install-reviewer): bump gh-aw pin to latest stable v0.79.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Skills
+
+- **install-reviewer — pin gh-aw install to the latest stable (v0.79.8)** — The preflight's install and recovery commands pinned `v0.71.0`, which is the technical *floor* (where `acceptEdits` and `engine.args` landed), not a version anyone should freshly install — so every fresh setup landed on a months-old gh-aw. The install/recovery commands now pin the latest stable, and the floor (`GH_AW_MIN`) and pin (`GH_AW_PIN`) are named constants in `preflight.sh` so they can't drift apart or silently go stale again. The enforced floor is unchanged at `v0.71.0`. Also corrected now-false prose: when the skill was written, latest stable (`v0.68.3`) sat below the floor so a prerelease pin was mandatory; stable has since caught up (`v0.79.8` > `v0.71.0`), so the "unpinned install fails the version check" warning no longer holds.
+
 ## 0.3.67 — 2026-06-19
 
 ### Rules

--- a/skills/install-reviewer/SKILL.md
+++ b/skills/install-reviewer/SKILL.md
@@ -43,7 +43,7 @@ The skill runs in one of two modes determined by the user's request:
 Runs every precondition (git worktree, GitHub CLI install + auth, gh-aw extension at minimum version, plugin template, origin remote, plus mode-dependent branch state) and returns one JSON object: `{"ok": bool, "override": bool, "failures": [...], "warnings": [...]}`.
 
 - **Exit 0, empty `failures`** — every precondition passed; proceed to Step 2.
-- **Exit 1, populated `failures`** — report each failure's `reason` verbatim and stop. Every failure carries a concrete recovery command. The gh-aw extension is `github/gh-aw` (lives under the `github` org, not the plugin owner) and must be v0.71.0+. Install with `gh extension install github/gh-aw --pin v0.71.0` — the unpinned form would land on the latest *stable* release (currently below v0.71.0; everything from v0.69.0 onward is marked prerelease) and fail the version check.
+- **Exit 1, populated `failures`** — report each failure's `reason` verbatim and stop. Every failure carries a concrete recovery command. The gh-aw extension is `github/gh-aw` (lives under the `github` org, not the plugin owner) and must be v0.71.0+. Install with `gh extension install github/gh-aw --pin v0.79.8` — pinning the current latest *stable* keeps installs reproducible. (The unpinned form tracks whatever stable is current; stable now sits above the v0.71.0 floor and passes the version check — that wasn't always true, which is why the pin exists.)
 - **Non-empty `warnings`** — informational only; never affects `ok` or the exit code. Report each `reason` verbatim alongside the Step 1 outcome and remember them for Step 7's PR body. Do not stop; proceed to Step 2.
 
 ## Step 2 — Refuse Overwrite (install mode only)

--- a/skills/install-reviewer/SKILL.md
+++ b/skills/install-reviewer/SKILL.md
@@ -43,7 +43,7 @@ The skill runs in one of two modes determined by the user's request:
 Runs every precondition (git worktree, GitHub CLI install + auth, gh-aw extension at minimum version, plugin template, origin remote, plus mode-dependent branch state) and returns one JSON object: `{"ok": bool, "override": bool, "failures": [...], "warnings": [...]}`.
 
 - **Exit 0, empty `failures`** — every precondition passed; proceed to Step 2.
-- **Exit 1, populated `failures`** — report each failure's `reason` verbatim and stop. Every failure carries a concrete recovery command. The gh-aw extension is `github/gh-aw` (lives under the `github` org, not the plugin owner) and must be v0.71.0+. Install with `gh extension install github/gh-aw --pin v0.79.8` — pinning the current latest *stable* keeps installs reproducible. (The unpinned form tracks whatever stable is current; stable now sits above the v0.71.0 floor and passes the version check — that wasn't always true, which is why the pin exists.)
+- **Exit 1, populated `failures`** — report each failure's `reason` verbatim and stop. Every failure carries a concrete recovery command. The gh-aw extension is `github/gh-aw` (under the `github` org, not the plugin owner); its version floor and install pin are the script's policy — see `skills/install-reviewer/preflight.sh` (`GH_AW_MIN` / `GH_AW_PIN` constants at the top of the file).
 - **Non-empty `warnings`** — informational only; never affects `ok` or the exit code. Report each `reason` verbatim alongside the Step 1 outcome and remember them for Step 7's PR body. Do not stop; proceed to Step 2.
 
 ## Step 2 — Refuse Overwrite (install mode only)

--- a/skills/install-reviewer/preflight.sh
+++ b/skills/install-reviewer/preflight.sh
@@ -33,6 +33,17 @@
 
 set -euo pipefail
 
+# gh-aw version policy (enforced in check_gh_aw_min_version):
+#   GH_AW_MIN — hard floor. `acceptEdits` (replaced bypassPermissions) and
+#               `engine.args` both require >= 0.71.0; older compiles produce
+#               lock files current Claude SDK versions reject.
+#   GH_AW_PIN — version the install/recovery commands pin to, for
+#               reproducibility. Tracks the latest gh-aw stable release,
+#               which now sits above the floor (stable used to lag below it,
+#               which is why a prerelease pin was once required).
+GH_AW_MIN="0.71.0"
+GH_AW_PIN="0.79.8"
+
 OVERRIDE_MODE=0
 for arg in "$@"; do
   case "$arg" in
@@ -119,31 +130,28 @@ check_gh_authenticated() {
 
 check_gh_aw_installed() {
   gh aw --version >/dev/null 2>&1 || \
-    push_failure "gh-aw-installed" "gh-aw extension missing — run 'gh extension install github/gh-aw'"
+    push_failure "gh-aw-installed" "gh-aw extension missing — run 'gh extension install github/gh-aw --pin v${GH_AW_PIN}'"
 }
 
-# v0.71.0 replaced the deprecated `bypassPermissions` Claude SDK flag with
-# `acceptEdits`. Older gh-aw compiles lock files that current Claude SDK
-# versions reject, so refuse to scaffold against < v0.71.0. github/gh-aw
-# marks releases >= v0.69.0 as prerelease, so `gh extension install
-# github/gh-aw` installs the latest stable (v0.68.3) by default — the
-# recovery command pins explicitly to a known-good prerelease.
+# Floor and pin are defined at the top of the script (GH_AW_MIN / GH_AW_PIN).
+# We enforce a >= GH_AW_MIN floor but tell users to install GH_AW_PIN (the
+# latest stable), which clears the floor and keeps installs reproducible.
 check_gh_aw_min_version() {
   local raw min major minor patch min_major min_minor min_patch
   # `gh aw --version` writes to stderr (typical gh-extension idiom), so merge
   # streams before parsing rather than discarding stderr.
   raw=$(gh aw --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1) || true
   if [[ -z "$raw" ]]; then
-    push_failure "gh-aw-min-version" "Could not parse 'gh aw --version' output — re-install with 'gh extension remove gh-aw && gh extension install github/gh-aw --pin v0.71.0'"
+    push_failure "gh-aw-min-version" "Could not parse 'gh aw --version' output — re-install with 'gh extension remove gh-aw && gh extension install github/gh-aw --pin v${GH_AW_PIN}'"
     return
   fi
   IFS='.' read -r major minor patch <<<"$raw"
-  min="0.71.0"
+  min="$GH_AW_MIN"
   IFS='.' read -r min_major min_minor min_patch <<<"$min"
   if (( major < min_major )) \
      || (( major == min_major && minor < min_minor )) \
      || (( major == min_major && minor == min_minor && patch < min_patch )); then
-    push_failure "gh-aw-min-version" "gh-aw v${raw} is too old (need >= v${min} for the Claude SDK 'acceptEdits' flag) — run 'gh extension remove gh-aw && gh extension install github/gh-aw --pin v${min}'"
+    push_failure "gh-aw-min-version" "gh-aw v${raw} is too old (need >= v${min} for the Claude SDK 'acceptEdits' flag) — run 'gh extension remove gh-aw && gh extension install github/gh-aw --pin v${GH_AW_PIN}'"
   fi
 }
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## What
The install-reviewer preflight told users to install gh-aw **v0.71.0** — but that's the technical *floor* (where `acceptEdits` and `engine.args` landed), not a version anyone should freshly install. Every fresh setup landed on a months-old gh-aw.

## Changes
- Install/recovery commands now pin the **latest stable, v0.79.8** (`preflight.sh` + `SKILL.md`).
- Extracted `GH_AW_MIN` (floor) and `GH_AW_PIN` (install target) as named constants at the top of `preflight.sh`, so the two numbers can't drift apart or silently go stale again.
- **Enforced floor unchanged at v0.71.0** — only the pin moved (per the scope decision: update the pin, not the floor).
- Corrected now-false prose: when the skill was written, latest stable (v0.68.3) sat *below* the floor, so a prerelease pin was mandatory. Stable has since caught up (v0.79.8 > v0.71.0), so the "unpinned install fails the version check" warning no longer holds.

## Not changed
- `review-anthropic.md`'s `>= v0.71.0` note is a floor reference (accurate) — left as-is.
- No test/eval asserts on the old pin string, so nothing to update there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNuuu4xXKpFwkHwzDWen1D