### PR TITLE
fix(install-reviewer): give consumer gate's gh pr view repo context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Build
+
+- **Consumer gate's trailer fallback was dead: `gh pr view` had no repo context** — The consumer templates' `gate` job (`skills/install-reviewer/review-{anthropic,openai}.md`) runs without `actions/checkout` (it installs the plugin instead), so its `gh pr view "$PR_NUMBER" --json commits` call had no git remote to infer the repo from and failed on **every** run — observed as a consistent `author-family gate: 'gh pr view' failed; proceeding body-only` in all `jbaruch/fifty-tabs-of-fares` gate logs (e.g. runs 28662293652, 28679850281). Fail-open meant nothing was silently unreviewed, but the #161 gate's signal 2 (the `Co-authored-by:` trailer email domain — Claude Code's default attribution) never fired in consumers: a same-family PR declaring authorship only via trailer fell through to the agent and burned the ~400K tokens the gate exists to save. Body-declared PRs were unaffected (the body arrives via the event payload, not `gh`). Fixed by adding `GH_REPO: ${{ github.repository }}` to the `decide` step's env — `gh` reads it natively, no checkout needed. The in-repo workflows (`.github/workflows/review-{anthropic,openai}.md`) were never affected: their gate job checks out the repo. Consumers pick the fix up via the install-reviewer **upgrade** action.
+
 ## 0.3.84 — 2026-07-02
 
 ### Build

--- a/skills/install-reviewer/review-anthropic.md
+++ b/skills/install-reviewer/review-anthropic.md
@@ -99,6 +99,11 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
+          # No actions/checkout in this job — without a git context `gh pr
+          # view` cannot infer the repo and fails on every run, silently
+          # reducing the gate to body-only (trailer-only PRs never skip).
+          # GH_REPO supplies the repo context explicitly.
+          GH_REPO: ${{ github.repository }}
         # Fails OPEN: a failed gate job would cascade-skip the agent and
         # silently drop the review, so any trouble here defaults
         # should_skip=false and lets the agent run. The setup/install steps

--- a/skills/install-reviewer/review-openai.md
+++ b/skills/install-reviewer/review-openai.md
@@ -93,6 +93,11 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
+          # No actions/checkout in this job — without a git context `gh pr
+          # view` cannot infer the repo and fails on every run, silently
+          # reducing the gate to body-only (trailer-only PRs never skip).
+          # GH_REPO supplies the repo context explicitly.
+          GH_REPO: ${{ github.repository }}
         # Fails OPEN: a failed gate job would cascade-skip the agent and
         # silently drop the review, so any trouble here defaults
         # should_skip=false and lets the agent run. The setup/install steps


### PR DESCRIPTION
**Author-Model:** claude-fable-5

## What

Adds `GH_REPO: ${{ github.repository }}` to the `decide` step's env in both consumer reviewer templates (`skills/install-reviewer/review-{anthropic,openai}.md`).

## Why

The consumer gate job runs without `actions/checkout` — it installs the plugin instead — so its trailer-fallback `gh pr view "$PR_NUMBER" --json commits` call has no git remote to infer the repo from and fails on **every** run. Observed as a consistent `author-family gate: 'gh pr view' failed; proceeding body-only` in all `jbaruch/fifty-tabs-of-fares` gate logs (runs 28662293652, 28679850281 — both today, both PR-body-declared so the skip still worked).

Consequence of the dead fallback: the #161 gate's signal 2 (the `Co-authored-by:` trailer email domain, Claude Code's default attribution) never fires in consumers. A same-family PR declaring authorship only via trailer falls through to the agent and burns the ~400K tokens the gate exists to save. Fail-open, so nothing goes unreviewed — the cost is tokens, not coverage.

`GH_REPO` is read natively by `gh`, needs no checkout, and keeps the gate job slim. The in-repo workflows (`.github/workflows/review-{anthropic,openai}.md`) are unaffected: their gate job checks out the repo, so `gh` resolves the remote there.

Consumers pick the fix up via the install-reviewer **upgrade** action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)