### PR TITLE
fix(reviewer): resolve the reviewed repo's own plugins

### DIFF
--- a/.github/codex-review/fleet-prompt.md
+++ b/.github/codex-review/fleet-prompt.md
@@ -7,15 +7,22 @@ Do this:
 
 1. List and read every file under `.tessl/plugins/jbaruch/coding-policy/rules/`. Read them
    fully. Remember how many rule files you read — you surface that count in the `summary`.
-2. Also read any `skills/*/SKILL.md` in this repo that governs a changed path, and check it
+2. Several rules carve out exceptions that a repo satisfies by documenting an
+   "authority-of-record rule in its own plugin". Those plugins are installed alongside the
+   policy, so before reporting such a carve-out as undocumented, list
+   `.tessl/plugins/*/*/rules/` and read the authority rule there. Never conclude a rule is
+   absent from a `grep` of the repo's own tree — plugin rules are installed, never
+   committed, so they are never in the tree by design. If the rule is genuinely missing
+   from every installed plugin, say which plugin you expected it in.
+3. Also read any `skills/*/SKILL.md` in this repo that governs a changed path, and check it
    against the installed `skill-authoring` rule.
-3. Review the changes on this pull request — run the `git diff` named above (and
+4. Review the changes on this pull request — run the `git diff` named above (and
    `git log`/`git show` as needed) to see exactly what changed.
-4. For every changed line, check it against every rule. Flag concrete violations only:
+5. For every changed line, check it against every rule. Flag concrete violations only:
    secrets, missing error handling, formatting, dependency hygiene, `ci-safety`, `no-secrets`,
    `testing-standards`, and the rest.
-5. Minor style preferences that no rule covers are NOT grounds for a finding.
-6. Assign each finding a `severity` per the `review-severity` rule:
+6. Minor style preferences that no rule covers are NOT grounds for a finding.
+7. Assign each finding a `severity` per the `review-severity` rule:
    - `blocking` — fixing it changes behavior or closes a contract gap: correctness, security,
      a carve-out's unmet preconditions, `no-secrets`, `ci-safety` gate-evasion, surface-sync
      that breaks publish, a rule directive whose violation changes agent behavior, or a style

--- a/.github/codex-review/fleet-review-one.sh
+++ b/.github/codex-review/fleet-review-one.sh
@@ -107,6 +107,17 @@ main() {
   # tip.
   local base_manifest
   if base_manifest=$(cd "$work" && git show "origin/${base}:tessl.json" 2>/dev/null); then
+    # Capture the dependency list in an explicitly checked assignment, NOT via
+    # process substitution: `while read < <(jq ...)` discards jq's exit status,
+    # so a malformed tessl.json would yield an empty list and the review would
+    # proceed with no authority plugins installed — silently reproducing the
+    # exact wrong-verdict bug this step exists to fix
+    # (rules/error-handling.md Shell Error Handling).
+    local deps
+    if ! deps=$(printf '%s' "$base_manifest" | jq -r '.dependencies // {} | keys[]'); then
+      echo "error: could not parse dependencies from ${full}:${base}/tessl.json — refusing to review with an unknown plugin set" >&2
+      exit 1
+    fi
     local dep
     while IFS= read -r dep; do
       [ -n "$dep" ] || continue
@@ -119,7 +130,7 @@ main() {
         # how a reviewer blocks a compliant PR without saying why.
         echo "::warning::could not install ${dep} for ${full}#${pr} — carve-outs citing its rules cannot be verified this run" >&2
       fi
-    done < <(printf '%s' "$base_manifest" | jq -r '.dependencies // {} | keys[]')
+    done <<< "$deps"
   else
     echo "note: ${full} has no tessl.json on ${base} — reviewing against coding-policy alone" >&2
   fi

--- a/.github/codex-review/fleet-review-one.sh
+++ b/.github/codex-review/fleet-review-one.sh
@@ -91,6 +91,38 @@ main() {
   POLICY=$(mktemp -d) || { echo "error: mktemp -d failed (policy)" >&2; exit 1; }
   ( cd "$POLICY" && tessl install jbaruch/coding-policy >/dev/null ) \
     || { echo "error: tessl install jbaruch/coding-policy failed for ${full}#${pr}" >&2; exit 1; }
+
+  # Also install the reviewed repo's OWN plugins, because several
+  # coding-policy carve-outs (dependency-management's Runtime-Managed
+  # Manifest and Adversarial-Freshness, ci-safety's Content-Only
+  # Direct-Push) are satisfied by an "authority-of-record rule in its own
+  # plugin" — and with only coding-policy installed, the reviewer cannot
+  # resolve a single one of them. It then reports the rule as absent and
+  # blocks a PR whose carve-out is fully documented, which is what
+  # happened on jbaruch/nanoclaw#883.
+  #
+  # Resolved from the BASE ref's manifest, never the PR head's: the head
+  # is the content under review, so reading it would let a PR name a
+  # plugin that authorizes the PR. The base is the repo's own trusted
+  # tip.
+  local base_manifest
+  if base_manifest=$(cd "$work" && git show "origin/${base}:tessl.json" 2>/dev/null); then
+    local dep
+    while IFS= read -r dep; do
+      [ -n "$dep" ] || continue
+      # coding-policy is already installed above at its own latest.
+      [ "$dep" = "jbaruch/coding-policy" ] && continue
+      if ! ( cd "$POLICY" && tessl install "$dep" >/dev/null 2>&1 ); then
+        # Best-effort per `rules/error-handling.md` Graceful Fallback: a
+        # private or unpublished plugin must not fail the whole review,
+        # but it MUST be visible — a silently missing authority rule is
+        # how a reviewer blocks a compliant PR without saying why.
+        echo "::warning::could not install ${dep} for ${full}#${pr} — carve-outs citing its rules cannot be verified this run" >&2
+      fi
+    done < <(printf '%s' "$base_manifest" | jq -r '.dependencies // {} | keys[]')
+  else
+    echo "note: ${full} has no tessl.json on ${base} — reviewing against coding-policy alone" >&2
+  fi
   ln -s "${POLICY}/.tessl" "${work}/.tessl" \
     || { echo "error: could not link the installed policy into the workspace for ${full}#${pr}" >&2; exit 1; }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### Fleet reviewer — resolve the reviewed repo's own plugins (closes #245)
+
+The fleet reviewer installed `jbaruch/coding-policy` into a temp dir and symlinked it in as the reviewed workspace's entire `.tessl`. The consumer's own plugins were never installed — so `.tessl/plugins/` held exactly one plugin, and every carve-out satisfied by an "authority-of-record rule in its own plugin" was unverifiable. That covers `dependency-management`'s Runtime-Managed Manifest and Adversarial-Freshness carve-outs and `ci-safety`'s Content-Only Direct-Push: three carve-outs the reviewer structurally could not confirm, for as long as the fleet reviewer has existed.
+
+The failure mode is worse than a missed check. On `jbaruch/nanoclaw#883` the reviewer recognized the Adversarial-Freshness carve-out, went looking for the authority rule, `rg`'d the repo's own tree, found nothing, and blocked — reporting a fully-documented carve-out as undocumented. The rule was published in `jbaruch/nanoclaw-host` 0.1.53 the whole time. Plugin rules are installed, never committed (No Vendoring), so grepping the tree can only ever come back empty.
+
+`fleet-review-one.sh` now also installs the plugins named in the reviewed repo's manifest. Resolved from the BASE ref, never the PR head: the head is the content under review, so reading it would let a PR name a plugin that authorizes the PR. A plugin that fails to install emits a `::warning::` naming it rather than failing the review — best-effort, but never silent, since an invisibly-missing authority rule is exactly how this bug blocked a compliant PR.
+
+`fleet-prompt.md` gains the matching instruction: read `.tessl/plugins/*/*/rules/` before reporting a carve-out as undocumented, never conclude a rule is absent from a grep of the repo's tree, and name the plugin you expected it in when it genuinely is missing.
+
 ## 0.3.126 — 2026-07-27
 
 ### Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The failure mode is worse than a missed check. On `jbaruch/nanoclaw#883` the rev
 
 `fleet-review-one.sh` now also installs the plugins named in the reviewed repo's manifest. Resolved from the BASE ref, never the PR head: the head is the content under review, so reading it would let a PR name a plugin that authorizes the PR. A plugin that fails to install emits a `::warning::` naming it rather than failing the review — best-effort, but never silent, since an invisibly-missing authority rule is exactly how this bug blocked a compliant PR.
 
+The dependency list is captured in an explicitly checked assignment rather than read through process substitution: `while read < <(jq ...)` discards jq's exit status, so a malformed `tessl.json` would yield an empty list and the review would proceed with no authority plugins installed — silently reproducing the exact wrong-verdict bug the step exists to fix. A parse failure now aborts the review.
+
 `fleet-prompt.md` gains the matching instruction: read `.tessl/plugins/*/*/rules/` before reporting a carve-out as undocumented, never conclude a rule is absent from a grep of the repo's tree, and name the plugin you expected it in when it genuinely is missing.
 
 ## 0.3.126 — 2026-07-27


### PR DESCRIPTION
## Summary

Closes #245.

`fleet-review-one.sh` installs `jbaruch/coding-policy` into a temp dir and symlinks it in as the reviewed workspace's **entire** `.tessl`. The consumer's own plugins are never installed — so `.tessl/plugins/` contains exactly one plugin, and every carve-out that a repo satisfies by documenting an *"authority-of-record rule in its own plugin"* is unverifiable.

That's three of them:

- `dependency-management` → Runtime-Managed Manifest Carve-Out
- `dependency-management` → Adversarial-Freshness Dependency Carve-Out
- `ci-safety` → Content-Only Direct-Push Carve-Out

The reviewer has never been able to confirm any of them.

## The failure mode is worse than a missed check

On [jbaruch/nanoclaw#883](https://github.com/jbaruch/nanoclaw/pull/883) the reviewer did everything right up to the last step: recognized the Adversarial-Freshness carve-out, went looking for the authority-of-record rule, `rg`'d the repo's own tree, found nothing, and blocked — reporting a fully-documented carve-out as undocumented.

The rule was published in `jbaruch/nanoclaw-host` **0.1.53** the entire time. And `rg` was never going to find it: plugin rules are installed, never committed (No Vendoring), so grepping the consumer's tree comes back empty *by design*. A reviewer that treats "not in the tree" as "does not exist" will reject every correctly-documented carve-out it ever meets.

## Fix

`fleet-review-one.sh` also installs the plugins named in the reviewed repo's manifest.

**Resolved from the BASE ref, never the PR head.** The head is the content under review — reading it would let a PR name a plugin that authorizes the PR. The base is the repo's own trusted tip.

**A plugin that fails to install emits a `::warning::` naming it, rather than failing the review.** Best-effort, but never silent: an invisibly-missing authority rule is exactly how this bug blocked a compliant PR, and repeating that failure quietly would be the worst of both worlds.

`fleet-prompt.md` gains the matching instruction — read `.tessl/plugins/*/*/rules/` before reporting a carve-out as undocumented, never conclude a rule is absent from a grep of the repo's tree, and name the plugin you expected it in when it genuinely is missing. Steps renumbered.

## Test plan

- [x] `bash -n` on the modified script.
- [ ] End-to-end verification is the next review this workflow runs — nanoclaw#883 is the live case: it should stop reporting `snitchmd-image-floating` as absent once `jbaruch/nanoclaw-host` is installed alongside the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfN1npq8DeoLtqFKSHwJfv
