### PR TITLE
feat(rules): add the adversarial-freshness dependency carve-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Rule — dependency-management: adversarial-freshness carve-out
+
+`dependency-management` had exactly two carve-outs, both structural: a manifest a tool rewrites at runtime, and a same-repo action self-reference. Neither covers a dependency that floats for a *semantic* reason — where tracking the upstream IS the feature.
+
+Surfaced on `jbaruch/nanoclaw` PR #883. Its `fetch_markdown` handler pulls `syabro/snitchmd:latest`, a headless-browser content extractor whose releases carry updated CloakBrowser fingerprints. Pinning it doesn't stabilize anything: the pin ages into blocked fetches as anti-bot detection advances, and the failure is silent — pages come back empty, not broken. The consuming repo wrote an authority-of-record rule plus a deploy gate (`nanoclaw-host: snitchmd-image-floating`), but the reviewer correctly rejected it, because a consumer plugin cannot mint an exception this rule never offered. The carve-out has to exist here or it doesn't exist.
+
+Preconditions are deliberately tighter than the manifest carve-out's. Beyond the authority-of-record rule and the deploy gate, the gate must fail when it can no longer *find* the reference — a rename or refactor that moves the target out of sight is the obvious way this decays into a check that passes vacuously forever. The per-install override is required rather than optional, so reproducibility stays reachable without a code change, and is explicitly out of the gate's scope: environment configuration is not a committed dependency.
+
+Three anti-patterns are bulleted rather than left implied, since this is the carve-out most likely to be reached for in bad faith: "the upstream releases often" (that's Freshness), "pinning is inconvenient", and any dependency whose consumed surface is a versioned API however adversarial its domain.
+
 ## 0.3.121 — 2026-07-27
 
 ### Skills

--- a/rules/dependency-management.md
+++ b/rules/dependency-management.md
@@ -40,6 +40,22 @@ alwaysApply: true
 - Multiple covered manifests permitted iff each independently meets all three preconditions
 - Every other manifest in the repo still pins
 
+## Adversarial-Freshness Dependency Carve-Out
+
+- Narrow exception for a dependency whose value is tracking an adversary, not a version
+- Applies when the upstream ships countermeasures against an actively-adapting opponent (browser-fingerprint evasion, malware signatures, threat feeds, blocklists) AND the consumed surface is data or rendered output, not a versioned API contract
+- A pin degrades the capability rather than stabilizing it: the pin's renewal cadence competes with the adversary's release cadence, and staleness surfaces as silent capability loss, never as a build break
+- The reference MAY use a floating specifier (e.g., a `:latest` container tag) and skip the lock file
+- Preconditions (each covered reference, all required):
+  1. The project documents an authority-of-record rule in its own plugin naming every covered reference, the adversary being tracked, and why a pin degrades rather than stabilizes
+  2. A deploy-time check fails the deployment when the committed reference is anything other than the permitted floating form, and fails when it can no longer locate the reference (a moved or renamed target fails loudly, never passes vacuously)
+  3. The check runs as a deterministic script per `rules/script-delegation.md`, not agent judgment
+  4. A per-install override lets an operator pin for reproducibility, documented in the authority-of-record rule and explicitly outside the deploy check's scope — environment configuration is not a committed dependency
+- "The upstream releases often" does NOT qualify — Freshness already covers a fast-moving pin
+- "Pinning is inconvenient" does NOT qualify
+- A dependency whose consumed surface is a versioned API does NOT qualify, however adversarial its domain
+- Every other dependency in the repo still pins with a stated renewal mechanism
+
 ## Same-Repo Reusable-Workflow Action Carve-Out
 
 - Narrow exception for a reusable workflow (`on: workflow_call`) referencing a composite action in its OWN repository

--- a/rules/dependency-management.md
+++ b/rules/dependency-management.md
@@ -45,15 +45,16 @@ alwaysApply: true
 - Narrow exception for a dependency whose value is tracking an adversary, not a version
 - Applies when the upstream ships countermeasures against an actively-adapting opponent (browser-fingerprint evasion, malware signatures, threat feeds, blocklists) AND the consumed surface is data or rendered output, not a versioned API contract
 - A pin degrades the capability rather than stabilizing it: the pin's renewal cadence competes with the adversary's release cadence, and staleness surfaces as silent capability loss, never as a build break
-- The reference MAY use a floating specifier (e.g., a `:latest` container tag) and skip the lock file
+- The covered reference MAY use a floating specifier (e.g., a `:latest` container tag)
+- The exemption reaches that reference alone — never the project's lock file, and never a sibling dependency in the same manifest
 - Preconditions (each covered reference, all required):
   1. The project documents an authority-of-record rule in its own plugin naming every covered reference, the adversary being tracked, and why a pin degrades rather than stabilizes
   2. A deploy-time check fails the deployment when the committed reference is anything other than the permitted floating form, and fails when it can no longer locate the reference (a moved or renamed target fails loudly, never passes vacuously)
   3. The check runs as a deterministic script per `rules/script-delegation.md`, not agent judgment
   4. A per-install override lets an operator pin for reproducibility, documented in the authority-of-record rule and explicitly outside the deploy check's scope — environment configuration is not a committed dependency
-- "The upstream releases often" does NOT qualify — Freshness already covers a fast-moving pin
+- "The upstream releases often" does NOT qualify. See Freshness
 - "Pinning is inconvenient" does NOT qualify
-- A dependency whose consumed surface is a versioned API does NOT qualify, however adversarial its domain
+- A dependency whose consumed surface is a versioned API does NOT qualify in an adversarial domain
 - Every other dependency in the repo still pins with a stated renewal mechanism
 
 ## Same-Repo Reusable-Workflow Action Carve-Out


### PR DESCRIPTION
## Summary

`dependency-management` has two carve-outs today, and both are *structural*: a manifest a tool rewrites at runtime, and a same-repo action self-reference. Neither covers a dependency that floats for a **semantic** reason — one where tracking the upstream is the whole point.

Surfaced on [jbaruch/nanoclaw#883](https://github.com/jbaruch/nanoclaw/pull/883). That repo's `fetch_markdown` handler pulls `syabro/snitchmd:latest`, a headless-browser content extractor whose releases carry updated CloakBrowser fingerprints. Pinning it stabilizes nothing — the pin ages into *blocked fetches* as anti-bot detection advances, and the failure mode is silent: pages come back empty, not broken. Nobody gets a build error telling them the pin went stale.

The consuming repo did the honest thing first — authority-of-record rule plus a deploy gate ([nanoclaw-host#42](https://github.com/jbaruch/nanoclaw-host/pull/42)) — and the reviewer **correctly rejected it**, because a consumer plugin can't mint an exception this rule never offered. Either the carve-out exists here or it doesn't exist. Hence this PR.

## Why the preconditions are tighter than the manifest carve-out's

Two additions worth calling out:

- **The gate must fail when it can't find the reference.** A rename or refactor that moves the target out of the check's sight is the obvious way this decays into a check that passes vacuously forever, which is worse than no check — it reads as enforcement.
- **The per-install override is required, not optional.** Reproducibility has to stay reachable without a code change. It's explicitly outside the gate's scope: environment configuration is not a committed dependency.

## Anti-patterns bulleted, not implied

This is the carve-out most likely to be reached for in bad faith, so the three obvious abuses are named directly: "the upstream releases often" (that's Freshness, not this), "pinning is inconvenient", and any dependency whose consumed surface is a versioned API however adversarial its domain.

## Surface sync

Rule body + CHANGELOG. No manifest or README table change — this extends an existing rule rather than adding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfN1npq8DeoLtqFKSHwJfv