### PR TITLE
fix(install-reviewer): skip Dependabot PRs in fleet-review trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Skills
+
+- **`install-reviewer` — fleet-review trigger skips Dependabot PRs** — the scaffolded `review-trigger.yml` guarded only fork PRs (`head.repo.full_name == github.repository`). Dependabot PRs are same-repo, so they passed that guard, but the `dependabot[bot]` actor receives no secrets — `FLEET_DISPATCH_TOKEN` came through empty and the workflow's own empty-token guard exited 1, leaving a permanent red check on every Dependabot PR. The job `if:` now also requires `github.actor != 'dependabot[bot]'`; the coding-policy cron poll reviews Dependabot PRs as the backstop. PR body template and the workflow header note the new skip.
+
 ## 0.3.107 — 2026-07-21
 
 ### Rules

--- a/skills/install-reviewer/PR_BODY_TEMPLATE.md
+++ b/skills/install-reviewer/PR_BODY_TEMPLATE.md
@@ -20,7 +20,7 @@ The fleet reviewer is the policy reviewer; Copilot is the code-quality reviewer.
 
 The Codex credential lives only in `jbaruch/coding-policy`. The consumer sets **one** repo secret so the trigger can reach it:
 
-- `FLEET_DISPATCH_TOKEN` — a **fine-grained PAT scoped to only `jbaruch/coding-policy`** with `Actions: write` (nothing else). It can trigger the review workflow and nothing more. Set it (Settings → Secrets and variables → Actions) before the first PR after merge, or the PR-time review won't fire (the poll backstop still would). Fork PRs are skipped — they can't read the secret; adopt them via the `adopt-fork-pr` skill.
+- `FLEET_DISPATCH_TOKEN` — a **fine-grained PAT scoped to only `jbaruch/coding-policy`** with `Actions: write` (nothing else). It can trigger the review workflow and nothing more. Set it (Settings → Secrets and variables → Actions) before the first PR after merge, or the PR-time review won't fire (the poll backstop still would). Fork PRs are skipped — they can't read the secret; adopt them via the `adopt-fork-pr` skill. Dependabot PRs are skipped too — the dependabot actor gets no secrets, so the poll backstop reviews them instead.
 
 ### 3. Load indicator (so the consumer can confirm policy actually loaded)
 

--- a/skills/install-reviewer/templates/review-trigger.yml
+++ b/skills/install-reviewer/templates/review-trigger.yml
@@ -4,6 +4,8 @@ name: Trigger fleet policy review
 # same-repo PR event this fires a single-PR review in coding-policy immediately,
 # so the policy verdict is available before merge (the coding-policy cron poll is
 # only a backstop). Fork PRs are skipped — they cannot read the dispatch secret.
+# Dependabot PRs are skipped too — the dependabot actor gets no secrets, so the
+# dispatch could never authenticate (the cron poll backstop still reviews them).
 #
 # Requires one repo secret (set it at
 # https://github.com/<owner>/<repo>/settings/secrets/actions for this repo):
@@ -24,7 +26,11 @@ concurrency:
 jobs:
   trigger:
     # Fork PRs cannot read secrets — skip them (adopt via the adopt-fork-pr skill).
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Dependabot's actor also gets no secrets, so its dispatch can't authenticate —
+    # skip it too (the coding-policy cron poll reviews dependabot PRs instead).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Dispatch the single-PR review to coding-policy


### PR DESCRIPTION
## Problem

The scaffolded `review-trigger.yml` (from `skills/install-reviewer/`) guarded only **fork** PRs via `head.repo.full_name == github.repository`. Dependabot PRs are same-repo, so they sailed past that guard — but the `dependabot[bot]` actor receives **no secrets**, so `FLEET_DISPATCH_TOKEN` arrives empty and the workflow's own empty-token guard exits 1. Result: a **permanent red check** on every Dependabot PR. The cron sweep already covers policy review for those PRs, so the trigger's failure is pure noise.

## Fix

One-line actor gate ANDed onto the existing job `if:`:

```yaml
if: >-
  github.event.pull_request.head.repo.full_name == github.repository &&
  github.actor != 'dependabot[bot]'
```

The coding-policy cron poll reviews Dependabot PRs as the backstop.

## Scope
- `templates/review-trigger.yml` — the job gate + header comment
- `PR_BODY_TEMPLATE.md` — notes the new skip alongside the fork skip
- `CHANGELOG.md`

Existing consumers pick this up on their next `install-reviewer --override` upgrade.

## Verification
- YAML parses; `if:` folds to the single-line expression
- `tessl plugin lint` → valid
- `bash scripts/run-tests.sh` → 20/20 suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGeBDNcz72DVw61VTphuCm