### PR TITLE
chore(release): bump manifest to 0.3.112 past the blocked 0.3.111 ghost

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/coding-policy",
-  "version": "0.3.111",
+  "version": "0.3.112",
   "description": "General-purpose coding policy for Baruch's AI agents",
   "private": false,
   "skills": [


### PR DESCRIPTION
## Why

`0.3.111` published (via #221) but was **moderation-blocked**, reserving that version number on the registry (registry Latest is still `0.3.110`). The publish pipeline's `patch-version-publish` sees the manifest (`0.3.111`) ahead of registry and tries to publish it as-is → **`0.3.111 already exists`** collision (per the `coding_policy_0373` ghost-version pattern).

## Fix

Explicit manifest bump to **`0.3.112`**, past the ghost. The reframed `install-reviewer` prose (#222) + the frontmatter-length fix (#223) are already on main, so `0.3.112` carries them — and publishing it **re-runs the tile moderation review**, which is the real test of whether the reframe clears the block.

- `tessl plugin lint` → valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGeBDNcz72DVw61VTphuCm