### PR TITLE
fix(release): bump manifest to 0.3.74 past the ghost 0.3.73

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/coding-policy",
-  "version": "0.3.73",
+  "version": "0.3.74",
   "description": "General-purpose coding policy for Baruch's AI agents",
   "private": false,
   "skills": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Build
 
-- **Republish 0.3.73's content as 0.3.74 after a Tessl moderation infrastructure failure** — `0.3.73`'s registry moderation errored (*"Moderation could not be completed"*), not a content finding; `0.3.74` ships the identical rules/skills through a fresh publish-and-moderation run per `rules/ci-safety.md`'s safer-recovery guidance. The only change from `0.3.73` is this CHANGELOG entry. Full incident in PR #151.
+- **Publish 0.3.74 after 0.3.73's moderation failed and reserved its version** — `0.3.73`'s registry moderation errored (*"Moderation could not be completed"*), so it never became `Latest` (stuck at `0.3.72`) yet still reserved the `0.3.73` version number; a plain republish collided (`0.3.73 already exists`, since `tesslio/patch-version-publish` auto-bumps only from registry `Latest`, which the ghost defeats). `0.3.74` ships the identical rules/skills via an explicit manifest bump and a fresh publish-and-moderation run per `rules/ci-safety.md`. Full incident in PR #151.
 
 ## 0.3.73 — 2026-06-25
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## The ghost-version problem

The `0.3.74` republish (PR #151) merged but its publish run **failed**:

```
plugin.json (0.3.73) is ahead of registry (0.3.72) — publishing as-is
✘ jbaruch/coding-policy@0.3.73 already exists.
```

`0.3.73` (PR #150) *did* publish — only its **moderation** errored (*"could not be completed"*). So it never became registry `Latest` (stuck at `0.3.72`) **but it still reserved the `0.3.73` version number**. The #151 republish never bumped the manifest (it only edited the CHANGELOG), so the publish step tried to ship `0.3.73` again and collided.

`tesslio/patch-version-publish` auto-bumps only when manifest == registry `Latest`; the moderation-failed ghost defeats that assumption (manifest `0.3.73` > Latest `0.3.72`, so it tried "publish as-is" at the already-taken `0.3.73`).

## Fix

Explicit manifest bump `0.3.73 → 0.3.74` (a free number). On merge, the publish step ships `0.3.73`'s **identical rules/skills** as `0.3.74` through a fresh publish-and-moderation run — which is the original goal of the #151 republish.

Changes: `plugin.json` version + the existing republish CHANGELOG entry, corrected to describe the collision. No rules/skills changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)