### PR TITLE
feat(ci): post-review.sh APPROVEs on a pass, falls back to COMMENT (#200)

### DIFF
--- a/.github/codex-review/post-review.sh
+++ b/.github/codex-review/post-review.sh
@@ -22,6 +22,35 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
+# Submit ONE review event to the PR, retrying transient failures with backoff.
+# Args: <owner> <repo> <pr> <event> <body>
+# Return: 0 posted; 22 the event was rejected as unprocessable (HTTP 422 — e.g.
+#   an APPROVE from a token that cannot approve); 1 other failure after retries.
+submit_review() {
+  local owner="$1" repo="$2" pr="$3" event="$4" body="$5"
+  local payload attempt=0 max=3 err
+  payload=$(jq -n --arg event "$event" --arg body "$body" '{event: $event, body: $body}')
+  while :; do
+    attempt=$((attempt + 1))
+    # Capture stderr (stdout discarded) so a 422 can be told from a transient 5xx.
+    if err=$(printf '%s' "$payload" | gh api "repos/${owner}/${repo}/pulls/${pr}/reviews" --method POST --input - 2>&1 1>/dev/null); then
+      return 0
+    fi
+    # HTTP 422 (unprocessable) is not transient — do not retry; let the caller fall back.
+    if grep -q "HTTP 422" <<<"$err"; then
+      printf '%s\n' "$err" >&2
+      return 22
+    fi
+    if (( attempt >= max )); then
+      printf '%s\n' "$err" >&2
+      echo "error: failed to submit the review on ${owner}/${repo}#${pr} after ${max} attempts — see the gh error above (token scope, PR state, or a GitHub API outage)" >&2
+      return 1
+    fi
+    echo "post-review: submit attempt ${attempt} failed — retrying in $(( attempt * 5 ))s" >&2
+    sleep $(( attempt * 5 ))
+  done
+}
+
 main() {
   if [[ $# -ne 4 ]]; then
     echo "usage: $0 <owner> <repo> <pr-number> <result-json-file>" >&2
@@ -46,7 +75,7 @@ main() {
   local event
   case "$verdict" in
     changes_requested) event="REQUEST_CHANGES" ;;
-    pass)              event="COMMENT" ;;
+    pass)              event="APPROVE" ;;
     *) echo "error: unexpected verdict '${verdict}' in ${result} (want pass|changes_requested)" >&2; exit 1 ;;
   esac
 
@@ -58,26 +87,20 @@ main() {
     body="${body}"$'\n\n'"## Findings"$'\n'"${findings_md}"
   fi
 
-  local payload attempt=0 max=3
-  payload=$(jq -n --arg event "$event" --arg body "$body" '{event: $event, body: $body}')
+  # A pass is APPROVE when the token can approve (a GitHub App); a token that
+  # cannot approve (github-actions[bot] — HTTP 422) falls back to COMMENT so the
+  # verdict is never lost. The output reports the event actually posted.
+  local posted="$event" rc=0
+  submit_review "$owner" "$repo" "$pr" "$event" "$body" || rc=$?
+  if (( rc == 22 )) && [[ "$event" == "APPROVE" ]]; then
+    echo "post-review: APPROVE rejected as unprocessable (HTTP 422) — this token cannot approve; posting COMMENT instead" >&2
+    posted="COMMENT"
+    submit_review "$owner" "$repo" "$pr" "COMMENT" "$body" || exit 1
+  elif (( rc != 0 )); then
+    exit 1
+  fi
 
-  # Retry on a transient GitHub API failure (5xx / network) — a policy verdict
-  # must not be lost to a blip. gh exits non-zero on HTTP errors; back off and
-  # retry before giving up.
-  while :; do
-    attempt=$((attempt + 1))
-    if printf '%s' "$payload" | gh api "repos/${owner}/${repo}/pulls/${pr}/reviews" --method POST --input - >&2; then
-      break
-    fi
-    if (( attempt >= max )); then
-      echo "error: failed to submit the review on ${owner}/${repo}#${pr} after ${max} attempts — see the gh error above (token scope, PR state, or a GitHub API outage)" >&2
-      exit 1
-    fi
-    echo "post-review: submit attempt ${attempt} failed — retrying in $(( attempt * 5 ))s" >&2
-    sleep $(( attempt * 5 ))
-  done
-
-  jq -n --arg event "$event" --argjson findings "$findings_count" \
+  jq -n --arg event "$posted" --argjson findings "$findings_count" \
     '{state: "posted", event: $event, findings: $findings}'
 }
 

--- a/.github/codex-review/post-review.sh
+++ b/.github/codex-review/post-review.sh
@@ -7,9 +7,10 @@
 # the review body rather than as inline comments so an off-diff line can never
 # trigger the HTTP 422 that would cascade-fail the whole review.
 #
-# The review is authored by whoever GH_TOKEN belongs to — in CI that is
-# `github-actions[bot]`, which GitHub forbids from posting APPROVE (HTTP 422).
-# So a clean pass is a COMMENT; a violation is REQUEST_CHANGES.
+# The review is authored by whoever GH_TOKEN belongs to. A clean pass posts
+# APPROVE and a violation posts REQUEST_CHANGES. A token GitHub forbids from
+# approving (`github-actions[bot]` — HTTP 422) falls back to COMMENT on a pass,
+# so the verdict is never lost.
 #
 # Usage: post-review.sh <owner> <repo> <pr-number> <result-json-file>
 # Out:   one JSON object on stdout: {"state":"posted","event":"...","findings":N}

--- a/.github/codex-review/post-review.sh
+++ b/.github/codex-review/post-review.sh
@@ -33,7 +33,8 @@ submit_review() {
   payload=$(jq -n --arg event "$event" --arg body "$body" '{event: $event, body: $body}')
   while :; do
     attempt=$((attempt + 1))
-    # Capture stderr (stdout discarded) so a 422 can be told from a transient 5xx.
+    # Capture stderr (stdout discarded) so a non-retryable 422 can be told apart
+    # from any other failure (which is retried).
     if err=$(printf '%s' "$payload" | gh api "repos/${owner}/${repo}/pulls/${pr}/reviews" --method POST --input - 2>&1 1>/dev/null); then
       return 0
     fi

--- a/.github/codex-review/tests/test_post_review.sh
+++ b/.github/codex-review/tests/test_post_review.sh
@@ -20,10 +20,19 @@ ok()  { printf 'ok   - %s\n' "$1"; pass=$((pass+1)); }
 bad() { printf 'FAIL - %s\n' "$1"; fail=$((fail+1)); }
 
 # Mock gh: capture the /reviews POST payload (arrives on stdin via --input -).
+# With MOCK_422_ON_APPROVE=1, an APPROVE submit fails HTTP 422 (as github-actions[bot]
+# would), so the fallback-to-COMMENT path can be exercised.
 GH_CAPTURE=""
+MOCK_422_ON_APPROVE=0
 gh() {
   if [[ "${1:-}" == "api" && "$*" == */reviews* ]]; then
-    cat > "$GH_CAPTURE"
+    local payload; payload=$(cat)
+    printf '%s' "$payload" > "$GH_CAPTURE"
+    local ev; ev=$(jq -r '.event' <<<"$payload")
+    if [[ "$MOCK_422_ON_APPROVE" == "1" && "$ev" == "APPROVE" ]]; then
+      echo "gh: Unprocessable Entity (HTTP 422)" >&2
+      return 1
+    fi
     return 0
   fi
   return 0
@@ -31,19 +40,34 @@ gh() {
 
 run_main() { ( set -euo pipefail; main "$@" ); }
 
-# --- pass, no findings -> COMMENT, body is the summary ---
+# --- pass, no findings -> APPROVE (token can approve), body is the summary ---
 t_pass() {
-  local dir; dir=$(mktemp -d)
-  GH_CAPTURE="$dir/payload.json"
-  printf '{"summary":"Policy loaded: 21 rule files from rules/. All rules pass.","verdict":"pass","findings":[]}' > "$dir/final.json"
+  local dir; dir=$(mktemp -d) || { bad "pass: mktemp -d failed"; return; }
+  GH_CAPTURE="$dir/payload.json"; MOCK_422_ON_APPROVE=0
+  printf '{"summary":"Policy loaded: 21 rule files from jbaruch/coding-policy. All rules pass.","verdict":"pass","findings":[]}' > "$dir/final.json"
   local out; out=$(run_main owner repo 5 "$dir/final.json")
   local rc=$?
   [[ $rc -eq 0 ]]                                              || { bad "pass: exit 0 (rc=$rc)"; rm -rf "$dir"; return; }
-  [[ "$(jq -r .event <<<"$out")" == "COMMENT" ]]              || { bad "pass: event COMMENT (got $out)"; rm -rf "$dir"; return; }
+  [[ "$(jq -r .event <<<"$out")" == "APPROVE" ]]             || { bad "pass: event APPROVE (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .findings <<<"$out")" == "0" ]]                 || { bad "pass: findings 0 (got $out)"; rm -rf "$dir"; return; }
-  [[ "$(jq -r .event "$GH_CAPTURE")" == "COMMENT" ]]          || { bad "pass: payload event COMMENT"; rm -rf "$dir"; return; }
+  [[ "$(jq -r .event "$GH_CAPTURE")" == "APPROVE" ]]         || { bad "pass: payload event APPROVE"; rm -rf "$dir"; return; }
   jq -r .body "$GH_CAPTURE" | grep -q "Policy loaded: 21"     || { bad "pass: body carries the load indicator"; rm -rf "$dir"; return; }
-  ok "pass verdict -> COMMENT, summary body, 0 findings"
+  ok "pass verdict -> APPROVE, summary body, 0 findings"
+  rm -rf "$dir"
+}
+
+# --- pass but token can't approve (HTTP 422) -> falls back to COMMENT ---
+t_pass_422_fallback() {
+  local dir; dir=$(mktemp -d) || { bad "fallback: mktemp -d failed"; return; }
+  GH_CAPTURE="$dir/payload.json"; MOCK_422_ON_APPROVE=1
+  printf '{"summary":"Policy loaded: 21 rule files from jbaruch/coding-policy. Clean.","verdict":"pass","findings":[]}' > "$dir/final.json"
+  local out; out=$(run_main owner repo 5 "$dir/final.json" 2>/dev/null)
+  local rc=$?
+  MOCK_422_ON_APPROVE=0
+  [[ $rc -eq 0 ]]                                              || { bad "fallback: exit 0 (rc=$rc)"; rm -rf "$dir"; return; }
+  [[ "$(jq -r .event <<<"$out")" == "COMMENT" ]]             || { bad "fallback: output event COMMENT (got $out)"; rm -rf "$dir"; return; }
+  [[ "$(jq -r .event "$GH_CAPTURE")" == "COMMENT" ]]         || { bad "fallback: last payload event COMMENT"; rm -rf "$dir"; return; }
+  ok "pass + APPROVE 422 -> falls back to COMMENT"
   rm -rf "$dir"
 }
 
@@ -69,20 +93,21 @@ JSON
 # --- missing result file -> exit 1 ---
 t_missing_file() {
   local rc=0; run_main owner repo 1 "/nonexistent/final.json" >/dev/null 2>&1 || rc=$?
-  [[ $rc -eq 1 ]] && ok "missing result file -> exit 1" || bad "missing result file -> exit 1 (rc=$rc)"
+  if [[ $rc -eq 1 ]]; then ok "missing result file -> exit 1"; else bad "missing result file -> exit 1 (rc=$rc)"; fi
 }
 
 # --- invalid JSON -> exit 1 ---
 t_invalid_json() {
-  local dir; dir=$(mktemp -d)
+  local dir; dir=$(mktemp -d) || { bad "invalid_json: mktemp -d failed"; return; }
   printf 'not json at all' > "$dir/final.json"
   local rc=0; run_main owner repo 1 "$dir/final.json" >/dev/null 2>&1 || rc=$?
-  [[ $rc -eq 1 ]] && ok "invalid JSON -> exit 1" || bad "invalid JSON -> exit 1 (rc=$rc)"
+  if [[ $rc -eq 1 ]]; then ok "invalid JSON -> exit 1"; else bad "invalid JSON -> exit 1 (rc=$rc)"; fi
   rm -rf "$dir"
 }
 
 echo "== post-review.sh tests =="
 t_pass
+t_pass_422_fallback
 t_changes
 t_missing_file
 t_invalid_json

--- a/.github/workflows/fleet-review.yml
+++ b/.github/workflows/fleet-review.yml
@@ -12,10 +12,11 @@ name: Fleet Policy Review (Codex, central)
 #   TESSL_TOKEN           — to `tessl install jbaruch/coding-policy` in CI
 #
 # The App (Pull requests: RW, Contents: RO, Metadata: RO) must be installed on
-# every reviewed repo. It posts reviews as `<app-slug>[bot]`; a pass posts as a
-# COMMENT and a violation as REQUEST_CHANGES (post-review.sh). Posting APPROVE on
-# a pass — which the App identity permits, unlike github-actions[bot] — is a
-# tracked follow-up, not current behavior.
+# every reviewed repo. It posts reviews as `<app-slug>[bot]`; a pass posts as
+# APPROVE and a violation as REQUEST_CHANGES (post-review.sh). The App identity
+# can APPROVE (unlike github-actions[bot], which gets HTTP 422 and falls back to
+# COMMENT), so a clean re-review supersedes an earlier REQUEST_CHANGES — no
+# stale-review dismissal needed in the reviewed repo.
 #
 # Token isolation: fleet-review-one.sh scrubs the App token from the workdir and
 # the environment before the sandbox-bypassed Codex step runs; the Codex auth.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### CI
+
+- **`post-review.sh` posts `APPROVE` on a pass** — a pass verdict now submits an `APPROVE` review instead of a `COMMENT`, so a clean re-review supersedes an earlier `REQUEST_CHANGES` in GitHub's merge gate without a manual dismissal — which matters for fleet-reviewed consumer repos, where no release skill runs to dismiss stale reviews. A token that cannot approve (`github-actions[bot]`, HTTP 422) falls back to `COMMENT`, so this repo's own self-review still works during the transition. The submit logic is factored into a `submit_review()` helper that distinguishes a non-retryable 422 from a transient 5xx. Implements #200.
+
 ## 0.3.99 — 2026-07-20
 
 ### CI

--- a/skills/install-reviewer/templates/codex-review/post-review.sh
+++ b/skills/install-reviewer/templates/codex-review/post-review.sh
@@ -22,6 +22,35 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
+# Submit ONE review event to the PR, retrying transient failures with backoff.
+# Args: <owner> <repo> <pr> <event> <body>
+# Return: 0 posted; 22 the event was rejected as unprocessable (HTTP 422 — e.g.
+#   an APPROVE from a token that cannot approve); 1 other failure after retries.
+submit_review() {
+  local owner="$1" repo="$2" pr="$3" event="$4" body="$5"
+  local payload attempt=0 max=3 err
+  payload=$(jq -n --arg event "$event" --arg body "$body" '{event: $event, body: $body}')
+  while :; do
+    attempt=$((attempt + 1))
+    # Capture stderr (stdout discarded) so a 422 can be told from a transient 5xx.
+    if err=$(printf '%s' "$payload" | gh api "repos/${owner}/${repo}/pulls/${pr}/reviews" --method POST --input - 2>&1 1>/dev/null); then
+      return 0
+    fi
+    # HTTP 422 (unprocessable) is not transient — do not retry; let the caller fall back.
+    if grep -q "HTTP 422" <<<"$err"; then
+      printf '%s\n' "$err" >&2
+      return 22
+    fi
+    if (( attempt >= max )); then
+      printf '%s\n' "$err" >&2
+      echo "error: failed to submit the review on ${owner}/${repo}#${pr} after ${max} attempts — see the gh error above (token scope, PR state, or a GitHub API outage)" >&2
+      return 1
+    fi
+    echo "post-review: submit attempt ${attempt} failed — retrying in $(( attempt * 5 ))s" >&2
+    sleep $(( attempt * 5 ))
+  done
+}
+
 main() {
   if [[ $# -ne 4 ]]; then
     echo "usage: $0 <owner> <repo> <pr-number> <result-json-file>" >&2
@@ -46,7 +75,7 @@ main() {
   local event
   case "$verdict" in
     changes_requested) event="REQUEST_CHANGES" ;;
-    pass)              event="COMMENT" ;;
+    pass)              event="APPROVE" ;;
     *) echo "error: unexpected verdict '${verdict}' in ${result} (want pass|changes_requested)" >&2; exit 1 ;;
   esac
 
@@ -58,26 +87,20 @@ main() {
     body="${body}"$'\n\n'"## Findings"$'\n'"${findings_md}"
   fi
 
-  local payload attempt=0 max=3
-  payload=$(jq -n --arg event "$event" --arg body "$body" '{event: $event, body: $body}')
+  # A pass is APPROVE when the token can approve (a GitHub App); a token that
+  # cannot approve (github-actions[bot] — HTTP 422) falls back to COMMENT so the
+  # verdict is never lost. The output reports the event actually posted.
+  local posted="$event" rc=0
+  submit_review "$owner" "$repo" "$pr" "$event" "$body" || rc=$?
+  if (( rc == 22 )) && [[ "$event" == "APPROVE" ]]; then
+    echo "post-review: APPROVE rejected as unprocessable (HTTP 422) — this token cannot approve; posting COMMENT instead" >&2
+    posted="COMMENT"
+    submit_review "$owner" "$repo" "$pr" "COMMENT" "$body" || exit 1
+  elif (( rc != 0 )); then
+    exit 1
+  fi
 
-  # Retry on a transient GitHub API failure (5xx / network) — a policy verdict
-  # must not be lost to a blip. gh exits non-zero on HTTP errors; back off and
-  # retry before giving up.
-  while :; do
-    attempt=$((attempt + 1))
-    if printf '%s' "$payload" | gh api "repos/${owner}/${repo}/pulls/${pr}/reviews" --method POST --input - >&2; then
-      break
-    fi
-    if (( attempt >= max )); then
-      echo "error: failed to submit the review on ${owner}/${repo}#${pr} after ${max} attempts — see the gh error above (token scope, PR state, or a GitHub API outage)" >&2
-      exit 1
-    fi
-    echo "post-review: submit attempt ${attempt} failed — retrying in $(( attempt * 5 ))s" >&2
-    sleep $(( attempt * 5 ))
-  done
-
-  jq -n --arg event "$event" --argjson findings "$findings_count" \
+  jq -n --arg event "$posted" --argjson findings "$findings_count" \
     '{state: "posted", event: $event, findings: $findings}'
 }
 

--- a/skills/install-reviewer/templates/codex-review/post-review.sh
+++ b/skills/install-reviewer/templates/codex-review/post-review.sh
@@ -7,9 +7,10 @@
 # the review body rather than as inline comments so an off-diff line can never
 # trigger the HTTP 422 that would cascade-fail the whole review.
 #
-# The review is authored by whoever GH_TOKEN belongs to — in CI that is
-# `github-actions[bot]`, which GitHub forbids from posting APPROVE (HTTP 422).
-# So a clean pass is a COMMENT; a violation is REQUEST_CHANGES.
+# The review is authored by whoever GH_TOKEN belongs to. A clean pass posts
+# APPROVE and a violation posts REQUEST_CHANGES. A token GitHub forbids from
+# approving (`github-actions[bot]` — HTTP 422) falls back to COMMENT on a pass,
+# so the verdict is never lost.
 #
 # Usage: post-review.sh <owner> <repo> <pr-number> <result-json-file>
 # Out:   one JSON object on stdout: {"state":"posted","event":"...","findings":N}

--- a/skills/install-reviewer/templates/codex-review/post-review.sh
+++ b/skills/install-reviewer/templates/codex-review/post-review.sh
@@ -33,7 +33,8 @@ submit_review() {
   payload=$(jq -n --arg event "$event" --arg body "$body" '{event: $event, body: $body}')
   while :; do
     attempt=$((attempt + 1))
-    # Capture stderr (stdout discarded) so a 422 can be told from a transient 5xx.
+    # Capture stderr (stdout discarded) so a non-retryable 422 can be told apart
+    # from any other failure (which is retried).
     if err=$(printf '%s' "$payload" | gh api "repos/${owner}/${repo}/pulls/${pr}/reviews" --method POST --input - 2>&1 1>/dev/null); then
       return 0
     fi


### PR DESCRIPTION
## Summary

Implements #200. A pass verdict now submits an **APPROVE** review instead of a `COMMENT`.

- For the **fleet reviewer** (a GitHub App, which *can* approve), a fresh APPROVE supersedes an earlier `REQUEST_CHANGES` in the merge gate — no manual dismissal. This matters for consumer repos, where no release skill runs to dismiss stale reviews.
- A token that **cannot** approve (`github-actions[bot]`, HTTP 422) **falls back to COMMENT**, so this repo's own self-review is unchanged during the transition (the release skill's dismiss-stale flow still applies to it).
- Submit logic factored into `submit_review()`, which distinguishes a non-retryable 422 from a transient 5xx.
- Template `post-review.sh` kept byte-identical to the central copy.

Unblocks Part A of #202 (migrating `coding-policy` onto the App reviewer).

## Test plan
- [x] `scripts/run-tests.sh` — green; new tests cover APPROVE-on-pass and the 422→COMMENT fallback
- [x] `scripts/run-diagnostics.sh` — shellcheck + pyright clean
- [x] `actionlint` — clean
- [x] Also converted this test file's two pre-existing SC2015 asserts to if/then/else (partial #199)

🤖 Generated with [Claude Code](https://claude.com/claude-code)