### PR TITLE
feat(rules): add response-clarity rule for action-first agent responses

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,3 +23,4 @@ This repo IS `jbaruch/coding-policy`. The rule files below are the source-of-tru
 @../rules/boy-scout.md
 @../rules/external-repo-contributions.md
 @../rules/reviewer-feedback-reading.md
+@../rules/response-clarity.md

--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -30,6 +30,7 @@
     "rules/agent-worktree-isolation.md",
     "rules/boy-scout.md",
     "rules/external-repo-contributions.md",
-    "rules/reviewer-feedback-reading.md"
+    "rules/reviewer-feedback-reading.md",
+    "rules/response-clarity.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **New `response-clarity` rule — action-first agent responses** — adapts the ten output principles from [`ayghri/i-have-adhd`](https://github.com/ayghri/i-have-adhd) into an always-on steering rule for how agents shape their live responses to the user (distinct from `context-writing-style`, which governs written context artifacts). Lead with the command or answer, number multi-step work, one bounded action per item, cap unranked lists at 5, restate progress across turns, make wins concrete and verifiable, give concrete time ballparks, report errors matter-of-fact, close with one two-minute next step, no preamble or closers. Exceptions loosen the rules for requested explanations, destructive actions (add confirmation), debug spirals (ask one diagnostic question), and genuine ambiguity (ask one clarifying question).
+
 ## 0.3.106 — 2026-07-21
 
 ### Skills

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ tessl install jbaruch/coding-policy
 | Concurrency | [agent-worktree-isolation](rules/agent-worktree-isolation.md) | Mandatory git worktrees for concurrent agent work; cleanup; read-only exception |
 | Discipline | [boy-scout](rules/boy-scout.md) | Leave it better than you found it; "pre-existing" is not a valid concept; in-scope cleanups bundle, out-of-scope ones get filed |
 | Scope | [external-repo-contributions](rules/external-repo-contributions.md) | Default deny on issues, PRs, comments, reactions, and discussions in repos the operator does not own; explicit permission required per repo and action type |
+| Communication | [response-clarity](rules/response-clarity.md) | Shape responses action-first: lead with the command, number steps, show progress, plain errors, one concrete next step, no preamble or closers (exceptions for explanations, destructive actions, debug, ambiguity) |
 
 ### Skills
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Coding policy plugin for Baruch's AI agents. Language-agnostic code quality rule
 ## What's New
 
 - Policy review runs on the OpenAI Codex CLI authenticated by a ChatGPT subscription (no API key) via `.github/workflows/review-codex.yml`, reviewing every PR against the in-tree `rules/*.md`; Copilot stays as the complementary code-quality lane
-- 21 rules — 15 always-on, 6 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 10 covering code quality, 7 covering plugin authoring, 1 covering concurrency, 1 covering review discipline, 1 covering reviewer-feedback reading, 1 covering external-repo action scope
+- 22 rules — 16 always-on, 6 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 10 covering code quality, 7 covering plugin authoring, 1 covering concurrency, 1 covering review discipline, 1 covering reviewer-feedback reading, 1 covering external-repo action scope, 1 covering response communication
 - `release` skill — structured PR + merge workflow gated on the Codex policy review and Copilot code-quality review
 - `install-reviewer` skill — enroll a consumer repo in the central fleet policy reviewer (the `.github/fleet-review-enabled` marker + the Copilot lane); no per-repo workflow or secrets
 - `adopt-fork-pr` skill — bring a fork PR's branch into the base repo as a same-repo PR the reviewer can run on

--- a/rules/response-clarity.md
+++ b/rules/response-clarity.md
@@ -13,8 +13,10 @@ description: How agents shape their responses to the user — action-first, numb
 ## Lead With the Action
 
 - Open with the command, edit, or answer — never context, preamble, or restated question
-- Number multi-step work; one bounded action per item, no compound "and then" clause
-- Cap an unranked list at 5 items; split a longer one into "do now" and "later" tiers
+- Number multi-step work
+- Keep each numbered item to one bounded action, no compound "and then" clause
+- Cap an unranked list at 5 items
+- Split a longer list into "do now" and "later" tiers
 - Defer secondary issues — finish the primary problem, then offer the rest as separate follow-ups
 
 ## Show State and Progress
@@ -31,7 +33,8 @@ description: How agents shape their responses to the user — action-first, numb
 ## Close With One Next Step
 
 - End with one concrete action the user can take in two minutes or less
-- No recap, no pleasantries, no closer — end when the answer is done
+- No recap, no pleasantries, no closer
+- End when the answer is done
 
 ## Exceptions
 

--- a/rules/response-clarity.md
+++ b/rules/response-clarity.md
@@ -1,0 +1,41 @@
+---
+alwaysApply: true
+description: How agents shape their responses to the user — action-first, numbered, one next step, no preamble
+---
+
+# Response Clarity
+
+## Scope
+
+- Governs the agent's live responses to the user, not context artifacts (rules, skills, READMEs — those follow `rules/context-writing-style.md`)
+- Applies every turn, in every session
+
+## Lead With the Action
+
+- Open with the command, edit, or answer — never context, preamble, or restated question
+- Number multi-step work; one bounded action per item, no compound "and then" clause
+- Cap an unranked list at 5 items; split a longer one into "do now" and "later" tiers
+- Defer secondary issues — finish the primary problem, then offer the rest as separate follow-ups
+
+## Show State and Progress
+
+- Restate progress across turns: "Step 3 of 5 done: schema updated. Next: backfill the column"
+- Make a win concrete and verifiable — name what works and the command that shows it
+- Give a concrete time ballpark ("~15 minutes if tests exist"), never vague "some work"
+
+## Report Errors Plainly
+
+- State a failure matter-of-fact: what failed, where, expected versus actual
+- No softening, no apology spiral
+
+## Close With One Next Step
+
+- End with one concrete action the user can take in two minutes or less
+- No recap, no pleasantries, no closer — end when the answer is done
+
+## Exceptions
+
+- Explanation requested — give full detail, still no preamble
+- Destructive or irreversible action — add a confirmation step before running it
+- Debug spiral — ask one diagnostic question instead of guessing
+- Genuine ambiguity with no obvious default — ask one clarifying question, then proceed


### PR DESCRIPTION
## What

New always-on rule `rules/response-clarity.md` — adapts the ten output principles from [`ayghri/i-have-adhd`](https://github.com/ayghri/i-have-adhd) into a coding-policy steering rule for how agents shape their **live responses to the user**.

Deliberately distinct from `rules/context-writing-style.md`, which governs written **context artifacts** (rules, skills, READMEs). This one governs the conversation surface.

### The rule, in five sections
- **Lead With the Action** — open with the command/answer, number multi-step work, cap unranked lists at 5, defer secondary issues
- **Show State and Progress** — restate progress across turns, concrete verifiable wins, concrete time ballparks
- **Report Errors Plainly** — matter-of-fact, no apology spiral
- **Close With One Next Step** — one two-minute action, no recap/closer
- **Exceptions** — explanations, destructive actions (confirm), debug spirals (one diagnostic question), genuine ambiguity (one clarifying question)

## Surface sync
- `.tessl-plugin/plugin.json` — rule path added
- `.claude/CLAUDE.md` — maintainer import chain
- `README.md` — rules table (Communication row)
- `CHANGELOG.md` — un-headed `### Rules` block (stamp step adds the version heading)

## Verification
- `tessl plugin lint` → valid
- `bash scripts/run-tests.sh` → 20/20 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGeBDNcz72DVw61VTphuCm