### PR TITLE
chore(review-severity): fold in deferred advisory nits

### DIFF
--- a/.github/codex-review/tests/test_post_review.sh
+++ b/.github/codex-review/tests/test_post_review.sh
@@ -51,7 +51,12 @@ t_pass() {
   [[ "$(jq -r .event <<<"$out")" == "APPROVE" ]]             || { bad "pass: event APPROVE (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .findings <<<"$out")" == "0" ]]                 || { bad "pass: findings 0 (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .event "$GH_CAPTURE")" == "APPROVE" ]]         || { bad "pass: payload event APPROVE"; rm -rf "$dir"; return; }
-  jq -r .body "$GH_CAPTURE" | grep -qE "^Policy loaded: [0-9]+ rule files" || { bad "pass: body begins with the load indicator"; rm -rf "$dir"; return; }
+  # Assert the WHOLE body begins with the load indicator (schema contract), not
+  # merely that some line within it does — `grep -E "^..."` anchors per line, so
+  # a preamble before the summary would pass it. `[[ =~ ]]` anchors the whole string.
+  local body indicator_re='^Policy loaded: [0-9]+ rule files'
+  body=$(jq -r .body "$GH_CAPTURE")
+  [[ "$body" =~ $indicator_re ]]                              || { bad "pass: body begins with the load indicator"; rm -rf "$dir"; return; }
   ok "no findings -> APPROVE, summary body, 0 findings"
   rm -rf "$dir"
 }

--- a/.github/codex-review/tests/test_post_review.sh
+++ b/.github/codex-review/tests/test_post_review.sh
@@ -51,9 +51,11 @@ t_pass() {
   [[ "$(jq -r .event <<<"$out")" == "APPROVE" ]]             || { bad "pass: event APPROVE (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .findings <<<"$out")" == "0" ]]                 || { bad "pass: findings 0 (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .event "$GH_CAPTURE")" == "APPROVE" ]]         || { bad "pass: payload event APPROVE"; rm -rf "$dir"; return; }
-  # Assert the WHOLE body begins with the load indicator (schema contract), not
-  # merely that some line within it does — `grep -E "^..."` anchors per line, so
-  # a preamble before the summary would pass it. `[[ =~ ]]` anchors the whole string.
+  # Assert the body begins with the load indicator (schema contract), not merely
+  # that some line within it does — `grep -E "^..."` anchors per line, so a
+  # preamble line before the summary would pass it. Here `=~` matches against the
+  # whole body string (not line by line), so the pattern's leading `^` anchors to
+  # the body's start.
   local body indicator_re='^Policy loaded: [0-9]+ rule files'
   body=$(jq -r .body "$GH_CAPTURE")
   [[ "$body" =~ $indicator_re ]]                              || { bad "pass: body begins with the load indicator"; rm -rf "$dir"; return; }

--- a/.github/codex-review/tests/test_post_review.sh
+++ b/.github/codex-review/tests/test_post_review.sh
@@ -51,7 +51,7 @@ t_pass() {
   [[ "$(jq -r .event <<<"$out")" == "APPROVE" ]]             || { bad "pass: event APPROVE (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .findings <<<"$out")" == "0" ]]                 || { bad "pass: findings 0 (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .event "$GH_CAPTURE")" == "APPROVE" ]]         || { bad "pass: payload event APPROVE"; rm -rf "$dir"; return; }
-  jq -r .body "$GH_CAPTURE" | grep -q "Policy loaded: 23"     || { bad "pass: body carries the load indicator"; rm -rf "$dir"; return; }
+  jq -r .body "$GH_CAPTURE" | grep -qE "Policy loaded: [0-9]+ rule files" || { bad "pass: body carries the load indicator"; rm -rf "$dir"; return; }
   ok "no findings -> APPROVE, summary body, 0 findings"
   rm -rf "$dir"
 }

--- a/.github/codex-review/tests/test_post_review.sh
+++ b/.github/codex-review/tests/test_post_review.sh
@@ -51,7 +51,7 @@ t_pass() {
   [[ "$(jq -r .event <<<"$out")" == "APPROVE" ]]             || { bad "pass: event APPROVE (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .findings <<<"$out")" == "0" ]]                 || { bad "pass: findings 0 (got $out)"; rm -rf "$dir"; return; }
   [[ "$(jq -r .event "$GH_CAPTURE")" == "APPROVE" ]]         || { bad "pass: payload event APPROVE"; rm -rf "$dir"; return; }
-  jq -r .body "$GH_CAPTURE" | grep -qE "Policy loaded: [0-9]+ rule files" || { bad "pass: body carries the load indicator"; rm -rf "$dir"; return; }
+  jq -r .body "$GH_CAPTURE" | grep -qE "^Policy loaded: [0-9]+ rule files" || { bad "pass: body begins with the load indicator"; rm -rf "$dir"; return; }
   ok "no findings -> APPROVE, summary body, 0 findings"
   rm -rf "$dir"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **`review-severity` — atomic-bullet cleanup** (closes #231) — folds in the advisory findings deferred from #230: the Gating Predicate's watcher/Copilot bullet and the Split-Reading-From-Acting acknowledge/fold/defer bullet each split into one-directive-per-bullet per `context-writing-style` Structure. Also drops the `test_post_review.sh` load-indicator assertion's hardcoded rule count for a `Policy loaded: [0-9]+ rule files` pattern so it no longer churns when rules are added or removed. Prose and behavior unchanged.
+
 ## 0.3.116 — 2026-07-23
 
 ### Rules

--- a/rules/review-severity.md
+++ b/rules/review-severity.md
@@ -31,11 +31,14 @@ description: Review findings carry a severity — blocking gates the merge, advi
 - Any blocking finding present → the reviewer posts `CHANGES_REQUESTED` and the merge gates
 - Only advisory findings → the reviewer posts `COMMENTED` and the merge is allowed
 - The policy reviewer's posted state already encodes this — the event is derived from per-finding severity (see `.github/codex-review/post-review.sh` header)
-- The merge watcher gates on the policy reviewer's `CHANGES_REQUESTED` alone; Copilot never gates (see `skills/release/watch-pr-reviews.sh` header)
+- The merge watcher gates on the policy reviewer's `CHANGES_REQUESTED` alone (see `skills/release/watch-pr-reviews.sh` header)
+- Copilot never gates
 
 ## Split Reading From Acting
 
 - Read every finding in full first — severity never licenses skipping a body (see `rules/reviewer-feedback-reading.md`)
 - Blocking → fix before merge
-- Advisory → acknowledge; fold in only when a blocking round is already happening, else defer to a follow-up (see `rules/boy-scout.md`)
+- Advisory → acknowledge
+- Fold an advisory in only when a blocking round is already happening
+- Otherwise defer the advisory to a follow-up (see `rules/boy-scout.md`)
 - Never burn a dedicated re-review round on a lone advisory


### PR DESCRIPTION
## Summary
Folds in the advisory findings deferred from #230 (closes #231). All presentation-only, prose/behavior unchanged:
- `rules/review-severity.md` — split two multi-directive bullets (Gating Predicate watcher/Copilot; Split-Reading-From-Acting acknowledge/fold/defer) into one-directive-per-bullet per `context-writing-style` Structure.
- `.github/codex-review/tests/test_post_review.sh` — the load-indicator assertion now matches `Policy loaded: [0-9]+ rule files` instead of a hardcoded count, so it stops churning when rules are added or removed.

These are exactly the lone advisories the severity split keeps out of the merge gate — batched into one focused cleanup PR.

## Test plan
- [x] `bash scripts/run-tests.sh` — all suites pass
- [x] `bash scripts/run-diagnostics.sh` — shellcheck + pyright clean
- [x] `tessl plugin lint` — valid