### PR TITLE
feat(rules): add always-on ship-on-green merge-autonomy rule (#187)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,4 +23,6 @@ This repo IS `jbaruch/coding-policy`. The rule files below are the source-of-tru
 @../rules/boy-scout.md
 @../rules/external-repo-contributions.md
 @../rules/reviewer-feedback-reading.md
+@../rules/review-severity.md
 @../rules/response-clarity.md
+@../rules/ship-on-green.md

--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -32,6 +32,7 @@
     "rules/external-repo-contributions.md",
     "rules/reviewer-feedback-reading.md",
     "rules/review-severity.md",
-    "rules/response-clarity.md"
+    "rules/response-clarity.md",
+    "rules/ship-on-green.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Rules
+
+- **`ship-on-green` — new always-on rule; merge-autonomy contract** (closes #187) — the "green gate ⇒ merge, don't ask" contract lived only in `skills/release/SKILL.md`, so an agent that ran the flow by hand (`gh pr create` → watch → `gh pr merge`) without invoking `/release` never loaded it — the exact failure in `jbaruch/nanoclaw-trusted#80`, where a green PR was flagged for permission anyway. Extracted into an always-on rule so every merge decision loads it regardless of skill invocation. It carries: the green gate IS the approval (flag / confirm / "say go and I'll" / "worth one confirmation" are asking in a costume, and asking IS the decision to not ship); stakes raise care, not permission (scary / wide / ships-to-prod / deletes-a-thing ⇒ verify harder, never ask); and the three exhaustive, objective exits, each with a literal test — **Red** (a required check failing/pending, not "I feel uneasy"), **No undo** (`git revert` can't restore it — force-push over protected history, immutable published artifact, deleted data, sent external comms; a supersedable version bump is undoable and shipping to prod is NOT "no undo"), **Murky** (the task's own source states 2+ conflicting options AND names no default; a named default is never murky). `SKILL.md` Step 7 now references the rule instead of restating it.
+- **Fixed `.claude/CLAUDE.md` import drift** — `review-severity` (added 0.3.116) was in `.tessl-plugin/plugin.json` and the README but never added to the maintainer `.claude/CLAUDE.md` @-import chain, so the maintainer session didn't load it. Added it alongside the new `ship-on-green` import.
+
 ## 0.3.123 — 2026-07-27
 
 ### CI

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Coding policy plugin for Baruch's AI agents. Language-agnostic code quality rule
 ## What's New
 
 - Policy review runs on the OpenAI Codex CLI authenticated by a ChatGPT subscription (no API key) via `.github/workflows/review-codex.yml`, reviewing every PR against the in-tree `rules/*.md`; Copilot stays as the complementary code-quality lane
-- 23 rules — 17 always-on, 6 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 10 covering code quality, 7 covering plugin authoring, 1 covering concurrency, 1 covering review discipline, 1 covering reviewer-feedback reading, 1 covering review severity, 1 covering external-repo action scope, 1 covering response communication
+- 24 rules — 18 always-on, 6 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 10 covering code quality, 7 covering plugin authoring, 1 covering concurrency, 1 covering review discipline, 1 covering reviewer-feedback reading, 1 covering review severity, 1 covering external-repo action scope, 1 covering response communication, 1 covering merge/ship autonomy
 - `release` skill — structured PR + merge workflow gated on the Codex policy review's blocking findings; Copilot is the complementary code-quality lane and is always advisory
 - `install-reviewer` skill — enroll a consumer repo in the central fleet policy reviewer (the `.github/fleet-review-enabled` marker + the Copilot lane); no per-repo workflow or secrets
 - `adopt-fork-pr` skill — bring a fork PR's branch into the base repo as a same-repo PR the reviewer can run on
@@ -49,6 +49,7 @@ tessl install jbaruch/coding-policy
 | Discipline | [boy-scout](rules/boy-scout.md) | Leave it better than you found it; "pre-existing" is not a valid concept; in-scope cleanups bundle, out-of-scope ones get filed |
 | Scope | [external-repo-contributions](rules/external-repo-contributions.md) | Default deny on issues, PRs, comments, reactions, and discussions in repos the operator does not own; explicit permission required per repo and action type |
 | Communication | [response-clarity](rules/response-clarity.md) | Shape responses action-first: lead with the command, number steps, show progress, plain errors, one concrete next step, no preamble or closers (exceptions for explanations, destructive actions, debug, ambiguity) |
+| Discipline | [ship-on-green](rules/ship-on-green.md) | Green gate is the approval — merge, never ask; asking in a costume (flag/confirm/"say go") is deciding not to ship; stakes raise care not permission; three objective exits only — Red / No undo / Murky |
 
 ### Skills
 

--- a/rules/ship-on-green.md
+++ b/rules/ship-on-green.md
@@ -1,0 +1,29 @@
+---
+alwaysApply: true
+---
+
+# Ship on Green
+
+## Green Gate Is the Approval
+
+- Required checks green and no exit below holding ⇒ merge. The green gates ARE the approval; do not pause to ask a human whether to merge
+- Flag, confirm, "say go and I'll", "worth one confirmation", "want me to?" are asking in a costume — each resolves to asking, and asking IS the decision to not ship
+- Governs every merge, whether or not `skills/release` was invoked — an agent running the flow by hand is bound identically
+
+## Stakes Raise Care, Not Permission
+
+- Scary, wide-reaching, always-on, ships-to-prod, deletes-a-thing ⇒ verify harder — more tests, tighter review, a pristine-checkout lint
+- A change being high-impact is never itself an exit — stakes buy care, never permission
+
+## The Three Exits Are Exhaustive
+
+- Merge is blocked only by one of these three, each with a literal test — no fourth exit, no vibe word:
+- **Red** — a required check is failing or pending. Not "I feel uneasy"
+- **No undo** — `git revert` cannot restore it: force-push over protected history, an immutable published artifact, deleted data, sent external comms. A supersedable version bump is undoable; shipping to prod is NOT "no undo"
+- **Murky** — the task's own source states 2+ conflicting options AND names no default. Source names a default ⇒ take it, never murky
+
+## Relationship to Other Rules
+
+- `skills/release/SKILL.md` Step 7 references this rule for the merge decision rather than restating it
+- The release contract's watch and verify steps (`rules/ci-safety.md`) feed the Red test; they add no fourth exit
+- Advisory findings never gate (`rules/review-severity.md`), so an unaddressed advisory does not make a gate Red

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -118,7 +118,7 @@ Only proceed when:
 
 A `COMMENTED` review never gates the merge on its state alone — but its body must be read before merge, zero inline comments included. With inline comments, it is mergeable once every thread also has a reply. Advisory findings (the reviewer's `## Advisory findings` section, and every Copilot comment) do not block the merge — acknowledge them and defer per `rules/review-severity.md`; only a blocking finding gates.
 
-Once these conditions hold, merge automatically — the green gates are the approval. Do not pause to ask a human whether to merge.
+Once these conditions hold, merge automatically per `rules/ship-on-green.md` — the green gates are the approval, stakes raise care not permission, and the only blocks are its three objective exits (Red / No undo / Murky). Do not pause to ask a human whether to merge.
 
 **Clear superseded review gates first.** This applies to coding-policy's OWN releases, where the policy reviewer posts as `github-actions[bot]`, which cannot `APPROVE` (GitHub returns HTTP 422), so a clean re-review lands as a `COMMENT` that does NOT supersede the bot's earlier `CHANGES_REQUESTED` — the stale request keeps `merge_state.status` at `BLOCKED`. On consumer repos the reviewer is the central fleet App `coding-policy-fleet-reviewer[bot]` (coding-policy#202), which CAN `APPROVE` and supersedes its own earlier `CHANGES_REQUESTED` directly — no dismissal needed there. Dismiss every superseded `github-actions[bot]` review before merging:
 


### PR DESCRIPTION
Closes #187.

The "green gate ⇒ merge, don't ask" contract lived **only** in `skills/release/SKILL.md:116`, so an agent that ran the flow by hand (`gh pr create` → watch → `gh pr merge`) without invoking `/release` never loaded it. That's exactly what happened in `jbaruch/nanoclaw-trusted#80` — a fully-green PR got flagged for permission anyway, and the directive that would have prevented it was never in context because the skill was never invoked.

## New rule: `rules/ship-on-green.md` (`alwaysApply: true`)
Loads on every merge decision, skill or no skill:
- **Green gate is the approval** — merge, don't ask. Flag / confirm / "say go and I'll" / "worth one confirmation" / "want me to?" are asking in a costume; asking IS the decision not to ship.
- **Stakes raise care, not permission** — scary / wide-reaching / ships-to-prod / deletes-a-thing ⇒ verify harder, never ask. High impact is never itself an exit.
- **Three exhaustive, objective exits**, each with a literal test:
  - **Red** — a required check failing or pending. Not "I feel uneasy."
  - **No undo** — `git revert` can't restore it (force-push over protected history, immutable published artifact, deleted data, sent external comms). A supersedable version bump is undoable; shipping to prod is NOT "no undo".
  - **Murky** — the task's own source states 2+ conflicting options AND names no default. A named default is never murky.

## Surface sync
- `SKILL.md` Step 7 references the rule instead of restating it.
- `.tessl-plugin/plugin.json`, README rules table + counts (23→24, 17→18 always-on).
- `.claude/CLAUDE.md` import added.

## Boy-scout
Fixed a pre-existing drift: `review-severity` (added 0.3.116) was in `plugin.json` and the README but never in the `.claude/CLAUDE.md` @-import chain, so the maintainer session wasn't loading it. Added alongside the new import.

Note: the operator's personal `~/.claude/CLAUDE.md` carries a caveman-form `Ship.` bullet with the same three exits; per the issue it can now defer to this rule as canonical (operator's call — their personal config, not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GummAyubViVFrn5TVEUWEi