### PR TITLE
docs(language-diagnostics): resolve the in-loop-vs-gate tension (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Rules
+
+- **`language-diagnostics` — the in-loop expectation is a deterministic run, not memory** (closes #175) — the rule told the agent to "read diagnostics on the files it touches and clear them before handing work off" (Enable the Language Server) while also holding that "'don't ignore the warnings' enforced by memory is not a gate — a deterministic check nobody runs does not exist" (Gate It Deterministically). Those two contradicted: the in-loop clause rested on the memory the gate clause disqualified. Resolved by pointing the pre-handoff expectation at the same headless gate CI runs — the `LSP` tool surfaces findings live as the agent works, and clearing before handoff is a deterministic run of the gate over the changed set, with CI as the backstop rather than the first place a finding surfaces. A `Stop`/pre-handoff hook mechanizes it where the harness supports it. Silent-dismissal mechanical detection (a gate that rejects a bare blanket-ignore) and a wired hook are noted as optional follow-ons, not built here.
+
 ## 0.3.125 — 2026-07-27
 
 ### Rules

--- a/rules/language-diagnostics.md
+++ b/rules/language-diagnostics.md
@@ -7,7 +7,8 @@ alwaysApply: true
 ## Enable the Language Server
 
 - Every project turns on the diagnostics engine appropriate to its language — pyright/pylance for Python, tsserver/tsc for TypeScript, rust-analyzer/clippy for Rust, gopls/`go vet` for Go, and the like
-- Enable it in-editor for the human and in-loop for the agent — Claude Code and other coding CLIs expose the language server (the `LSP` tool here), so the agent reads diagnostics on the files it touches and clears them before handing work off
+- Enable it in-editor for the human and in-loop for the agent — Claude Code and other coding CLIs expose the language server (the `LSP` tool here), so the agent reads diagnostics on the files it touches as it works
+- Clearing findings before handoff is a deterministic run, not a remembered intention — see Gate It Deterministically
 - Configure the engine for the project's module layout so references resolve (see Resolve Modules First)
 - Use whatever engine the project already has — don't introduce a second one without consensus
 
@@ -23,6 +24,9 @@ alwaysApply: true
 - CI runs the engine's headless/CLI form — pyright CLI, `tsc --noEmit`, `clippy`, `go vet` — as a gate at zero findings
 - The language server is the editor surface; the gate runs the same engine in batch mode, before tests, alongside format/lint (see `rules/code-formatting.md` CI Integration)
 - "Don't ignore the warnings" enforced by an agent's or contributor's memory is not a gate — a deterministic check nobody runs does not exist (see `rules/script-delegation.md`)
+- The in-loop expectation resolves to the same deterministic run: before handing work off, the agent runs the headless gate over what it changed and clears every finding. The `LSP` tool surfaces findings live; the pre-handoff run makes "cleared before handoff" a checkable event
+- The pre-handoff run and the CI gate are the same command at two times — CI is the backstop, never the first place a finding surfaces
+- A `Stop` or pre-handoff hook running the gate on the changed set mechanizes the pre-handoff run where the harness supports it
 
 ## Resolve Modules First
 


### PR DESCRIPTION
Closes #175.

`language-diagnostics` contained an internal contradiction:
- **Enable the Language Server** told the agent to "read diagnostics on the files it touches and clear them before handing work off" — in-loop discipline.
- **Gate It Deterministically** said "'don't ignore the warnings' enforced by memory is not a gate — a deterministic check nobody runs does not exist."

The in-loop clause rested on exactly the memory the gate clause disqualified, so the only real backstop was the post-push CI gate.

## Resolution (the issue's direction B)
Point the pre-handoff expectation at the **same headless gate CI runs**, not at memory:
- The `LSP` tool surfaces findings live as the agent works (editor/in-loop surface).
- Clearing before handoff is a **deterministic run** of the gate over the changed set — the pre-handoff run makes "cleared before handoff" a checkable event.
- The pre-handoff run and the CI gate are the same command at two times; CI is the backstop, never the first place a finding surfaces.
- A `Stop`/pre-handoff hook mechanizes the pre-handoff run where the harness supports it.

## Not built here (noted as optional follow-ons)
- Mechanical silent-dismissal detection (a gate that rejects a bare blanket-ignore with no adjacent cause) — the rule forbids blanket ignores but a grep-gate to catch them is a separate change.
- A wired `Stop` hook in this repo's `.claude/settings.json` — environment/config, not plugin content.

Rule-prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GummAyubViVFrn5TVEUWEi