### PR TITLE
chore(boy-scout): reframe around round economics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **`boy-scout` reframed around round economics, not reviewer-domain exclusion** — the 0.3.118 framing (below) over-corrected: it scoped reviewer findings out of boy-scout entirely. Boy-scouting a reviewer's finding is fine; the real constraint is the cost of an extra review round, not the finding's source. Boy-scout now carries a "Fold Into a Round Already in Flight" section: the cost unit is the extra round, not the extra line — when a blocking finding forces another push, clean up the adjacent loose ends in that same round (free); when the change is already mergeable, merge and file the loose ends to the next ticket rather than pushing a commit only to fold them in. Points to `rules/review-severity.md` as the review-pipeline form of the same economics. Restores reviewer findings as valid boy-scout targets, dropping the "not boy-scout's domain" bullets.
+
 ## 0.3.118 — 2026-07-24
 
 ### Rules

--- a/rules/boy-scout.md
+++ b/rules/boy-scout.md
@@ -9,14 +9,20 @@ alwaysApply: true
 - Leave the codebase in better shape than you found it. If you see something wrong while doing something else, fix it
 - "Pre-existing" is not a valid concept. The state you observed is the state you own, regardless of who or what put it there
 - Applies to anything you'd flag if a colleague had just written it: failing tests, broken docs, dead code, stale comments, lying type signatures, leaked secrets, missing newlines, unbumped versions
-- The trigger is your own eyes — issues you spot while working. A reviewer's stated findings are not boy-scout's domain
-- Acting on a reviewer's finding is `rules/review-severity.md`: a blocking finding gets fixed, a lone advisory gets deferred — never folded into the current round under a boy-scout in-scope claim
+- Reviewer findings are fair game too — folding a reviewer's advisory in is boy-scouting, subject to the timing rule below
 
 ## How to Apply
 
 - **In-scope cleanups** (typo, missing newline, broken doc link, small drift): roll into the current PR. The bundle is fine when the PR's stated scope still reads coherently
 - **Out-of-scope discoveries** (untested module, contradicting rules, unrelated security gap): open a follow-up PR — or an issue if the fix needs design — and reference it from the current one. Walking away with no record is the failure mode this rule prevents
 - When unsure whether to bundle or split, prefer **bundle small + cite** or **split large + file**. The wrong answer is "leave it"
+
+## Fold Into a Round Already in Flight
+
+- The cost unit is the extra round, not the extra line. Fold loose ends into work that is already happening; do not spin a fresh round up just to boy-scout
+- A blocking finding is forcing another push: clean up the adjacent loose ends in that same round — folding them in there is free
+- The change is already mergeable: merge and file the loose ends to the next ticket rather than pushing another commit only to fold them in
+- The review-pipeline form of this economics is `rules/review-severity.md` — fold an advisory in when a blocking round is already happening, else defer
 
 ## Reconciliation With `commit-conventions`
 


### PR DESCRIPTION
## Summary
The 0.3.118 boy-scout edit over-corrected — it scoped reviewer findings out of boy-scout entirely. Boy-scouting a reviewer's finding is fine; the real constraint is the **cost of an extra review round**, not where the finding came from.

- `rules/boy-scout.md` — new **"Fold Into a Round Already in Flight"** section: the cost unit is the extra round, not the extra line. When a blocking finding forces another push, fold the adjacent loose ends into that same round (free). When the change is already mergeable, merge and file the loose ends to the next ticket rather than pushing a commit only to fold them in. Points to `review-severity` as the review-pipeline form of the same economics.
- Restores "reviewer findings are fair game" and removes the "not boy-scout's domain" bullets.

Removes the `boy-scout.md:13` bullet that #234 tracked → **closes #234** (its target no longer exists).

## Test plan
- [x] `tessl plugin lint` — valid
- [x] no banned connectives
- [x] post-edit audit: boy-scout ↔ review-severity now agree (one-directional reference, no duplicated predicate)

Closes #234.