### PR TITLE
ci: add tessl plugin lint as a PR-time gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,19 @@
 name: Tests
 
-# Two gates on every PR (and on direct pushes to main):
+# Three gates on every PR (and on direct pushes to main):
 #   1. diagnostics — shellcheck over every first-party shell script and
 #      pyright over the first-party Python, at zero findings
 #      (rules/language-diagnostics.md). Runs first: static checks are fast
 #      and cheap, so style/type regressions block before the suites run
 #      (rules/code-formatting.md CI Integration).
-#   2. unit-tests — every module's bash unit suite via scripts/run-tests.sh
+#   2. lint — `tessl plugin lint` (manifest + skill-frontmatter + structure
+#      validation). Pre-merge so a bad manifest or frontmatter (e.g. an
+#      over-length skill `description`) is caught here, not only when it
+#      breaks publish.yml's first step after merge.
+#   3. unit-tests — every module's bash unit suite via scripts/run-tests.sh
 #      (rules/testing-standards.md). Gated on diagnostics passing.
-# publish.yml reruns both before release as defense-in-depth.
+# publish.yml reruns lint + diagnostics + the suites before release as
+# defense-in-depth.
 on:
   pull_request:
   push:
@@ -26,6 +31,16 @@ jobs:
       - uses: ./.github/actions/setup-diagnostics
       - name: Run language-diagnostics gate
         run: bash scripts/run-diagnostics.sh
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: tesslio/setup-tessl@v2
+        with:
+          token: ${{ secrets.TESSL_TOKEN }}
+      - name: Lint plugin
+        run: tessl plugin lint
 
   unit-tests:
     needs: diagnostics

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: tessl plugin lint
 
   unit-tests:
-    needs: diagnostics
+    needs: [diagnostics, lint]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### CI
+
+- **PR-time `tessl plugin lint` gate** — `tests.yml` gains a `lint` job running `tessl plugin lint` on every PR, alongside `diagnostics` and `unit-tests`. Previously lint ran only in `publish.yml` (post-merge), so a bad manifest or skill frontmatter — e.g. an over-length `description` — passed PR review and merged, then failed the publish pipeline's first step (seen during the 0.3.112 recovery). Now it's caught before merge.
+
 ### Skills
 
 - **`install-reviewer` wording made plain and factual** — the skill's prose (SKILL.md, `PR_BODY_TEMPLATE.md`, the `review-trigger.yml` template header, and the `.env.example` block scaffold.sh writes) now describes each file and the review's data flow in plain, minimal terms — what runs, where, and when — without dwelling on repository permissions or trust boundaries. Behavior is unchanged and the `no-secrets` documentation (settings URL + placeholder) is preserved; the plainer wording keeps the registry's automated review of the published tile clear.


### PR DESCRIPTION
## Why

`tessl plugin lint` ran **only in `publish.yml`** (post-merge). So a bad manifest or skill frontmatter passed PR review, merged, and only failed the publish pipeline's **first step** — exactly what happened during the `0.3.112` recovery, when an over-length `install-reviewer` `description` (>1024 chars) sailed through PR CI and broke publish.

## What

`tests.yml` gains a **`lint`** job running `tessl plugin lint` on every PR, parallel to `diagnostics` and `unit-tests`. Uses `tesslio/setup-tessl@v2` + `TESSL_TOKEN` (same setup as `publish.yml`; lint is local validation, so no `id-token`/publish permissions needed).

CI-scoped change (the PR is the approval artifact per `ci-safety`).

## Verify
- `tests.yml` YAML parses (jobs: `diagnostics`, `lint`, `unit-tests`)
- The new `lint` job itself is the real check — I'll watch it run green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGeBDNcz72DVw61VTphuCm