### PR TITLE
feat(rules): sanction mid-session-install recovery in Typed Calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **`skill-authoring` Typed Calls: mid-session-install recovery carve-out** — field feedback from a first-run consumer setup (jbaruch/jbaruch-travel-policy#24): a policy skill's Setup installs its library plugin mid-session, and the harness's skill registry only loads at session start — the documented typed `Skill()` call throws "Unknown skill" for the rest of that session no matter how the skill phrases it. The consumer documented the only working recovery (read the just-installed skill's mounted `SKILL.md` and execute its steps), and the policy reviewer correctly flagged that as a Typed Calls violation with no sanctioned form, naming "update the governing rule with an explicit carve-out" as a remedy. The carve-out sanctions exactly that shape with three preconditions: the typed call stays the sole authored invocation path, the recovery reads the plugin-mount `SKILL.md`, and the skill text scopes the recovery to the installing session.
+
 ## 0.3.100 — 2026-07-21
 
 ### CI

--- a/rules/skill-authoring.md
+++ b/rules/skill-authoring.md
@@ -47,7 +47,7 @@ description: SKILL.md structure, frontmatter, execution-mode preamble, flat step
 - Invoke other skills with typed `Skill(skill: "name")` calls, never prose references
 - Never call `Skill()` on a rule (rules are auto-loaded, not invoked via Skill)
 - Narrow exception for mid-session-install recovery
-- Applies when the authored flow's typed `Skill()` call targets a skill whose plugin was installed earlier in the same session and the harness throws "Unknown skill" — the skill registry loads at session start and does not see mid-session installs
+- Applies when the authored flow's typed `Skill()` call targets a skill whose plugin was installed earlier in the same session and the harness throws "Unknown skill"
 - Preconditions (all required):
   1. The typed `Skill()` call stays the sole invocation path in authored flow; the recovery never replaces it
   2. The recovery reads the target skill's mounted `SKILL.md` at its plugin mount path (`.tessl/plugins/<workspace>/<plugin>/skills/<name>/SKILL.md`) and executes its steps

--- a/rules/skill-authoring.md
+++ b/rules/skill-authoring.md
@@ -46,6 +46,13 @@ description: SKILL.md structure, frontmatter, execution-mode preamble, flat step
 
 - Invoke other skills with typed `Skill(skill: "name")` calls, never prose references
 - Never call `Skill()` on a rule (rules are auto-loaded, not invoked via Skill)
+- Narrow exception for mid-session-install recovery
+- Applies when the authored flow's typed `Skill()` call targets a skill whose plugin was installed earlier in the same session and the harness throws "Unknown skill" — the skill registry loads at session start and does not see mid-session installs
+- Preconditions (all required):
+  1. The typed `Skill()` call stays the sole invocation path in authored flow; the recovery never replaces it
+  2. The recovery reads the target skill's mounted `SKILL.md` at its plugin mount path (`.tessl/plugins/<workspace>/<plugin>/skills/<name>/SKILL.md`) and executes its steps
+  3. The skill text scopes the recovery to the installing session and states that later sessions use the typed call
+- Every other cross-skill reference is a typed `Skill()` call
 
 ## Silence Instructions
 

--- a/rules/skill-authoring.md
+++ b/rules/skill-authoring.md
@@ -46,13 +46,15 @@ description: SKILL.md structure, frontmatter, execution-mode preamble, flat step
 
 - Invoke other skills with typed `Skill(skill: "name")` calls, never prose references
 - Never call `Skill()` on a rule (rules are auto-loaded, not invoked via Skill)
-- Narrow exception for mid-session-install recovery
-- Applies when the authored flow's typed `Skill()` call targets a skill whose plugin was installed earlier in the same session and the harness throws "Unknown skill"
+- Narrow exception for mid-session-install recovery.
+- Applies when the authored flow's typed `Skill(skill: "name")` call targets a skill whose plugin was installed earlier in the same session and the harness throws "Unknown skill"
 - Preconditions (all required):
-  1. The typed `Skill()` call stays the sole invocation path in authored flow; the recovery never replaces it
-  2. The recovery reads the target skill's mounted `SKILL.md` at its plugin mount path (`.tessl/plugins/<workspace>/<plugin>/skills/<name>/SKILL.md`) and executes its steps
-  3. The skill text scopes the recovery to the installing session and states that later sessions use the typed call
-- Every other cross-skill reference is a typed `Skill()` call
+  1. The typed `Skill(skill: "name")` call stays the sole invocation path in authored flow
+  2. The skill text presents the recovery as error handling for the failed typed call, never as an alternative invocation
+  3. The recovery reads the target skill's mounted `SKILL.md` at its plugin mount path (`.tessl/plugins/<workspace>/<plugin>/skills/<name>/SKILL.md`) and executes its steps
+  4. The recovery is scoped to the installing session
+  5. The skill text states that later sessions use the typed call
+- Every other cross-skill reference is a typed `Skill(skill: "name")` call
 
 ## Silence Instructions
 


### PR DESCRIPTION
## Summary
- `skill-authoring` Typed Calls gains a narrow carve-out for mid-session-install recovery: when a typed `Skill()` call targets a skill whose plugin was installed earlier in the same session, the harness throws "Unknown skill" (skill registry loads at session start) — the carve-out sanctions reading the target's plugin-mount `SKILL.md` as session-scoped recovery
- Three preconditions keep the typed call the sole authored invocation path; every other cross-skill reference stays a typed call
- Surfaced by jbaruch/jbaruch-travel-policy#24, where the policy reviewer correctly flagged the consumer's documented recovery as a violation with no sanctioned form and named a governing-rule carve-out as the remedy

## Test plan
- [x] Prose-only rule + CHANGELOG change — no scripts touched
- [x] No banned connectives in the added rule text (`rules/context-writing-style.md`)
- [x] Carve-out format: applies-when, numbered preconditions, one-line reset (`rules/context-writing-style.md` Structure)
- [x] Policy review (Codex) + Copilot on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSDZLTe7NYwrRtfcRdqn6v