### PR TITLE
feat(release): auto-merge on green + dismiss superseded review gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Skills
+
+- **`release` skill: dismiss superseded review gates automatically** — New `skills/release/dismiss-stale-reviews.sh` clears a policy bot's `CHANGES_REQUESTED` that a later all-clear from the same bot superseded. A `github-actions[bot]` reviewer cannot `APPROVE` (HTTP 422), so a clean re-review lands as a `COMMENT` that never supersedes the earlier `CHANGES_REQUESTED` in GitHub's merge gate — the stale request kept `merge_state.status` at `BLOCKED` and had to be dismissed by hand every cycle. The script dismisses only superseded requests (leaves a bot whose latest verdict is still `CHANGES_REQUESTED` untouched) and is idempotent; Step 7 runs it before merging. Covered by `skills/release/tests/test_dismiss_stale_reviews.sh`.
+- **`release` skill: auto-open PR and auto-merge on green gates** — Steps 2 and 7 now state explicitly that PR creation and merge proceed automatically once their objective gates are green — the readiness checks and the merge conjunction are the approval; the operator no longer pauses for a human ack.
+
 ## 0.3.87 — 2026-07-03
 
 ### Rules

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -130,7 +130,7 @@ Once these conditions hold, merge automatically — the green gates are the appr
 skills/release/dismiss-stale-reviews.sh <owner> <repo> <pr-number>
 ```
 
-The script dismisses only a bot's `CHANGES_REQUESTED` that a later all-clear (`COMMENTED` or `APPROVED`) from the same bot has superseded; it leaves a bot whose latest verdict is still `CHANGES_REQUESTED` — or whose latest review is merely `DISMISSED`/`PENDING` — untouched, and re-running is a no-op (see the script's header for the decision contract and output shape). Run it after Step 5's poll shows every bot's latest verdict clean.
+Run it once Step 5's poll shows every bot's latest verdict clean. It emits a JSON summary of what it dismissed and what it left active, exits non-zero on API failure, and is idempotent on re-run. Which reviews it dismisses and which it leaves is the script's decision contract — see `skills/release/dismiss-stale-reviews.sh` header, not restated here (`rules/script-as-black-box.md`).
 
 Before merging, capture the registry baseline so the post-merge check has something to compare against:
 

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -33,6 +33,7 @@ Structured workflow for shipping code: PR creation, automated policy review, mer
 
 ## Step 2 — Create PR
 
+- Once Step 1's readiness checks pass, create the PR automatically — the green readiness checks are the gate. Do not pause to ask a human whether to open it.
 - Push the branch: `git push -u origin <branch>`
 - Create the PR with `gh pr create`:
   - **Title**: `<type>(<scope>): <imperative summary>`
@@ -120,6 +121,16 @@ Only proceed when:
 - Every inline comment from Step 5's `inline_comments` count has a `Fixed in <sha>` or `Declining — <reason>` reply per Step 6 (verify by listing the PR's review comments — the poll script tracks counts, not reply state, so the operator confirms thread closure).
 
 A `COMMENTED` review never gates the merge on its state alone — but its body must be read before merge, zero inline comments included. With inline comments, it is mergeable once every thread also has a reply.
+
+Once these conditions hold, merge automatically — the green gates are the approval. Do not pause to ask a human whether to merge.
+
+**Clear superseded review gates first.** A policy bot cannot `APPROVE` (`github-actions[bot]` gets HTTP 422), so a clean re-review lands as a `COMMENT` that does NOT supersede the bot's earlier `CHANGES_REQUESTED` in GitHub's merge gate — the stale request keeps `merge_state.status` at `BLOCKED`. Dismiss every such superseded review before merging:
+
+```bash
+skills/release/dismiss-stale-reviews.sh <owner> <repo> <pr-number>
+```
+
+The script dismisses only a bot's `CHANGES_REQUESTED` that a later non-`CHANGES_REQUESTED` verdict from the same bot has superseded; it leaves a bot whose latest verdict is still `CHANGES_REQUESTED` untouched, and re-running is a no-op (see the script's header for the decision contract and output shape). Run it after Step 5's poll shows every bot's latest verdict clean.
 
 Before merging, capture the registry baseline so the post-merge check has something to compare against:
 

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -130,7 +130,7 @@ Once these conditions hold, merge automatically — the green gates are the appr
 skills/release/dismiss-stale-reviews.sh <owner> <repo> <pr-number>
 ```
 
-The script dismisses only a bot's `CHANGES_REQUESTED` that a later non-`CHANGES_REQUESTED` verdict from the same bot has superseded; it leaves a bot whose latest verdict is still `CHANGES_REQUESTED` untouched, and re-running is a no-op (see the script's header for the decision contract and output shape). Run it after Step 5's poll shows every bot's latest verdict clean.
+The script dismisses only a bot's `CHANGES_REQUESTED` that a later all-clear (`COMMENTED` or `APPROVED`) from the same bot has superseded; it leaves a bot whose latest verdict is still `CHANGES_REQUESTED` — or whose latest review is merely `DISMISSED`/`PENDING` — untouched, and re-running is a no-op (see the script's header for the decision contract and output shape). Run it after Step 5's poll shows every bot's latest verdict clean.
 
 Before merging, capture the registry baseline so the post-merge check has something to compare against:
 

--- a/skills/release/dismiss-stale-reviews.sh
+++ b/skills/release/dismiss-stale-reviews.sh
@@ -14,10 +14,13 @@
 # judgment (rules/script-delegation.md).
 #
 # Decision, per gating bot (see GATING_BOTS below):
-#   - latest review state == CHANGES_REQUESTED  => leave it; the bot is
+#   - latest review state == CHANGES_REQUESTED => leave it; the bot is
 #     currently requesting changes, nothing to dismiss.
-#   - latest review state is anything else (COMMENTED/APPROVED) => dismiss
-#     every EARLIER review from that bot still in CHANGES_REQUESTED.
+#   - latest review state == COMMENTED or APPROVED (a fresh all-clear) =>
+#     dismiss every EARLIER review from that bot still in CHANGES_REQUESTED.
+#   - any other latest state (DISMISSED, PENDING) => no-op; a dismissed or
+#     pending latest review is NOT an all-clear, so an earlier active
+#     CHANGES_REQUESTED that no all-clear superseded must stay put.
 # Reviews already in DISMISSED state are skipped, so re-running is a no-op
 # (idempotent per rules/file-hygiene.md).
 #
@@ -94,7 +97,15 @@ main() {
       continue
     fi
 
-    # Latest is COMMENTED/APPROVED — dismiss every EARLIER review still in
+    # Dismissal requires a fresh all-clear from the same bot. Only COMMENTED
+    # (a bot cannot APPROVE — HTTP 422) or APPROVED counts. A latest state
+    # of DISMISSED or PENDING is NOT an all-clear, so an earlier active
+    # CHANGES_REQUESTED that no all-clear superseded must stay put.
+    if [[ "$latest_state" != "COMMENTED" && "$latest_state" != "APPROVED" ]]; then
+      continue
+    fi
+
+    # Latest is an all-clear — dismiss every EARLIER review still in
     # CHANGES_REQUESTED (already-DISMISSED ones are excluded, so re-runs
     # are no-ops).
     stale=$(jq -c '.[:-1][] | select(.state == "CHANGES_REQUESTED")' <<<"$reviews")

--- a/skills/release/dismiss-stale-reviews.sh
+++ b/skills/release/dismiss-stale-reviews.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Dismiss a gating bot's CHANGES_REQUESTED review once the SAME bot has
+# posted a later non-CHANGES_REQUESTED verdict on the PR.
+#
+# Why this exists: the policy reviewers run as `github-actions[bot]`, which
+# GitHub rejects `APPROVE` from with HTTP 422 (see
+# .github/workflows/review-anthropic.md Step 5). A clean re-review is
+# therefore a COMMENT ("All rules pass"), and a later COMMENT never
+# supersedes an earlier CHANGES_REQUESTED in GitHub's merge-gating model —
+# the stale CHANGES_REQUESTED keeps blocking the merge until it is
+# dismissed. The bot cannot dismiss its own review (it holds only
+# `pull-requests: read`), so the operator running the release skill does it
+# here. The decision is fully deterministic, so it is a script, not agent
+# judgment (rules/script-delegation.md).
+#
+# Decision, per gating bot (see GATING_BOTS below):
+#   - latest review state == CHANGES_REQUESTED  => leave it; the bot is
+#     currently requesting changes, nothing to dismiss.
+#   - latest review state is anything else (COMMENTED/APPROVED) => dismiss
+#     every EARLIER review from that bot still in CHANGES_REQUESTED.
+# Reviews already in DISMISSED state are skipped, so re-running is a no-op
+# (idempotent per rules/file-hygiene.md).
+#
+# Usage: dismiss-stale-reviews.sh <owner> <repo> <pr-number>
+# Out:   one JSON object on stdout:
+#   {
+#     "pr_number": N,
+#     "dismissed": [{"login": "...", "review_id": N, "commit_id": "..."}],
+#     "left_active": [{"login": "...", "review_id": N}]  // latest is still CHANGES_REQUESTED
+#   }
+# Exit:  0 on successful query (including no-op); non-zero with a stderr
+#        diagnostic on API/argument failure.
+
+set -euo pipefail
+
+# The bot logins whose CHANGES_REQUESTED reviews gate the merge — the same
+# two the release skill polls (skills/release/poll-pr-reviews.sh).
+GATING_BOTS="github-actions[bot] copilot-pull-request-reviewer[bot]"
+
+# Fixed dismissal message — a dismissal records who/why on the PR timeline.
+DISMISS_MESSAGE="Superseded by a later all-clear review from the same bot — dismissed by the release skill so the stale request stops gating the merge."
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is not installed; install with 'brew install jq' (macOS) or 'apt install jq' (Debian/Ubuntu) and re-run" >&2
+  exit 2
+fi
+
+# All reviews by one login, chronological (GitHub returns ascending by
+# submitted_at). `--paginate` is mandatory so a PR with >30 reviews doesn't
+# truncate and hide the latest verdict — same discipline as
+# poll-pr-reviews.sh.
+reviews_by() {
+  local owner="$1" repo="$2" pr="$3" login="$4"
+  gh api --paginate "repos/${owner}/${repo}/pulls/${pr}/reviews?per_page=100" \
+    | jq -s --arg login "$login" \
+        '(add // []) | [.[] | select(.user.login == $login) | {id, state, commit_id, submitted_at}]'
+}
+
+dismiss_review() {
+  local owner="$1" repo="$2" pr="$3" review_id="$4"
+  gh api -X PUT \
+    "repos/${owner}/${repo}/pulls/${pr}/reviews/${review_id}/dismissals" \
+    -f message="$DISMISS_MESSAGE" \
+    -f event="DISMISS" >/dev/null
+}
+
+main() {
+  if [[ $# -ne 3 ]]; then
+    echo "usage: $0 <owner> <repo> <pr-number>" >&2
+    exit 2
+  fi
+  local owner="$1" repo="$2" pr="$3"
+  if [[ -z "$owner" || -z "$repo" || -z "$pr" ]]; then
+    echo "error: <owner>, <repo>, and <pr-number> are all required and must be non-empty" >&2
+    exit 2
+  fi
+
+  local dismissed="[]" left_active="[]"
+  local login reviews latest_state stale
+
+  for login in $GATING_BOTS; do
+    reviews=$(reviews_by "$owner" "$repo" "$pr" "$login") \
+      || { echo "error: failed to fetch reviews for ${login} on ${owner}/${repo}#${pr} — run 'gh auth status' to verify auth, then retry" >&2; exit 1; }
+
+    # No reviews from this bot yet — nothing to do.
+    [[ "$(jq 'length' <<<"$reviews")" == "0" ]] && continue
+
+    latest_state=$(jq -r '.[-1].state' <<<"$reviews")
+
+    # The bot's current verdict is still CHANGES_REQUESTED: leave it gating.
+    if [[ "$latest_state" == "CHANGES_REQUESTED" ]]; then
+      left_active=$(jq --arg login "$login" \
+        '. + [{login: $login, review_id: '"$(jq '.[-1].id' <<<"$reviews")"'}]' <<<"$left_active")
+      continue
+    fi
+
+    # Latest is COMMENTED/APPROVED — dismiss every EARLIER review still in
+    # CHANGES_REQUESTED (already-DISMISSED ones are excluded, so re-runs
+    # are no-ops).
+    stale=$(jq -c '.[:-1][] | select(.state == "CHANGES_REQUESTED")' <<<"$reviews")
+    [[ -z "$stale" ]] && continue
+
+    local row rid cid
+    while IFS= read -r row; do
+      [[ -z "$row" ]] && continue
+      rid=$(jq -r '.id' <<<"$row")
+      cid=$(jq -r '.commit_id' <<<"$row")
+      dismiss_review "$owner" "$repo" "$pr" "$rid" \
+        || { echo "error: failed to dismiss review ${rid} by ${login} on ${owner}/${repo}#${pr}" >&2; exit 1; }
+      dismissed=$(jq --arg login "$login" --arg cid "$cid" \
+        '. + [{login: $login, review_id: '"$rid"', commit_id: $cid}]' <<<"$dismissed")
+    done <<<"$stale"
+  done
+
+  jq -n \
+    --argjson pr "$pr" \
+    --argjson dismissed "$dismissed" \
+    --argjson left_active "$left_active" \
+    '{pr_number: $pr, dismissed: $dismissed, left_active: $left_active}'
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/skills/release/dismiss-stale-reviews.sh
+++ b/skills/release/dismiss-stale-reviews.sh
@@ -37,8 +37,12 @@
 set -euo pipefail
 
 # The bot logins whose CHANGES_REQUESTED reviews gate the merge — the same
-# two the release skill polls (skills/release/poll-pr-reviews.sh).
-GATING_BOTS="github-actions[bot] copilot-pull-request-reviewer[bot]"
+# two the release skill polls (skills/release/poll-pr-reviews.sh). An array
+# iterated with quoted expansion, NOT a space-string: the `[bot]` suffix is
+# a glob bracket, so an unquoted `for login in $GATING_BOTS` would rewrite
+# the token against a matching filename in the release checkout (e.g.
+# `github-actionsb`) and silently miss the review.
+GATING_BOTS=("github-actions[bot]" "copilot-pull-request-reviewer[bot]")
 
 # Fixed dismissal message — a dismissal records who/why on the PR timeline.
 DISMISS_MESSAGE="Superseded by a later all-clear review from the same bot — dismissed by the release skill so the stale request stops gating the merge."
@@ -81,7 +85,7 @@ main() {
   local dismissed="[]" left_active="[]"
   local login reviews latest_state stale
 
-  for login in $GATING_BOTS; do
+  for login in "${GATING_BOTS[@]}"; do
     reviews=$(reviews_by "$owner" "$repo" "$pr" "$login") \
       || { echo "error: failed to fetch reviews for ${login} on ${owner}/${repo}#${pr} — run 'gh auth status' to verify auth, then retry" >&2; exit 1; }
 

--- a/skills/release/tests/test_dismiss_stale_reviews.sh
+++ b/skills/release/tests/test_dismiss_stale_reviews.sh
@@ -184,6 +184,28 @@ t_multiple_stale_crs_all_dismissed() {
   assert_eq "two dismissals"       "2"     "$(dismiss_count)"
 }
 
+# The bot logins contain `[bot]`, a glob bracket. If the loop iterated them
+# unquoted, a file in the working directory matching the pattern (e.g.
+# `github-actionsb`) would rewrite the login token via pathname expansion
+# and the review would never be found. Run from a directory seeded with
+# such a decoy file and assert the dismissal still happens.
+t_login_is_glob_safe_against_cwd_files() {
+  MOCK_REVIEWS_BODY='[
+    {"id":71,"state":"CHANGES_REQUESTED","commit_id":"aaa","submitted_at":"2026-01-01T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":72,"state":"COMMENTED","commit_id":"bbb","submitted_at":"2026-01-02T00:00:00Z","user":{"login":"github-actions[bot]"}}
+  ]'
+  local decoy_dir out ids
+  decoy_dir=$(mktemp -d)
+  # Files that `github-actions[bot]` and `copilot-...[bot]` would glob to.
+  : > "${decoy_dir}/github-actionsb"
+  : > "${decoy_dir}/copilot-pull-request-reviewero"
+  out=$(cd "$decoy_dir" && main "owner" "repo" "1") || { rm -rf "$decoy_dir"; return 1; }
+  rm -rf "$decoy_dir"
+  ids=$(jq -r '.dismissed | map(.review_id) | join(",")' <<<"$out")
+  assert_eq "dismissed despite cwd decoy files" "71" "$ids" || return 1
+  assert_eq "one dismissal" "1" "$(dismiss_count)"
+}
+
 # --- runner ---
 
 echo "test_dismiss_stale_reviews.sh"
@@ -194,6 +216,7 @@ run "per-bot independence"                      t_per_bot_independence
 run "no reviews is a no-op"                     t_no_reviews_is_noop
 run "latest DISMISSED leaves earlier active CR" t_latest_dismissed_leaves_earlier_active_cr
 run "multiple stale CRs all dismissed"          t_multiple_stale_crs_all_dismissed
+run "login is glob-safe against cwd files"      t_login_is_glob_safe_against_cwd_files
 
 echo
 echo "passed: ${PASS_COUNT}, failed: ${FAIL_COUNT}"

--- a/skills/release/tests/test_dismiss_stale_reviews.sh
+++ b/skills/release/tests/test_dismiss_stale_reviews.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Outcome-based tests for dismiss-stale-reviews.sh.
+#
+# Approach: source the script (its main() guard prevents auto-run when
+# sourced) and override `gh` with a shell function that (a) serves a
+# fixture reviews list for the GET reviews surface and (b) records every
+# dismissal PUT into $DISMISS_LOG. jq runs locally so the script's real
+# decision logic is exercised, not duplicated in the test.
+#
+# Run: bash skills/release/tests/test_dismiss_stale_reviews.sh
+# Exit 0 on all-pass; non-zero with a per-test diagnostic on failure.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/dismiss-stale-reviews.sh"
+[[ -r "$SCRIPT" ]] || { echo "fatal: dismiss-stale-reviews.sh not readable at $SCRIPT" >&2; exit 2; }
+
+# shellcheck disable=SC1090
+source "$SCRIPT" || true
+set +e
+
+FAIL_COUNT=0
+PASS_COUNT=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    return 0
+  fi
+  echo "    FAIL: ${label}: expected '${expected}', got '${actual}'" >&2
+  return 1
+}
+
+run() {
+  local name="$1"; shift
+  DISMISS_LOG="$(mktemp)"
+  export DISMISS_LOG
+  if "$@"; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  pass: $name"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "  FAIL: $name" >&2
+  fi
+  rm -f "$DISMISS_LOG"
+}
+
+# Mock `gh api` — two surfaces:
+#   GET  repos/<o>/<r>/pulls/<N>/reviews?per_page=100   -> $MOCK_REVIEWS_BODY
+#   PUT  repos/<o>/<r>/pulls/<N>/reviews/<id>/dismissals -> log <id>, return {}
+gh() {
+  [[ "$1" == "api" ]] || { echo "mock gh: unsupported invocation: $*" >&2; return 2; }
+  shift
+  local method="GET" path="" saw_paginate=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -X)         method="$2"; shift 2 ;;
+      --paginate) saw_paginate=1; shift ;;
+      -f)         shift 2 ;;   # message=... / event=DISMISS
+      repos/*)    path="$1"; shift ;;
+      *)          shift ;;
+    esac
+  done
+
+  if [[ "$method" == "PUT" && "$path" == *"/dismissals" ]]; then
+    local rid="${path%/dismissals}"; rid="${rid##*/}"
+    echo "$rid" >> "$DISMISS_LOG"
+    echo '{}'
+    return 0
+  fi
+
+  [[ $saw_paginate -eq 1 ]] || { echo "mock gh api: reviews fetch missing --paginate" >&2; return 99; }
+  case "$path" in
+    *reviews*) echo "${MOCK_REVIEWS_BODY:-[]}" ;;
+    *) echo "mock gh api: unsupported path: $path" >&2; return 2 ;;
+  esac
+}
+
+# Convenience: how many dismissals were issued this test.
+dismiss_count() { [[ -s "$DISMISS_LOG" ]] && wc -l < "$DISMISS_LOG" | tr -d ' ' || echo 0; }
+
+# --- test bodies ---
+
+# Stale CHANGES_REQUESTED superseded by a later COMMENT from the same bot
+# is dismissed. This is the everyday case: bot requests changes, agent
+# fixes, bot re-reviews clean with a COMMENT (it cannot APPROVE — 422).
+t_stale_cr_then_comment_is_dismissed() {
+  MOCK_REVIEWS_BODY='[
+    {"id":11,"state":"CHANGES_REQUESTED","commit_id":"aaa","submitted_at":"2026-01-01T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":12,"state":"COMMENTED","commit_id":"bbb","submitted_at":"2026-01-02T00:00:00Z","user":{"login":"github-actions[bot]"}}
+  ]'
+  local out ids n
+  out=$(main "owner" "repo" "1") || { echo "    main exited non-zero" >&2; return 1; }
+  ids=$(jq -r '.dismissed | map(.review_id) | join(",")' <<<"$out")
+  n=$(dismiss_count)
+  assert_eq "dismissed review_id" "11" "$ids" || return 1
+  assert_eq "PUT dismissal count" "1" "$n"     || return 1
+  assert_eq "logged dismissed id" "11" "$(tr -d '\n' < "$DISMISS_LOG")"
+}
+
+# Latest review is still CHANGES_REQUESTED -> leave it gating, dismiss nothing.
+t_latest_cr_is_left_active() {
+  MOCK_REVIEWS_BODY='[
+    {"id":21,"state":"CHANGES_REQUESTED","commit_id":"aaa","submitted_at":"2026-01-01T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":22,"state":"COMMENTED","commit_id":"bbb","submitted_at":"2026-01-02T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":23,"state":"CHANGES_REQUESTED","commit_id":"ccc","submitted_at":"2026-01-03T00:00:00Z","user":{"login":"github-actions[bot]"}}
+  ]'
+  local out active n
+  out=$(main "owner" "repo" "1") || return 1
+  active=$(jq -r '.left_active | map("\(.login):\(.review_id)") | join(",")' <<<"$out")
+  n=$(dismiss_count)
+  assert_eq "left_active entry" "github-actions[bot]:23" "$active" || return 1
+  assert_eq "no dismissals"     "0"                      "$n"      || return 1
+  assert_eq "dismissed empty"   "0" "$(jq '.dismissed | length' <<<"$out")"
+}
+
+# An already-DISMISSED stale review is not re-dismissed (idempotent re-run).
+t_already_dismissed_is_skipped() {
+  MOCK_REVIEWS_BODY='[
+    {"id":31,"state":"DISMISSED","commit_id":"aaa","submitted_at":"2026-01-01T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":32,"state":"COMMENTED","commit_id":"bbb","submitted_at":"2026-01-02T00:00:00Z","user":{"login":"github-actions[bot]"}}
+  ]'
+  local out n
+  out=$(main "owner" "repo" "1") || return 1
+  n=$(dismiss_count)
+  assert_eq "no dismissals" "0" "$n" || return 1
+  assert_eq "dismissed empty" "0" "$(jq '.dismissed | length' <<<"$out")"
+}
+
+# Per-bot independence: one bot cleared (dismiss its stale CR), the other
+# still requesting changes (leave active).
+t_per_bot_independence() {
+  MOCK_REVIEWS_BODY='[
+    {"id":41,"state":"CHANGES_REQUESTED","commit_id":"aaa","submitted_at":"2026-01-01T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":42,"state":"COMMENTED","commit_id":"bbb","submitted_at":"2026-01-02T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":43,"state":"CHANGES_REQUESTED","commit_id":"ccc","submitted_at":"2026-01-02T06:00:00Z","user":{"login":"copilot-pull-request-reviewer[bot]"}}
+  ]'
+  local out dismissed active
+  out=$(main "owner" "repo" "1") || return 1
+  dismissed=$(jq -r '.dismissed | map("\(.login):\(.review_id)") | join(",")' <<<"$out")
+  active=$(jq -r '.left_active | map("\(.login):\(.review_id)") | join(",")' <<<"$out")
+  assert_eq "dismissed gh-aw stale"       "github-actions[bot]:41"                 "$dismissed" || return 1
+  assert_eq "copilot left active"         "copilot-pull-request-reviewer[bot]:43"  "$active"    || return 1
+  assert_eq "exactly one dismissal"       "1"                                      "$(dismiss_count)"
+}
+
+# No reviews at all -> empty envelope, exit 0.
+t_no_reviews_is_noop() {
+  MOCK_REVIEWS_BODY='[]'
+  local out
+  out=$(main "owner" "repo" "1") || return 1
+  assert_eq "dismissed empty"   "0" "$(jq '.dismissed | length' <<<"$out")"   || return 1
+  assert_eq "left_active empty" "0" "$(jq '.left_active | length' <<<"$out")" || return 1
+  assert_eq "no dismissals"     "0" "$(dismiss_count)"
+}
+
+# Two stale CRs before a clean COMMENT -> both dismissed.
+t_multiple_stale_crs_all_dismissed() {
+  MOCK_REVIEWS_BODY='[
+    {"id":51,"state":"CHANGES_REQUESTED","commit_id":"aaa","submitted_at":"2026-01-01T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":52,"state":"CHANGES_REQUESTED","commit_id":"bbb","submitted_at":"2026-01-02T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":53,"state":"COMMENTED","commit_id":"ccc","submitted_at":"2026-01-03T00:00:00Z","user":{"login":"github-actions[bot]"}}
+  ]'
+  local out ids
+  out=$(main "owner" "repo" "1") || return 1
+  ids=$(jq -r '.dismissed | map(.review_id) | sort | join(",")' <<<"$out")
+  assert_eq "both stale dismissed" "51,52" "$ids" || return 1
+  assert_eq "two dismissals"       "2"     "$(dismiss_count)"
+}
+
+# --- runner ---
+
+echo "test_dismiss_stale_reviews.sh"
+run "stale CR then COMMENT is dismissed"        t_stale_cr_then_comment_is_dismissed
+run "latest CR is left active"                  t_latest_cr_is_left_active
+run "already-dismissed is skipped"              t_already_dismissed_is_skipped
+run "per-bot independence"                      t_per_bot_independence
+run "no reviews is a no-op"                     t_no_reviews_is_noop
+run "multiple stale CRs all dismissed"          t_multiple_stale_crs_all_dismissed
+
+echo
+echo "passed: ${PASS_COUNT}, failed: ${FAIL_COUNT}"
+[[ $FAIL_COUNT -eq 0 ]]

--- a/skills/release/tests/test_dismiss_stale_reviews.sh
+++ b/skills/release/tests/test_dismiss_stale_reviews.sh
@@ -154,6 +154,22 @@ t_no_reviews_is_noop() {
   assert_eq "no dismissals"     "0" "$(dismiss_count)"
 }
 
+# Latest review is DISMISSED (not an all-clear) with an EARLIER active
+# CHANGES_REQUESTED the bot never cleared -> dismiss nothing. A dismissed
+# latest verdict is not a COMMENTED/APPROVED all-clear, so the earlier
+# active request must stay put.
+t_latest_dismissed_leaves_earlier_active_cr() {
+  MOCK_REVIEWS_BODY='[
+    {"id":61,"state":"CHANGES_REQUESTED","commit_id":"aaa","submitted_at":"2026-01-01T00:00:00Z","user":{"login":"github-actions[bot]"}},
+    {"id":62,"state":"DISMISSED","commit_id":"bbb","submitted_at":"2026-01-02T00:00:00Z","user":{"login":"github-actions[bot]"}}
+  ]'
+  local out n
+  out=$(main "owner" "repo" "1") || return 1
+  n=$(dismiss_count)
+  assert_eq "no dismissals"   "0" "$n"                                   || return 1
+  assert_eq "dismissed empty" "0" "$(jq '.dismissed | length' <<<"$out")"
+}
+
 # Two stale CRs before a clean COMMENT -> both dismissed.
 t_multiple_stale_crs_all_dismissed() {
   MOCK_REVIEWS_BODY='[
@@ -176,6 +192,7 @@ run "latest CR is left active"                  t_latest_cr_is_left_active
 run "already-dismissed is skipped"              t_already_dismissed_is_skipped
 run "per-bot independence"                      t_per_bot_independence
 run "no reviews is a no-op"                     t_no_reviews_is_noop
+run "latest DISMISSED leaves earlier active CR" t_latest_dismissed_leaves_earlier_active_cr
 run "multiple stale CRs all dismissed"          t_multiple_stale_crs_all_dismissed
 
 echo


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary

Two recurring release-flow chores removed:

- **Auto-open PR / auto-merge on green gates.** `release` skill Steps 2 and 7 now state explicitly that PR creation and merge proceed automatically once their objective gates pass — the readiness checks and the merge conjunction are the approval; the operator no longer pauses for a human ack.
- **Dismiss superseded review gates automatically.** A `github-actions[bot]` policy reviewer cannot `APPROVE` (GitHub returns HTTP 422), so a clean re-review lands as a `COMMENT` that never supersedes the bot's earlier `CHANGES_REQUESTED` in GitHub's merge gate — the stale request kept `merge_state.status` at `BLOCKED` and had to be dismissed by hand every cycle. New `skills/release/dismiss-stale-reviews.sh` clears it deterministically (per `rules/script-delegation.md`): dismisses only a `CHANGES_REQUESTED` a later verdict from the same bot superseded, leaves a bot whose latest verdict is still `CHANGES_REQUESTED` untouched, idempotent on re-run. Step 7 runs it before merging.

Why the reviewer can't just dismiss its own review: the workflow holds only `pull-requests: read` and cannot `APPROVE` or dismiss — so the operator side is the only viable place to clear the stale gate.

## Test plan

- [x] `bash skills/release/tests/test_dismiss_stale_reviews.sh` — 6 cases: stale-CR-then-COMMENT dismissed, latest-CR left active, already-dismissed skipped (idempotent), per-bot independence, no-reviews no-op, multiple stale CRs all dismissed
- [x] `bash scripts/run-tests.sh` — 16/16 suites pass
- [x] `bash -n` + shellcheck clean on the new script and test
- [x] Self-audit: no banned connectives in auto-loaded SKILL prose, no trailing whitespace, script has entry-point guard + `set -euo pipefail` + JSON output + actionable errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNQYMB1HdsAxoedZ3CW2zo