### PR TITLE
docs(rules): ban time-dependent tests; ship as 0.3.75

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/coding-policy",
-  "version": "0.3.74",
+  "version": "0.3.75",
   "description": "General-purpose coding policy for Baruch's AI agents",
   "private": false,
   "skills": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.75 — 2026-06-28
+
+### Rules
+
+- **`rules/testing-standards.md` Determinism — ban tests that depend on the current date or wall-clock time** — Surfaced by `fifty-tabs-of-fares`, which had many tests hardcoding "today" or a future date into assertions and fixtures; they passed when written and started failing as the wall clock crossed the baked-in date. This is the temporal sibling of the existing no-self-generated-random-data ban — both leak non-determinism into tests. New bullets: no `today`/runtime `now()`/hardcoded future dates; control the clock by injecting or freezing "now" (passed-in reference date, mocked time source, freezegun); compute relative dates from a fixed injected reference; fixed past dates as fixtures remain fine since they don't rot. Post-edit audit found this repo's own tests already compliant — `test_poll_pr_reviews.sh` uses fixed past dates as fixtures, `test_stamp_changelog.py` injects the date as a parameter rather than reading the clock.
+
+## 0.3.74 — 2026-06-27
+
 ### Build
 
 - **Publish 0.3.74 after 0.3.73's moderation failed and reserved its version** — `0.3.73`'s registry moderation errored (*"Moderation could not be completed"*), so it never became `Latest` (stuck at `0.3.72`) yet still reserved the `0.3.73` version number; a plain republish collided (`0.3.73 already exists`, since `tesslio/patch-version-publish` auto-bumps only from registry `Latest`, which the ghost defeats). `0.3.74` ships the identical rules/skills via an explicit manifest bump and a fresh publish-and-moderation run per `rules/ci-safety.md`. Full incident in PR #151.

--- a/rules/testing-standards.md
+++ b/rules/testing-standards.md
@@ -30,6 +30,10 @@ alwaysApply: true
 
 - Tests must be deterministic — no self-generated random test data
 - Provide fixed test data; never have the test generate its own inputs randomly
+- No dependence on the current date or wall-clock time — no `today`, runtime `now()`, or hardcoded future dates in assertions or fixtures
+- Control the clock: inject or freeze "now" (a passed-in reference date, a mocked time source, freezegun) so a test green today is green every day
+- Compute relative dates from a fixed injected reference, never from the real clock at run time
+- Fixed past dates as fixtures are fine — the ban is on time-relative values that rot as the run date advances
 - Flaky tests are bugs — diagnose the root cause, don't retry and hope
 
 ## Fixtures


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## What

Primary: extend `testing-standards.md` **Determinism** to ban tests depending on the current date / wall-clock time — surfaced by `fifty-tabs-of-fares`, whose tests hardcoded "today"/future dates that passed when written and rotted as the clock crossed them. The temporal sibling of the existing no-random-data ban.

New bullets: no `today`/runtime `now()`/hardcoded future dates; control the clock (inject/freeze "now"); compute relative dates from a fixed injected reference; fixed past dates as fixtures stay fine.

**Post-edit audit:** this repo's own tests already comply — `test_poll_pr_reviews.sh` uses fixed past dates as fixtures, `test_stamp_changelog.py` injects the date as a parameter.

## Release mechanics (ghost-version recovery)

Rebased onto current main, which carries the ghost-version situation from the moderation outage. Two extra changes are required to publish cleanly:

- **Explicit manifest bump → `0.3.75`.** Auto-bump is dead while the moderation-stuck `0.3.73`/`0.3.74` block registry `Latest` at `0.3.72` (`patch-version-publish` bumps from `Latest`, lands on the taken `0.3.73`). `0.3.75` is the next free number.
- **Stamp the orphaned `0.3.74` CHANGELOG heading.** The `0.3.74` publish's stamp commit never pushed — `patch-version-publish` only pushes inside its "manifest changed" block, which an explicit pre-bump skips. Manually stamped `## 0.3.74` and `## 0.3.75` here.

Goal (per maintainer): get `0.3.75` — our latest content — into the registry so that when Tessl fixes the moderation queue, the **newest** version is what clears and becomes `Latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)