### PR TITLE
chore(boy-scout): scope to self-noticed issues; decouple from reviewers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **`boy-scout` scoped to self-noticed issues; decoupled from reviewer findings** — boy-scout was being read as a lever to fold a reviewer's advisory into the current round ("in-scope cleanup on a line I'm touching"), which fought `review-severity`'s "defer a lone advisory, never burn a dedicated round" — the #232 cleanup ran four review rounds partly on that tension. Boy-scout now states its trigger is the agent's own eyes: a reviewer's stated findings are `review-severity`'s domain — blocking gets fixed, a lone advisory gets deferred, never folded in under a boy-scout in-scope claim. Dropped boy-scout's bridging bullet about deferred review advisories, and dropped `review-severity`'s reverse `see rules/boy-scout.md` pointer on its defer bullet (it now names the follow-up mechanism directly), so neither rule reaches into the other's domain.
+
 ## 0.3.117 — 2026-07-24
 
 ### Rules

--- a/rules/boy-scout.md
+++ b/rules/boy-scout.md
@@ -9,13 +9,14 @@ alwaysApply: true
 - Leave the codebase in better shape than you found it. If you see something wrong while doing something else, fix it
 - "Pre-existing" is not a valid concept. The state you observed is the state you own, regardless of who or what put it there
 - Applies to anything you'd flag if a colleague had just written it: failing tests, broken docs, dead code, stale comments, lying type signatures, leaked secrets, missing newlines, unbumped versions
+- The trigger is your own eyes — issues you spot while working. A reviewer's stated findings are not boy-scout's domain
+- Acting on a reviewer's finding is `rules/review-severity.md`: a blocking finding gets fixed, a lone advisory gets deferred — never folded into the current round under a boy-scout in-scope claim
 
 ## How to Apply
 
 - **In-scope cleanups** (typo, missing newline, broken doc link, small drift): roll into the current PR. The bundle is fine when the PR's stated scope still reads coherently
 - **Out-of-scope discoveries** (untested module, contradicting rules, unrelated security gap): open a follow-up PR — or an issue if the fix needs design — and reference it from the current one. Walking away with no record is the failure mode this rule prevents
 - When unsure whether to bundle or split, prefer **bundle small + cite** or **split large + file**. The wrong answer is "leave it"
-- A review advisory deferred to a follow-up per `rules/review-severity.md` takes the filed-record path — a deferred advisory is not "walking away"
 
 ## Reconciliation With `commit-conventions`
 

--- a/rules/review-severity.md
+++ b/rules/review-severity.md
@@ -40,5 +40,5 @@ description: Review findings carry a severity — blocking gates the merge, advi
 - Blocking → fix before merge
 - Advisory → acknowledge
 - Fold an advisory in only when a blocking round is already happening
-- Otherwise defer the advisory to a follow-up (see `rules/boy-scout.md`)
+- Otherwise defer the advisory to a follow-up PR or issue and reference it from the current PR
 - Never burn a dedicated re-review round on a lone advisory


### PR DESCRIPTION
## Summary
`boy-scout` was being read as a lever to fold a reviewer's advisory into the current round ("in-scope cleanup on a line I'm touching"), which fights `review-severity`'s "defer a lone advisory, never burn a dedicated round." That tension drove extra review rounds on #232.

- `rules/boy-scout.md` — its trigger is now explicitly the agent's own eyes; a reviewer's stated findings are `review-severity`'s domain (blocking → fix, lone advisory → defer, never folded in under a boy-scout in-scope claim). Dropped the bridging bullet about deferred review advisories.
- `rules/review-severity.md` — the defer bullet names the follow-up mechanism directly instead of pointing back at `boy-scout`, so neither rule reaches into the other's domain.

No behavior change to scripts or the review pipeline — this is a rule-boundary cleanup.

## Test plan
- [x] `tessl plugin lint` — valid
- [x] no banned connectives in either edited rule
- [x] post-edit audit: no live surface still couples boy-scout to reviewer feedback