### PR TITLE
fix(release): recognize the fleet reviewer login on consumer repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Skills
+
+- **Release watcher recognizes the fleet reviewer on consumer repos** — `poll-pr-reviews.sh` resolved the policy reviewer only as `github-actions[bot]` (correct for coding-policy's own PRs), so on a consumer repo — where the central fleet App reviews as `coding-policy-fleet-reviewer[bot]` (#202) — `watch-pr-reviews.sh` saw `.reviews.codex.state` as `none` forever and sat at `pending_at_budget`. `latest_review_by` is now variadic and resolves the policy reviewer across both logins (a PR carries reviews from only one, so `last` in the set is unambiguous); the codex comment-login set gains the App login too. `SKILL.md` Step 5 and `dismiss-stale-reviews.sh` now note the consumer case: the fleet App CAN `APPROVE`, so its re-review supersedes its own `CHANGES_REQUESTED` directly and no dismissal is needed there. New tests cover the fleet-App review state, cross-login newest-verdict resolution, and the App comment count.
+
 ## 0.3.105 — 2026-07-21
 
 ### Rules

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -113,7 +113,7 @@ A `COMMENTED` review never gates the merge on its state alone — but its body m
 
 Once these conditions hold, merge automatically — the green gates are the approval. Do not pause to ask a human whether to merge.
 
-**Clear superseded review gates first.** The Codex policy reviewer posts as `github-actions[bot]`, which cannot `APPROVE` (GitHub returns HTTP 422), so a clean re-review lands as a `COMMENT` that does NOT supersede the bot's earlier `CHANGES_REQUESTED` in GitHub's merge gate — the stale request keeps `merge_state.status` at `BLOCKED`. Dismiss every such superseded review before merging:
+**Clear superseded review gates first.** This applies to coding-policy's OWN releases, where the policy reviewer posts as `github-actions[bot]`, which cannot `APPROVE` (GitHub returns HTTP 422), so a clean re-review lands as a `COMMENT` that does NOT supersede the bot's earlier `CHANGES_REQUESTED` — the stale request keeps `merge_state.status` at `BLOCKED`. On consumer repos the reviewer is the central fleet App `coding-policy-fleet-reviewer[bot]` (coding-policy#202), which CAN `APPROVE` and supersedes its own earlier `CHANGES_REQUESTED` directly — no dismissal needed there. Dismiss every superseded `github-actions[bot]` review before merging:
 
 ```bash
 skills/release/dismiss-stale-reviews.sh <owner> <repo> <pr-number>

--- a/skills/release/dismiss-stale-reviews.sh
+++ b/skills/release/dismiss-stale-reviews.sh
@@ -2,14 +2,20 @@
 # Dismiss a gating bot's CHANGES_REQUESTED review once the SAME bot has
 # posted a later non-CHANGES_REQUESTED verdict on the PR.
 #
-# Why this exists: the policy reviewer runs as `github-actions[bot]` (the
-# Codex CLI review workflow, review-codex.yml, submits with the workflow
-# token), which GitHub rejects APPROVE from with HTTP 422. A clean re-review is
-# therefore a COMMENT, and a later COMMENT never supersedes an earlier
-# CHANGES_REQUESTED in GitHub's merge-gating model — the stale
-# CHANGES_REQUESTED keeps blocking the merge until it is dismissed. The
+# Why this exists: on coding-policy's OWN PRs the policy reviewer runs as
+# `github-actions[bot]` (the Codex CLI review workflow, review-codex.yml,
+# submits with the workflow token), which GitHub rejects APPROVE from with HTTP
+# 422. A clean re-review is therefore a COMMENT, and a later COMMENT never
+# supersedes an earlier CHANGES_REQUESTED in GitHub's merge-gating model — the
+# stale CHANGES_REQUESTED keeps blocking the merge until it is dismissed. The
 # operator running the release skill dismisses it here. The decision is fully
 # deterministic, so it is a script, not agent judgment (rules/script-delegation.md).
+#
+# On consumer repos the reviewer is the central fleet App
+# `coding-policy-fleet-reviewer[bot]` (coding-policy#202), which CAN APPROVE, so
+# its re-approval supersedes its own earlier CHANGES_REQUESTED with no dismissal
+# needed. It is intentionally NOT in GATING_BOTS below — a bot that can approve
+# never needs its review dismissed.
 #
 # Decision, per gating bot (see GATING_BOTS below):
 #   - latest review state == CHANGES_REQUESTED => leave it; the bot is

--- a/skills/release/poll-pr-reviews.sh
+++ b/skills/release/poll-pr-reviews.sh
@@ -49,9 +49,11 @@ set -euo pipefail
 # GITHUB_TOKEN, so its author is `github-actions[bot]`; in every consumer repo as
 # the central fleet App (coding-policy#202), submitting as
 # `coding-policy-fleet-reviewer[bot]`. A given PR is reviewed by exactly one of
-# them, so resolving the policy reviewer across BOTH logins (latest review among
-# them) is unambiguous — and a watcher that only knew `github-actions[bot]` sat
-# blind at `none` on every consumer PR the fleet App reviewed.
+# them today, so the watcher must resolve the policy reviewer across BOTH logins
+# — one that only knew `github-actions[bot]` sat blind at `none` on every
+# consumer PR the fleet App reviewed. `latest_review_by` aggregates fail-safe
+# (each login's own latest, CHANGES_REQUESTED wins) so a hypothetical both-logins
+# PR can never mask an active block.
 #
 # Counting Copilot's comments against its REVIEW login matches nothing, so
 # `inline_comments.copilot` reads 0 on every PR — which vacuously satisfies the
@@ -74,10 +76,13 @@ COPILOT_COMMENT_LOGINS=("Copilot" "copilot-pull-request-reviewer[bot]")
 # every page into one array before filtering. `per_page=100` is the API
 # maximum and keeps request volume bounded.
 # Variadic on login so one reviewer's multiple identities collapse to a single
-# latest review — the policy reviewer is `github-actions[bot]` on coding-policy's
-# own PRs and `coding-policy-fleet-reviewer[bot]` on consumer repos (see the
-# login table above). A given PR carries reviews from only one of them, so `last`
-# after filtering to the set is that reviewer's newest verdict.
+# verdict — the policy reviewer is `github-actions[bot]` on coding-policy's own
+# PRs and `coding-policy-fleet-reviewer[bot]` on consumer repos (see the login
+# table above). A given PR carries reviews from only one of them today, but this
+# is a MERGE GATE: aggregate fail-safe rather than assume. Take each login's
+# OWN latest review, then if ANY of those is CHANGES_REQUESTED surface that
+# (an active block from one identity must never be masked by a later clean
+# review from another); otherwise surface the newest among them.
 latest_review_by() {
   local owner="$1" repo="$2" pr="$3"; shift 3
   local logins_json
@@ -87,7 +92,9 @@ latest_review_by() {
     | jq -s --argjson logins "$logins_json" '
         (add // [])
         | [.[] | select(.user.login | IN($logins[]))]
-        | last
+        | (group_by(.user.login) | map(last)) as $per_login_latest
+        | ( ($per_login_latest | map(select(.state == "CHANGES_REQUESTED")) | first)
+            // ($per_login_latest | sort_by(.submitted_at) | last) )
         | if . == null then {state: "none", submitted_at: null, body: null}
           else {state, submitted_at, body} end'
 }

--- a/skills/release/poll-pr-reviews.sh
+++ b/skills/release/poll-pr-reviews.sh
@@ -33,27 +33,35 @@
 set -euo pipefail
 
 # Bot logins, by surface. A reviewer does NOT necessarily author its reviews
-# and its inline comments under the same login:
+# and its inline comments under the same login, and the policy reviewer's login
+# depends on WHICH repo the PR is in:
 #
-#   surface          Codex policy reviewer   Copilot
-#   ---------------  ----------------------  --------------------------------
-#   review           github-actions[bot]     copilot-pull-request-reviewer[bot]
-#   inline comment   github-actions[bot]     Copilot
+#   surface          Policy reviewer                       Copilot
+#   ---------------  ------------------------------------  ----------------------------------
+#   review           github-actions[bot] (coding-policy's  copilot-pull-request-reviewer[bot]
+#                    own PRs) OR
+#                    coding-policy-fleet-reviewer[bot]
+#                    (consumer repos)
+#   inline comment   same login as its review              Copilot
 #
-# The Codex policy reviewer runs as a GitHub Actions workflow
-# (review-codex.yml, Codex CLI on a ChatGPT subscription) and submits its
-# review with the workflow's GITHUB_TOKEN, so its author is
-# `github-actions[bot]`.
+# The policy reviewer runs two ways: in coding-policy itself as a GitHub Actions
+# workflow (review-codex.yml, Codex CLI) submitting with the workflow's
+# GITHUB_TOKEN, so its author is `github-actions[bot]`; in every consumer repo as
+# the central fleet App (coding-policy#202), submitting as
+# `coding-policy-fleet-reviewer[bot]`. A given PR is reviewed by exactly one of
+# them, so resolving the policy reviewer across BOTH logins (latest review among
+# them) is unambiguous — and a watcher that only knew `github-actions[bot]` sat
+# blind at `none` on every consumer PR the fleet App reviewed.
 #
 # Counting Copilot's comments against its REVIEW login matches nothing, so
 # `inline_comments.copilot` reads 0 on every PR — which vacuously satisfies the
 # release skill's Step 7 "every inline comment has a reply" merge gate and lets
 # a real Copilot finding merge unanswered. Comment counting therefore matches a
 # SET of logins per reviewer. A comment carries exactly one author, so listing
-# both logins cannot double-count.
-CODEX_REVIEW_LOGIN="github-actions[bot]"
+# multiple logins cannot double-count.
+CODEX_REVIEW_LOGINS=("github-actions[bot]" "coding-policy-fleet-reviewer[bot]")
 COPILOT_REVIEW_LOGIN="copilot-pull-request-reviewer[bot]"
-CODEX_COMMENT_LOGINS=("github-actions[bot]")
+CODEX_COMMENT_LOGINS=("github-actions[bot]" "coding-policy-fleet-reviewer[bot]")
 COPILOT_COMMENT_LOGINS=("Copilot" "copilot-pull-request-reviewer[bot]")
 
 # `--paginate` is mandatory: GitHub's default per-page is 30, and a PR
@@ -65,12 +73,20 @@ COPILOT_COMMENT_LOGINS=("Copilot" "copilot-pull-request-reviewer[bot]")
 # pipe the raw paginated output through `jq -s 'add | ...'` to slurp
 # every page into one array before filtering. `per_page=100` is the API
 # maximum and keeps request volume bounded.
+# Variadic on login so one reviewer's multiple identities collapse to a single
+# latest review — the policy reviewer is `github-actions[bot]` on coding-policy's
+# own PRs and `coding-policy-fleet-reviewer[bot]` on consumer repos (see the
+# login table above). A given PR carries reviews from only one of them, so `last`
+# after filtering to the set is that reviewer's newest verdict.
 latest_review_by() {
-  local owner="$1" repo="$2" pr="$3" login="$4"
+  local owner="$1" repo="$2" pr="$3"; shift 3
+  local logins_json
+  logins_json=$(jq -n '$ARGS.positional' --args "$@") \
+    || { echo "error: failed to encode login list for review lookup" >&2; return 1; }
   gh api --paginate "repos/${owner}/${repo}/pulls/${pr}/reviews?per_page=100" \
-    | jq -s --arg login "$login" '
+    | jq -s --argjson logins "$logins_json" '
         (add // [])
-        | [.[] | select(.user.login == $login)]
+        | [.[] | select(.user.login | IN($logins[]))]
         | last
         | if . == null then {state: "none", submitted_at: null, body: null}
           else {state, submitted_at, body} end'
@@ -134,7 +150,7 @@ main() {
     || { echo "error: failed to fetch merge state for ${owner}/${repo}#${pr_number} — run 'gh auth status' to verify auth, then retry 'gh pr view ${pr_number} --repo ${owner}/${repo} --json mergeStateStatus,mergeable' to inspect the failing call directly" >&2; exit 1; }
 
   local codex_review copilot_review codex_comments copilot_comments
-  codex_review=$(latest_review_by   "$owner" "$repo" "$pr_number" "$CODEX_REVIEW_LOGIN") \
+  codex_review=$(latest_review_by   "$owner" "$repo" "$pr_number" "${CODEX_REVIEW_LOGINS[@]}") \
     || { echo "error: failed to fetch Codex review state" >&2; exit 1; }
   copilot_review=$(latest_review_by "$owner" "$repo" "$pr_number" "$COPILOT_REVIEW_LOGIN") \
     || { echo "error: failed to fetch Copilot review state" >&2; exit 1; }

--- a/skills/release/tests/test_poll_pr_reviews.sh
+++ b/skills/release/tests/test_poll_pr_reviews.sh
@@ -274,6 +274,44 @@ t_main_counts_copilot_comments_in_snapshot() {
   assert_eq "inline_comments {codex|copilot}" "2|1" "$counts"
 }
 
+# coding-policy#202: consumer PRs are reviewed by the central fleet App
+# `coding-policy-fleet-reviewer[bot]`, not `github-actions[bot]`. A watcher that
+# only knew the latter sat blind at `none` on every consumer PR. The policy
+# reviewer must resolve across BOTH logins.
+t_latest_review_by_resolves_fleet_app_login() {
+  MOCK_REVIEWS_BODY='[{"user":{"login":"coding-policy-fleet-reviewer[bot]"},"state":"APPROVED","submitted_at":"2026-07-21T05:15:00Z"}]'
+  local out state
+  out=$(latest_review_by "owner" "repo" "1" "${CODEX_REVIEW_LOGINS[@]}")
+  state=$(echo "$out" | jq -r '.state')
+  assert_eq "fleet-App review resolves to policy state" "APPROVED" "$state"
+}
+
+# Only one policy reviewer posts per PR, but resolving across both logins must
+# still return the newest verdict when (hypothetically) both appear.
+t_latest_review_by_policy_reviewer_picks_newest_across_logins() {
+  MOCK_REVIEWS_BODY='[{"user":{"login":"github-actions[bot]"},"state":"COMMENTED","submitted_at":"2026-07-21T05:00:00Z"},{"user":{"login":"coding-policy-fleet-reviewer[bot]"},"state":"CHANGES_REQUESTED","submitted_at":"2026-07-21T05:10:00Z"}]'
+  local out state
+  out=$(latest_review_by "owner" "repo" "1" "${CODEX_REVIEW_LOGINS[@]}")
+  state=$(echo "$out" | jq -r '.state')
+  assert_eq "newest policy verdict across both logins" "CHANGES_REQUESTED" "$state"
+}
+
+t_main_surfaces_fleet_app_review_as_codex() {
+  MOCK_MERGE_STATE=clean
+  MOCK_REVIEWS_BODY='[{"user":{"login":"coding-policy-fleet-reviewer[bot]"},"state":"APPROVED","submitted_at":"2026-07-21T05:15:00Z"}]'
+  local out state
+  out=$(main "owner" "repo" "1")
+  state=$(echo "$out" | jq -r '.reviews.codex.state')
+  assert_eq "fleet-App review surfaced as .reviews.codex.state" "APPROVED" "$state"
+}
+
+t_toplevel_comments_by_counts_fleet_app_login() {
+  MOCK_COMMENTS_BODY='[{"user":{"login":"coding-policy-fleet-reviewer[bot]"},"in_reply_to_id":null}]'
+  local count
+  count=$(toplevel_comments_by "owner" "repo" "1" "${CODEX_COMMENT_LOGINS[@]}")
+  assert_eq "fleet-App inline comment counted for policy reviewer" "1" "$count"
+}
+
 # --- driver ---
 
 echo "== poll-pr-reviews.sh tests =="
@@ -292,6 +330,10 @@ run "toplevel_comments_by counts the 'Copilot' comment login"         t_toplevel
 run "toplevel_comments_by matches either Copilot login"               t_toplevel_comments_by_matches_either_copilot_login
 run "toplevel_comments_by excludes replies and foreign logins"        t_toplevel_comments_by_excludes_replies_and_other_logins
 run "main counts Copilot comments in the snapshot"                    t_main_counts_copilot_comments_in_snapshot
+run "latest_review_by resolves the fleet App login (#202)"            t_latest_review_by_resolves_fleet_app_login
+run "latest_review_by picks newest policy verdict across logins"      t_latest_review_by_policy_reviewer_picks_newest_across_logins
+run "main surfaces the fleet App review as .reviews.codex"            t_main_surfaces_fleet_app_review_as_codex
+run "toplevel_comments_by counts the fleet App comment login"         t_toplevel_comments_by_counts_fleet_app_login
 
 echo "== summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed =="
 [[ "$FAIL_COUNT" -eq 0 ]]

--- a/skills/release/tests/test_poll_pr_reviews.sh
+++ b/skills/release/tests/test_poll_pr_reviews.sh
@@ -296,6 +296,18 @@ t_latest_review_by_policy_reviewer_picks_newest_across_logins() {
   assert_eq "newest policy verdict across both logins" "CHANGES_REQUESTED" "$state"
 }
 
+# Fail-safe: an active CHANGES_REQUESTED from one policy-reviewer identity must
+# NOT be masked by a LATER clean review from the other identity — a gating
+# watcher that surfaced the newest-overall would think the reviewer was clean
+# while GitHub still blocked the merge.
+t_latest_review_by_changes_requested_not_masked_by_later_other_login() {
+  MOCK_REVIEWS_BODY='[{"user":{"login":"github-actions[bot]"},"state":"CHANGES_REQUESTED","submitted_at":"2026-07-21T05:00:00Z"},{"user":{"login":"coding-policy-fleet-reviewer[bot]"},"state":"COMMENTED","submitted_at":"2026-07-21T05:10:00Z"}]'
+  local out state
+  out=$(latest_review_by "owner" "repo" "1" "${CODEX_REVIEW_LOGINS[@]}")
+  state=$(echo "$out" | jq -r '.state')
+  assert_eq "active block not masked by later clean review" "CHANGES_REQUESTED" "$state"
+}
+
 t_main_surfaces_fleet_app_review_as_codex() {
   MOCK_MERGE_STATE=clean
   MOCK_REVIEWS_BODY='[{"user":{"login":"coding-policy-fleet-reviewer[bot]"},"state":"APPROVED","submitted_at":"2026-07-21T05:15:00Z"}]'
@@ -332,6 +344,7 @@ run "toplevel_comments_by excludes replies and foreign logins"        t_toplevel
 run "main counts Copilot comments in the snapshot"                    t_main_counts_copilot_comments_in_snapshot
 run "latest_review_by resolves the fleet App login (#202)"            t_latest_review_by_resolves_fleet_app_login
 run "latest_review_by picks newest policy verdict across logins"      t_latest_review_by_policy_reviewer_picks_newest_across_logins
+run "latest_review_by never masks an active block with a later clean" t_latest_review_by_changes_requested_not_masked_by_later_other_login
 run "main surfaces the fleet App review as .reviews.codex"            t_main_surfaces_fleet_app_review_as_codex
 run "toplevel_comments_by counts the fleet App comment login"         t_toplevel_comments_by_counts_fleet_app_login
 


### PR DESCRIPTION
## Bug

The release-skill watcher went blind on consumer repos. `poll-pr-reviews.sh` resolved the policy reviewer's state only from `github-actions[bot]` — correct for coding-policy's **own** PRs (reviewed by `review-codex.yml`), but on every consumer repo the central fleet App reviews as `coding-policy-fleet-reviewer[bot]` (#202). So `watch-pr-reviews.sh` read `.reviews.codex.state` as `none` forever and sat at `pending_at_budget` until a human gated the merge by hand.

## Fix

- `latest_review_by` is now variadic (like `toplevel_comments_by`) and resolves the policy reviewer across **both** logins. A given PR carries reviews from only one of them, so `last` in the filtered set is unambiguously that reviewer's newest verdict.
- The codex comment-login set gains `coding-policy-fleet-reviewer[bot]` too.
- `SKILL.md` Step 5 and `dismiss-stale-reviews.sh` now note the consumer case: the fleet App **can** `APPROVE`, so its re-review supersedes its own `CHANGES_REQUESTED` directly — no dismissal needed there (it stays out of `GATING_BOTS`; a bot that can approve never needs its review dismissed).

## Tests

Added coverage for: the fleet-App review resolving to `.reviews.codex.state`, newest-verdict resolution across both policy logins, and the App's inline comments counting for the policy reviewer. All release suites green (poll 19, watch 14, dismiss 8), shellcheck clean.

Surfaced during the #206 fan-out — the watcher hit this on every consumer PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGeBDNcz72DVw61VTphuCm