### PR TITLE
docs(ci-safety): a reviewer's run conclusion is not proof of review (#185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **`ci-safety` — a reviewer's run conclusion is not proof the review happened** (closes #185) — during GitHub's 2026-07-16 REST degradation, a scaffolded reviewer workflow reported `completed success` while skipping the review entirely: a transient 503 in gh-aw's membership check collapsed "can't determine membership" into the same falsy value as "not a member", so every downstream job skipped and the run went green having reviewed nothing. Nothing merged unreviewed only because `watch-pr-reviews.sh` gates on the posted verdict, not the run's color. `ci-safety` now states that invariant explicitly — a run `conclusion` answers "did the workflow finish", never "did the review happen"; gate on the verdict — plus a caution against promoting a reviewer check to a required branch-protection gate while any fail-open path exists (required-and-green is satisfied by a run that did nothing). The upstream fail-open belongs in `githubnext/gh-aw` and consumers have since migrated off the per-repo gh-aw reviewer to the central fleet App, but the invariant is mechanism-agnostic and load-bearing for anyone merging by hand.
+
 ## 0.3.124 — 2026-07-27
 
 ### Rules

--- a/rules/ci-safety.md
+++ b/rules/ci-safety.md
@@ -75,6 +75,8 @@ alwaysApply: true
 - Never wrap a watch in an invented wall-clock `timeout` — no blanket minute count exists in this policy to cite; a watcher gives up only at its own documented budget
 - Watch only the fields the gate reads. For PR reviews that is each gating bot's latest review state resolved by bot login, CI status, and merge state — not the appearance of inline comments, and not a hand-picked run / comment / check id
 - A bot review is complete when its verdict posts (state leaves `none`), zero inline comments included — never wait for comments to appear
+- A reviewer workflow's run `conclusion` is not evidence a review happened — only the posted verdict is. A gate that fails open (a 503 in a membership check, a suppressed job) reports `success` having reviewed nothing, so a green check answers "did the workflow finish", never "did the review happen"; gate on the verdict, never on the check's color
+- Do not promote a reviewer's check to a required branch-protection gate while a fail-open path exists — required-and-green is satisfied by a run that did nothing, turning a stale green into merge authorization
 - The pre-merge review watch has an agent-executable form — `skills/release/watch-pr-reviews.sh` (see `skills/release/SKILL.md` Step 5); it owns the interval and budget and watches exactly the gate fields above
 - For plugin/package releases, the duty extends past merge — confirm the resolved run's conclusion, the registry advance, and the moderation clear; no single signal is authoritative
 - Release contract:


### PR DESCRIPTION
Closes #185.

During GitHub's 2026-07-16 REST degradation, a scaffolded reviewer workflow reported `completed success` while **skipping the review entirely** — a transient 503 in gh-aw's membership check collapsed "can't determine membership" into the same falsy value as "not a member", so every downstream job skipped and the run went green having reviewed nothing. Nothing merged unreviewed only because `watch-pr-reviews.sh` gates on the **posted verdict**, not the run's color — which is the whole point.

## Change
Two bullets in `ci-safety.md` "Always Watch CI", making the invariant explicit rather than leaving it implicit in "watch the fields the gate reads":
- A reviewer workflow's run `conclusion` is not evidence a review happened — only the posted verdict is. A fail-open gate reports `success` having reviewed nothing; gate on the verdict, never the check's color.
- Do not promote a reviewer check to a required branch-protection gate while a fail-open path exists — required-and-green is satisfied by a run that did nothing.

## Scope
- The **upstream** fix (gh-aw distinguishing "denied" from "undeterminable") belongs in `githubnext/gh-aw` — an external repo, so filing it needs explicit operator authorization (not done here).
- Consumers have since migrated off the per-repo gh-aw reviewer to the central fleet App (#202), reducing the specific exposure, but the invariant is mechanism-agnostic and load-bearing for anyone merging by hand.

Rule-prose only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GummAyubViVFrn5TVEUWEi