### PR TITLE
fix(release): stamp-changelog falls back to manifest on Tessl auth failure (#207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### CI
+
+- **`stamp-changelog` falls back to the manifest version on a Tessl auth failure** — the action's `query_latest_version` hard-raised when `tessl plugin info` failed for any non-404 reason, so a consumer's publish-on-merge wedged at the stamp step with "requires you to be logged in" when that step ran without `setup-tessl` / `tessl login`. An auth failure is now non-fatal — it warns and returns `None`, so the manifest version (the one being published when kept ahead of the registry) is used; `patch-version-publish` still does its own authoritative bump. Genuine non-auth failures still raise. Fixes #207.
+
 ## 0.3.102 — 2026-07-21
 
 ### CI

--- a/skills/release/stamp-changelog.py
+++ b/skills/release/stamp-changelog.py
@@ -29,6 +29,7 @@ import argparse
 import json
 import re
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -94,7 +95,22 @@ def query_latest_version(plugin_name: str) -> str | None:
         capture_output=True, text=True,
     )
     if proc.returncode != 0:
-        if "404" in (proc.stdout + proc.stderr):
+        combined = proc.stdout + proc.stderr
+        if "404" in combined:
+            return None
+        # No Tessl auth reached this step — e.g. a consumer publish workflow that
+        # stamps without running setup-tessl / `tessl login` first. Fall back to
+        # the manifest version rather than wedging the publish: the manifest is the
+        # version being published when kept ahead of the registry (the standard
+        # convention), and patch-version-publish still does its own authoritative
+        # bump downstream. Genuine (non-auth) failures still raise.
+        if re.search(r"authenticat|log ?in|sign (?:in|up)", combined, re.IGNORECASE):
+            print(
+                f"warning: `tessl plugin info {plugin_name}` requires Tessl auth in "
+                "this step — falling back to the manifest version. Run setup-tessl "
+                "before the stamp step for an authoritative registry check.",
+                file=sys.stderr,
+            )
             return None
         raise RuntimeError(
             f"`tessl plugin info {plugin_name}` failed (exit {proc.returncode}): "

--- a/skills/release/stamp-changelog.py
+++ b/skills/release/stamp-changelog.py
@@ -84,11 +84,12 @@ def stamp_changelog(text: str, version: str, date: str) -> tuple[str, bool]:
 
 
 def query_latest_version(plugin_name: str) -> str | None:
-    """Return the registry's latest published version, or None on first publish.
+    """Return the registry's latest published version, or None if it can't be read.
 
-    Mirrors patch-version-publish's handling: a 404 means the plugin has never
-    been published; any other failure is surfaced so auth/network issues are not
-    masked.
+    Mirrors patch-version-publish's handling. Returns None in two cases so the
+    caller falls back to the manifest version: a 404 (the plugin has never been
+    published) and a Tessl auth failure (the stamp step ran without login — see
+    the caller). Any other failure (network, etc.) is surfaced so it is not masked.
     """
     proc = subprocess.run(
         ["tessl", "plugin", "info", plugin_name],

--- a/skills/release/tests/test_stamp_changelog.py
+++ b/skills/release/tests/test_stamp_changelog.py
@@ -2,7 +2,9 @@
 """Tests for skills/release/stamp-changelog.py — version computation and stamping."""
 
 import importlib.util
+import subprocess
 import unittest
+from unittest import mock
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parent.parent / "stamp-changelog.py"
@@ -50,6 +52,30 @@ class ComputeVersion(unittest.TestCase):
             stamp_changelog.compute_version("0.18", "0.18.7")
         with self.assertRaises(ValueError):
             stamp_changelog.compute_version("0.18.7", "vNext")
+
+
+class QueryLatestVersion(unittest.TestCase):
+    """query_latest_version degrades gracefully when the stamp step has no auth."""
+
+    def _run(self, returncode, stdout="", stderr=""):
+        cp = subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+        with mock.patch.object(stamp_changelog.subprocess, "run", return_value=cp):
+            return stamp_changelog.query_latest_version("jbaruch/x")
+
+    def test_success_parses_latest(self):
+        self.assertEqual(self._run(0, stdout="Name  x\nLatest Version  0.2.64\n"), "0.2.64")
+
+    def test_404_returns_none(self):
+        self.assertIsNone(self._run(1, stderr="request failed: HTTP 404"))
+
+    def test_auth_failure_returns_none(self):
+        # The regression: no auth in the stamp step must fall back, not raise (#207).
+        msg = "✘ Please authenticate with Tessl to continue. Run `tessl login` to sign up or log in."
+        self.assertIsNone(self._run(1, stderr=msg))
+
+    def test_non_auth_failure_still_raises(self):
+        with self.assertRaises(RuntimeError):
+            self._run(1, stderr="connection reset by peer")
 
 
 class StampChangelog(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #207 — a consumer's publish-on-merge wedges at the **Stamp CHANGELOG** step with `Please authenticate with Tessl to continue. Run tessl login`.

`query_latest_version()` shelled out to `tessl plugin info` and **hard-raised on any non-404 failure**, including auth rejection. Consumers whose publish workflow stamps without running `setup-tessl` / `tessl login` first (and now that `tessl plugin info` requires auth) hit this and the pipeline dies *before* publishing.

**Fix:** treat an **auth** failure as non-fatal — warn and return `None`, so `compute_version` falls back to the manifest version (which *is* the version being published when kept ahead of the registry, the standard convention; e.g. nanoclaw-travel's manifest is `0.2.65` vs published `0.2.64`). `tesslio/patch-version-publish` still performs its own authoritative bump downstream. Genuine (non-auth) failures still raise, and `coding-policy`'s own publish (which runs `setup-tessl` before stamp) is unaffected.

## Test plan
- [x] `scripts/run-tests.sh` — green; 4 new `query_latest_version` tests (success / 404 / auth-fallback / non-auth-raises)
- [x] `scripts/run-diagnostics.sh` — clean

Note: consumers still need to bump their `stamp-changelog@<digest>` pin to a digest that includes this fix (or the durable path is #206 — a reusable publish workflow that wires `setup-tessl` before stamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)