### PR TITLE
docs(rules): add Freshness to dependency-management — pins need a renewal mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **`rules/dependency-management.md` — add a Freshness section: pins need a renewal mechanism** — Surfaced by a `nanoclaw` agent hitting phantom reformats: its system `ruff` (0.15.18) disagreed with CI's pinned `ruff` (0.7.4), so the formatter wanted to rewrite files it never touched. The agent correctly diagnosed version skew and matched CI via a pinned venv — but the deeper gap was that CI sat frozen on a 2024 ruff with no bump path. The Pinning rule demanded reproducibility and said nothing about freshness, so pins rot by design. The failure mode is dual: unpinned → local/CI skew (the agent's phantom diffs), pinned-and-never-bumped → frozen on stale (the 0.7.4 trap); the rule only encoded the first half. New section: every pinned dependency needs a stated renewal mechanism — automated via Dependabot/Renovate where a scanner supports the ecosystem, or a documented cadence beside pins no scanner tracks (a version baked into a script or action step); a version bump is its own focused change, formatter/linter bumps especially per `rules/code-formatting.md` Separation of Concerns. Surface-synced: README rules table. Post-edit audit found this repo itself non-compliant — no renewal mechanism for its own pins (the `shellcheck`/`pyright` tool pins in `setup-diagnostics`, the workflow `uses:` tags, around the gh-aw generated lock files); establishing one needs design, tracked in #155.
+
 ## 0.3.76 — 2026-06-29
 
 ### Build

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ tessl install jbaruch/coding-policy
 | Git | [sync-before-work](rules/sync-before-work.md) | Fetch and sync the local checkout to the remote default before reading, planning, or editing; branch from the fresh default |
 | Testing | [testing-standards](rules/testing-standards.md) | Outcome-based, deterministic, no binary fixtures |
 | Errors | [error-handling](rules/error-handling.md) | Specific exceptions (with outer-boundary process-contract carve-out), actionable messages, structured logging |
-| Deps | [dependency-management](rules/dependency-management.md) | Stdlib-first, pinned versions, lock files |
+| Deps | [dependency-management](rules/dependency-management.md) | Stdlib-first, pinned versions kept fresh via a renewal mechanism, lock files |
 | Files | [file-hygiene](rules/file-hygiene.md) | Proper .gitignore, no generated files committed |
 | CI | [ci-safety](rules/ci-safety.md) | Never skip tests, never modify CI without asking |
 | Secrets | [no-secrets](rules/no-secrets.md) | No credentials in code, env vars or secrets manager |

--- a/rules/dependency-management.md
+++ b/rules/dependency-management.md
@@ -19,6 +19,15 @@ alwaysApply: true
 - Pin versions or use a lock file to ensure reproducible builds
 - Lock files are committed to the repo
 
+## Freshness
+
+- Every pinned dependency needs a stated renewal mechanism
+- Automate it where a scanner supports the ecosystem: a committed Dependabot or Renovate config
+- Where no scanner tracks the pin — a version baked into a script or action step — document the renewal cadence beside the pin
+- A version bump is its own focused change, never bundled with feature work
+- Formatter and linter bumps especially (see `rules/code-formatting.md` Separation of Concerns)
+- Match a stale pin locally to ship the current task; bump it in a separate change
+
 ## Runtime-Managed Manifest Carve-Out
 
 - Narrow exception for runtime-managed manifests


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

Adds a **Freshness** section to `rules/dependency-management.md`. The Pinning section optimized 100% for reproducibility and said nothing about keeping pins current — so pins rot by design, exactly the failure a `nanoclaw` agent hit this week (system `ruff` 0.15.18 vs CI-pinned `ruff` 0.7.4, phantom reformats on untouched files). The failure mode is dual: unpinned → local/CI skew, pinned-and-never-bumped → frozen on stale. The rule only encoded the first half.

## The rule

- Every pinned dependency needs a stated renewal mechanism
- Automate it where a scanner supports the ecosystem (Dependabot/Renovate config); document the cadence beside pins no scanner tracks
- A version bump is its own focused change, never bundled with feature work — formatter/linter bumps especially (`code-formatting.md` Separation of Concerns)
- Match a stale pin locally to ship the task; bump it in a separate change

## Surface sync + audit

- README rules table row updated.
- **Post-edit audit:** this repo itself has no renewal mechanism, so it's now in drift against its own rule. Establishing one needs design (Dependabot scoped around the gh-aw generated `*.lock.yml`; a mechanism for the `shellcheck`/`pyright` tool pins no scanner tracks). Per `context-artifacts.md` Post-Edit Rule Audit's escape hatch, tracked as a follow-up in **#155** rather than bundled here.

## Verification

- `tessl plugin lint` → valid
- Markdown-only change; no `shellcheck`/`pyright`/test surface touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
