### PR TITLE
fix(install-reviewer): fail-open gate on Tessl outage + template/scaffold fixes (#163)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Build
+
+- **install-reviewer gate: fail-open on a Tessl outage, + template/scaffold accuracy fixes (#163)** — Surfaced by the Codex cross-family reviewer on a real consumer upgrade (`jbaruch/nanoclaw#709`). (1) The consumer gate's `tessl install` step had no `continue-on-error`, and the `agent` job has no `always()`/`!cancelled()` guard against a failed `gate`, so a transient registry/auth outage failed the gate *job* → the agent was cascade-skipped via `needs: gate` → the review was silently dropped. The `decide` step's fail-open only covered gate-*script* errors, not the preceding install. Fixed by marking the `tesslio/setup-tessl` and `tessl install` steps `continue-on-error: true` — on an outage the plugin is simply absent, so `decide` can't find the gate script and defaults `should_skip=false` (agent runs). Fail-open end-to-end. (2) Reworded the consumer template header from "public, version-pinned plugin" to "latest published plugin" — the install is `tessl install --yes` (unpinned). (3) `scaffold.sh` now appends missing reviewer secrets to `.env.example` as a labeled, contextual group in the header-present path too (previously bare `KEY=` at EOF); regression test covers it. (4) Fork-PR secret validation: investigated — gh-aw blocks forks by default at the `agent` job and non-member fork PRs skip cleanly via the `pre_activation` membership gate; only a team-member's fork PR hits `activation`'s secret-validation, an upstream gh-aw behavior (fork-guard sits on `agent`, not `activation` since v0.81.6) not fixable in-plugin without hand-editing a generated lock. Documented, not worked around.
+
 ## 0.3.81 — 2026-07-01
 
 ### Build

--- a/skills/install-reviewer/review-anthropic.md
+++ b/skills/install-reviewer/review-anthropic.md
@@ -21,8 +21,8 @@ description: |
   published policy files — to the review model (Anthropic here; OpenAI in
   the paired workflow), the same provider whose model renders the verdict.
   Repository secrets, tokens, and credentials are never included in that
-  payload. The `tessl install jbaruch/coding-policy` pre-step fetches a
-  public, version-pinned plugin from the official Tessl registry — a known
+  payload. The `tessl install jbaruch/coding-policy` pre-step fetches the
+  latest published plugin from the official Tessl registry — a known
   published ruleset, not arbitrary remote code.
 
   Required repository secrets (set at
@@ -78,11 +78,18 @@ jobs:
     outputs:
       should_skip: ${{ steps.decide.outputs.should_skip }}
     steps:
+      # continue-on-error keeps a Tessl setup/registry outage from FAILING
+      # the gate job — a failed gate job cascade-skips the agent (needs:
+      # gate) and silently drops the review. On failure the plugin is
+      # simply absent, so `decide` below can't find the gate script and
+      # defaults should_skip=false (agent runs). Fail-open end-to-end.
       - name: Install Tessl CLI
         uses: tesslio/setup-tessl@v2
+        continue-on-error: true
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Install jbaruch/coding-policy (latest published)
+        continue-on-error: true
         run: |
           mkdir -p /tmp/gh-aw/coding-policy
           cd /tmp/gh-aw/coding-policy
@@ -94,8 +101,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         # Fails OPEN: a failed gate job would cascade-skip the agent and
         # silently drop the review, so any trouble here defaults
-        # should_skip=false and lets the agent run. Explicit `if` checks
-        # (never silent suppression) keep the step's own exit at 0.
+        # should_skip=false and lets the agent run. The setup/install steps
+        # above are continue-on-error, so a Tessl outage lands here as a
+        # missing gate script → the `if` below fails → should_skip=false.
+        # Explicit `if` checks (never silent suppression) keep exit at 0.
         run: |
           set -uo pipefail
           GATE=/tmp/gh-aw/coding-policy/.tessl/plugins/jbaruch/coding-policy/skills/install-reviewer/author-family-gate.sh

--- a/skills/install-reviewer/review-openai.md
+++ b/skills/install-reviewer/review-openai.md
@@ -21,8 +21,8 @@ description: |
   published policy files — to the review model (OpenAI here; Anthropic in
   the paired workflow), the same provider whose model renders the verdict.
   Repository secrets, tokens, and credentials are never included in that
-  payload. The `tessl install jbaruch/coding-policy` pre-step fetches a
-  public, version-pinned plugin from the official Tessl registry — a known
+  payload. The `tessl install jbaruch/coding-policy` pre-step fetches the
+  latest published plugin from the official Tessl registry — a known
   published ruleset, not arbitrary remote code.
 
   Required repository secrets (set at
@@ -72,11 +72,18 @@ jobs:
     outputs:
       should_skip: ${{ steps.decide.outputs.should_skip }}
     steps:
+      # continue-on-error keeps a Tessl setup/registry outage from FAILING
+      # the gate job — a failed gate job cascade-skips the agent (needs:
+      # gate) and silently drops the review. On failure the plugin is
+      # simply absent, so `decide` below can't find the gate script and
+      # defaults should_skip=false (agent runs). Fail-open end-to-end.
       - name: Install Tessl CLI
         uses: tesslio/setup-tessl@v2
+        continue-on-error: true
         with:
           token: ${{ secrets.TESSL_TOKEN }}
       - name: Install jbaruch/coding-policy (latest published)
+        continue-on-error: true
         run: |
           mkdir -p /tmp/gh-aw/coding-policy
           cd /tmp/gh-aw/coding-policy
@@ -88,8 +95,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         # Fails OPEN: a failed gate job would cascade-skip the agent and
         # silently drop the review, so any trouble here defaults
-        # should_skip=false and lets the agent run. Explicit `if` checks
-        # (never silent suppression) keep the step's own exit at 0.
+        # should_skip=false and lets the agent run. The setup/install steps
+        # above are continue-on-error, so a Tessl outage lands here as a
+        # missing gate script → the `if` below fails → should_skip=false.
+        # Explicit `if` checks (never silent suppression) keep exit at 0.
         run: |
           set -uo pipefail
           GATE=/tmp/gh-aw/coding-policy/.tessl/plugins/jbaruch/coding-policy/skills/install-reviewer/author-family-gate.sh

--- a/skills/install-reviewer/scaffold.sh
+++ b/skills/install-reviewer/scaffold.sh
@@ -181,14 +181,23 @@ ensure_env_example() {
     cat "$tmp" > "$target"
     rm -f "$tmp"
   else
-    # Link already in the header — only the KEY= lines are missing.
-    # Append them; the header requirement is already satisfied.
+    # Link already in the header — the header block (with its context) is
+    # at the top, but one or more KEY= lines are missing. Append them as a
+    # labeled, contextual group rather than bare KEY= lines at EOF, so the
+    # reviewer secrets stay grouped-with-context whether or not the header
+    # block pre-existed (issue #163). Idempotent: once appended the keys
+    # are present, so the early-return guard skips this block on re-runs.
     if [[ -f "$target" && -s "$target" && -n "$(tail -c 1 "$target")" ]]; then
       printf '\n' >> "$target"
     fi
-    for k in "${missing[@]}"; do
-      printf '%s=\n' "$k" >> "$target"
-    done
+    {
+      printf '\n# CI reviewer secret(s) for the jbaruch/coding-policy gh-aw PR review\n'
+      printf '# workflows — set as GitHub Actions repository secrets (see the secrets\n'
+      printf '# link in the header above).\n'
+      for k in "${missing[@]}"; do
+        printf '%s=\n' "$k"
+      done
+    } >> "$target"
   fi
 
   # Normalize EOF to a single trailing newline — the prepended consumer

--- a/skills/install-reviewer/tests/test_scaffold_env_example.sh
+++ b/skills/install-reviewer/tests/test_scaffold_env_example.sh
@@ -274,6 +274,47 @@ test_env_idempotency() {
 }
 run "ensure_env_example: idempotent across invocations" test_env_idempotency
 
+# --- ensure_env_example: header present, a secret MISSING → contextual group -
+# Regression for issue #163: when THIS repo's header link already exists
+# but a reviewer secret is missing, the missing key must be appended as a
+# labeled, contextual group — not a bare KEY= at EOF with no CI context.
+test_env_header_present_missing_secret_grouped() {
+  local f="$TMPDIR_TEST/header-missing-secret.env"
+  {
+    printf '#   https://github.com/%s/settings/secrets/actions\n' "$SLUG"
+    printf 'ANTHROPIC_API_KEY=\nOPENAI_API_KEY=\nTESSL_TOKEN=\n'
+    printf 'DATABASE_URL=postgres://localhost/app\n'
+  } > "$f"
+  assert_eq "precondition: CODEX_API_KEY absent" "0" "$(key_count "$f" CODEX_API_KEY)" || return 1
+  assert_eq "precondition: this-repo header link present" "1" \
+    "$(grep -cF "github.com/${SLUG}/settings/secrets/actions" "$f")" || return 1
+  ensure_env_example "$f" "$SLUG" || return 1
+  # The missing key is appended exactly once.
+  assert_eq "CODEX_API_KEY appended once" "1" "$(key_count "$f" CODEX_API_KEY)" || return 1
+  # ... preceded by a CI-reviewer context comment (grouped, not bare at EOF).
+  local ctx_line codex_line
+  ctx_line=$(grep -nF 'CI reviewer secret' "$f" | tail -1 | cut -d: -f1)
+  codex_line=$(grep -nE '^CODEX_API_KEY=' "$f" | tail -1 | cut -d: -f1)
+  [[ -n "$ctx_line" ]] || { echo "    FAIL: appended CODEX_API_KEY has no CI-reviewer context comment" >&2; return 1; }
+  [[ "$ctx_line" -lt "$codex_line" ]] || { echo "    FAIL: context comment (line $ctx_line) not above appended key (line $codex_line)" >&2; return 1; }
+  # Consumer content and the other secrets are untouched (each present once).
+  grep -qxF 'DATABASE_URL=postgres://localhost/app' "$f" || { echo "    FAIL: consumer var clobbered" >&2; return 1; }
+  local k
+  for k in ANTHROPIC_API_KEY OPENAI_API_KEY TESSL_TOKEN; do
+    assert_eq "key ${k} count (unchanged)" "1" "$(key_count "$f" "$k")" || return 1
+  done
+  # The header link is not duplicated by the appended group.
+  assert_eq "deep-link header count" "1" "$(grep -cF 'settings/secrets/actions' "$f")" || return 1
+  assert_eq "trailing newline count" "1" "$(trailing_newline_count "$f")" || return 1
+  # Idempotent: a second run is a no-op (key now present → early return).
+  local fp_before fp_after
+  fp_before=$(content_fingerprint "$f")
+  ensure_env_example "$f" "$SLUG" || return 1
+  fp_after=$(content_fingerprint "$f")
+  assert_eq "second run no-op" "$fp_before" "$fp_after" || return 1
+}
+run "ensure_env_example: header present, missing secret appended as contextual group" test_env_header_present_missing_secret_grouped
+
 echo
 echo "results: ${PASS_COUNT} pass, ${FAIL_COUNT} fail"
 exit "$FAIL_COUNT"


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

Closes #163.

Follow-up to #161/#162, surfaced by the Codex cross-family reviewer on a real consumer upgrade (`jbaruch/nanoclaw#709`).

## 1. Gate was fail-*closed* on a Tessl outage (primary — my bug from #162)

The consumer gate's `Install Tessl CLI` + `tessl install` steps had **no `continue-on-error`**, and the `agent` job has no `always()`/`!cancelled()` guard against a failed `gate`. So a transient registry/auth outage failed the gate **job** → the agent was cascade-skipped via `needs: gate` → **the review was silently dropped**. The `decide` step's fail-open (which I added in #162) only covered gate-*script* errors, not the preceding install step. My "fail-open" claim was incomplete — the Codex reviewer correctly caught it.

**Fix:** `continue-on-error: true` on the `tesslio/setup-tessl` and `tessl install` steps. On an outage the plugin is simply absent, so `decide` can't find the gate script → its `if` fails → `should_skip=false` → the agent runs. **Fail-open end-to-end**, within gh-aw's composition (no lock hand-editing).

## 2. "version-pinned plugin" wording was inaccurate

The consumer template header said "public, **version-pinned** plugin" but the install is `tessl install --yes` (latest, unpinned). Reworded to "latest published plugin."

## 3. Fork-PR secret validation — investigated, upstream limitation

gh-aw blocks forks by default at the `agent` job, and **non-member fork PRs skip cleanly** via the `pre_activation` membership gate. Only a **team-member's fork PR** reaches `activation`'s secret-validation (which fork PRs can't satisfy — no secrets). Since v0.81.6 the fork-guard sits on `agent`, not `activation`, and the `activation` job is gh-aw-generated — **not fixable in-plugin** without hand-editing a generated lock or an upstream gh-aw change. The `forks:` frontmatter field gates fork *access* at the agent, not activation's secret step, so it doesn't address this. Documented rather than worked around; matches the issue's "low impact for repos that don't take external fork PRs" framing.

## 4. `.env.example` grouping in scaffold.sh

When THIS repo's deep-link header was already present but a reviewer secret was missing, `scaffold.sh` appended a bare `KEY=` at EOF with no CI context. Now it appends missing secrets as a **labeled, contextual group** in the header-present path too (matching the header-absent path). Idempotent via the existing early-return guard. Regression test added for the header-present-missing-secret path.

## Acceptance

- [x] Gate survives a `tessl install` failure without dropping the review — recompiled locks show `continue-on-error` on setup + install
- [x] Header wording matches actual install behavior (no "version-pinned" while using `--yes`)
- [~] Fork PR secret validation — non-member forks skip cleanly; member-fork edge is an upstream gh-aw constraint (documented)
- [x] `scaffold.sh` groups reviewer CI secrets contextually in both header paths; test covers both
- [ ] `tessl skill review --threshold 85` for `install-reviewer` — runs in CI

## Testing

- All 15 unit suites green; diagnostics (shellcheck + pyright) clean
- Consumer templates compile (`gh aw compile`, v0.81.6); `continue-on-error` present on both gate install steps
- New regression test: `ensure_env_example: header present, missing secret appended as contextual group`

## Note on scope

Only `install-reviewer` templates + `scaffold.sh` change here, so it republishes and consumers re-run `install-reviewer` in **upgrade mode** to pick up the fixed templates (e.g. `nanoclaw#709` gets re-scaffolded, not hand-patched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
