### PR TITLE
fix(rules): scope context-writing-style to SKILL.md, not all of skills/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
   The body's reading is the one preserved, on three grounds. `rules/skill-authoring.md` Keep Skills Compact designates reference files as the destination for detail moved off the loaded surface — applying the prose budget to both surfaces leaves that detail nowhere to live and makes progressive disclosure pointless. The convention is already established in practice: 31 of the 104 pattern files in speaker-toolkit's taxonomy carried the banned connectives before #117 (47 occurrences), including files from earlier ingests that shipped through this same reviewer. And the remedy the glob implied — strip mechanism prose from a reference file, move it to CHANGELOG — relocates selection-time information to a surface nobody reads at selection time.
 
+  The same glob/body split covers `CHANGELOG.md`, which the frontmatter lists while the body exempts it as
+  the archive that follows "looser discipline". Scope now states that `What to Cut` and `Structure` do not
+  govern CHANGELOG — `What to Cut` names CHANGELOG as where the stripped explanation goes, so a connective
+  ban there would leave it nowhere to live. Surfaced on `jbaruch/speaker-toolkit#121`, where the reviewer
+  flagged `because` in a CHANGELOG entry that was doing the archival job the rule assigns it. The rule
+  reaches CHANGELOG only to say what belongs in it.
+
   Scope-only change; the prose directives are untouched. `script-as-black-box` and `skill-authoring` keep `skills/**/*.md` deliberately — the former governs reference files by design (it names `references/*.md` in its own text), and the latter carries no prose budget that would gut them.
 
 ## 0.3.91 — 2026-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Rules
+
+- **`context-writing-style` Scope: resolve the frontmatter/body contradiction over `skills/**` reference files** — The rule's body scoped it to auto-loaded artifacts ("skills on invocation") while its own `applyTo:` glob said `skills/**/*.md`, which matches every on-demand reference file under `skills/<name>/references/**`. The two halves disagreed and the rule fired inconsistently: on `jbaruch/speaker-toolkit#117` the gh-aw reviewer returned a `context-writing-style` violation, then "All rules pass — no violations found", then a violation again — three verdicts on prose unchanged between runs, with nothing in the rule to say which half wins. Frontmatter now reads `skills/**/SKILL.md`, and Scope states the operative test: load-time, not directory. A file the agent receives without choosing it is in scope; a file it opens after reading a pointer is not.
+
+  The body's reading is the one preserved, on three grounds. `rules/skill-authoring.md` Keep Skills Compact designates reference files as the destination for detail moved off the loaded surface — applying the prose budget to both surfaces leaves that detail nowhere to live and makes progressive disclosure pointless. The convention is already established in practice: 31 of the 104 pattern files in speaker-toolkit's taxonomy carried the banned connectives before #117 (47 occurrences), including files from earlier ingests that shipped through this same reviewer. And the remedy the glob implied — strip mechanism prose from a reference file, move it to CHANGELOG — relocates selection-time information to a surface nobody reads at selection time.
+
+  Scope-only change; the prose directives are untouched. `script-as-black-box` and `skill-authoring` keep `skills/**/*.md` deliberately — the former governs reference files by design (it names `references/*.md` in its own text), and the latter carries no prose budget that would gut them.
+
 ## 0.3.91 — 2026-07-14
 
 ### Rules

--- a/rules/context-writing-style.md
+++ b/rules/context-writing-style.md
@@ -1,6 +1,6 @@
 ---
 alwaysApply: false
-applyTo: "rules/**/*.md, skills/**/*.md, README.md, CHANGELOG.md — when writing prose in plugin context artifacts"
+applyTo: "rules/**/*.md, skills/**/SKILL.md, README.md, CHANGELOG.md — when writing prose in plugin context artifacts"
 description: Prose discipline for rules, skills, and READMEs — what to cut, what to keep, structural format
 ---
 
@@ -8,7 +8,10 @@ description: Prose discipline for rules, skills, and READMEs — what to cut, wh
 
 ## Scope
 
-- Applies to auto-loaded artifacts: rules declared in `.tessl-plugin/plugin.json`, skills on invocation, READMEs on plugin fetch
+- Applies to auto-loaded artifacts: rules declared in `.tessl-plugin/plugin.json`, `SKILL.md` on skill invocation, READMEs on plugin fetch
+- Out of scope: every file the agent loads only after electing to open it — `skills/<name>/references/**`, lookup tables, worked examples, any file reached through a pointer
+- The test is load-time, not directory. A file the agent receives without choosing it is in scope. A file it opens after reading a reference is not, whatever directory holds it
+- `rules/skill-authoring.md` Keep Skills Compact names reference files as the destination for detail moved off the loaded surface
 - CHANGELOG entries load only on demand, not always-on
 - CHANGELOG entries are the archive — they carry the motivation and incident references stripped from rules, and follow looser discipline
 - Line-count and section-count budgets target single-concept rules; rules that cover one coherent policy area with several sub-aspects (e.g., `plugin-evals` covering coverage/lift/persistence/naming/hygiene; `context-artifacts` covering structure/review/sync/audit; `skill-authoring` covering frontmatter/preamble/steps/calls) may run larger

--- a/rules/context-writing-style.md
+++ b/rules/context-writing-style.md
@@ -14,6 +14,7 @@ description: Prose discipline for rules, skills, and READMEs — what to cut, wh
 - `rules/skill-authoring.md` Keep Skills Compact names reference files as the destination for detail moved off the loaded surface
 - CHANGELOG entries load only on demand, not always-on
 - CHANGELOG entries are the archive — they carry the motivation and incident references stripped from rules, and follow looser discipline
+- `What to Cut` and `Structure` do not govern CHANGELOG. `What to Cut` names CHANGELOG as where the stripped explanation goes; a connective ban there would leave it nowhere to live. The rule reaches CHANGELOG only to say what belongs in it
 - Line-count and section-count budgets target single-concept rules; rules that cover one coherent policy area with several sub-aspects (e.g., `plugin-evals` covering coverage/lift/persistence/naming/hygiene; `context-artifacts` covering structure/review/sync/audit; `skill-authoring` covering frontmatter/preamble/steps/calls) may run larger
 - Lists and quoted literals naming the forbidden terms themselves (e.g., this rule's own bullets enumerating the connectives and intensifiers) are not violations — the directive is the list, not prose use of the listed words
 


### PR DESCRIPTION
**Author-Model:** claude-opus-4-8

## Summary

`context-writing-style` contradicted itself, and the contradiction was load-bearing.

- **Body §Scope:** "Applies to auto-loaded artifacts: rules declared in `.tessl-plugin/plugin.json`, skills on invocation, READMEs on plugin fetch"
- **Its own frontmatter:** `applyTo: "rules/**/*.md, skills/**/*.md, README.md, CHANGELOG.md"`

`skills/**/*.md` matches every on-demand reference file under `skills/<name>/references/**`. The body says auto-loaded only; the glob says everything under `skills/`. Nothing in the rule said which wins.

**The symptom.** On `jbaruch/speaker-toolkit#117`, the gh-aw reviewer returned a `context-writing-style` violation (16:47), then **"All rules pass — no violations found"** (16:55), then a violation again (17:20) — on pattern-reference prose with **zero commits between those runs**. Three verdicts, identical bytes. That is what an internally contradictory rule looks like from the outside: the model weights the frontmatter on one pass and the body on the next. It reads as reviewer flakiness and isn't.

**The fix.** Frontmatter narrows to `skills/**/SKILL.md`. Scope gains the operative test — *load-time, not directory*: a file the agent receives without choosing it is in scope; a file it opens after reading a pointer is not, whatever directory holds it.

**Why the body's reading is the one preserved:**

1. `rules/skill-authoring.md` Keep Skills Compact designates reference files as the destination for detail moved off the loaded surface. Applying the prose budget to both surfaces leaves that detail nowhere to live and makes progressive disclosure pointless.
2. The convention is already established: **31 of the 104 pattern files in speaker-toolkit's taxonomy carried the banned connectives before #117 — 47 occurrences** — including files from the *Resonate* ingest that shipped through this same reviewer. The glob's reading would put a third of that corpus in violation.
3. The remedy the glob implies — strip mechanism prose from a reference file and move it to CHANGELOG — relocates selection-time information to a surface nobody reads at selection time. An agent choosing between two neighbouring patterns needs the distinction in the file it is reading.

**Scope-only change. No prose directive is touched.**

Per Post-Edit Rule Audit I checked the other two rules carrying `skills/**/*.md` and left both alone deliberately: `script-as-black-box` governs reference files by design (it names `references/*.md` in its own text), and `skill-authoring` carries no prose budget that would gut them. The contradiction is specific to this rule, which is the only one pairing that glob with an auto-loaded-only body.

## Test plan

- [x] `tessl plugin lint` — valid
- [x] Added lines self-check clean against the rule they amend — zero banned connectives (`git diff | grep "^+" | grep -iE "therefore|however|because|..."` returns nothing)
- [x] Rule stays within the section/line budget (56 lines; Scope remains one H2 of six)
- [x] Other `skills/**/*.md` consumers audited — `script-as-black-box` and `skill-authoring` intentionally unchanged
- [ ] Post-merge: re-run the reviewer on a speaker-toolkit pattern PR and confirm the verdict is stable across consecutive runs

## Context

Surfaced by `jbaruch/speaker-toolkit#117`, which merged via an explicit operator override recorded on the dismissed review rather than a carve-out — precisely because this ambiguity made the gate unresolvable on the merits. This PR is the durable fix so the question stops recurring on every pattern PR.
