### PR TITLE
feat(rules): add noise-word hygiene to response-clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-### Rules — Pre-Send Check in response-clarity
+### Rules — noise-word hygiene in response-clarity
 
-New `Pre-Send Check` section in `response-clarity` adding a final self-audit pass: cut noise-hedges, keep real-uncertainty hedges, replace idioms with the literal action, and verify the first line names the next action and the last line names what changed.
+`Lead With the Action` in `response-clarity` gains three prose-hygiene directives: cut hedging adverbs that carry no uncertainty, keep a hedge that carries real uncertainty, replace idioms with the literal action.
 
 The prompt: comparing rules-only behavior against `ayghri/i-have-adhd`'s opt-in skill, which duplicates our ten response-shaping directives, the skill still visibly changed output when invoked. If `response-clarity` is `alwaysApply: true`, why would an invoked skill that says the same things behave differently? Three mechanisms: position (the always-on rule sits buried among ~25 siblings thousands of tokens back, the skill invocation lands fresh right before the turn), salience (an explicit `/i-have-adhd` invocation is a "do this now" spike, an always-on rule is passive background), and richness (the skill kept Bad/Good example pairs and a Pre-send checklist our compression discipline had stripped). `alwaysApply: true` is not the same as reliably-applied.
 
-The active ingredient was the skill's Pre-send checklist — a mechanized audit, not a passive directive. Most of it already lived in our rule (an announcing first sentence is Lead With the Action, an "anything else?" closer is Close With One Next Step, a by-the-way sidebar is Defer secondary), so only the non-duplicative items landed to keep clear of `context-writing-style`'s no-duplication rule: the two new deletions and the verify gate. We did not vendor the skill — it is a separate MIT plugin, and copying it would violate `dependency-management` No Vendoring; anyone wanting the toggle installs it alongside.
+The finding narrowed under review. Most of the skill's Pre-send checklist already lived in our rule (an announcing first sentence is Lead With the Action, an "anything else?" closer is Close With One Next Step, a by-the-way sidebar is Defer secondary), so restating it would violate `context-writing-style`'s no-duplication rule. The checklist's first-line/last-line verify gate was worse than duplicative — it contradicted `Close With One Next Step` (last line is the next action, not a recap of what changed), so it was dropped: a verify gate re-checks directives the rule already states and has no non-duplicative form here. The only portable, net-new rule content was the two deletions (noise-hedges, idioms), folded into the existing `Lead With the Action` section rather than a new one to stay within the section budget. We did not vendor the skill — it is a separate MIT plugin, and copying it would violate `dependency-management` No Vendoring; anyone wanting the toggle installs it alongside.
 
 ## 0.3.129 — 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Rules — Pre-Send Check in response-clarity
+
+New `Pre-Send Check` section in `response-clarity` adding a final self-audit pass: cut noise-hedges, keep real-uncertainty hedges, replace idioms with the literal action, and verify the first line names the next action and the last line names what changed.
+
+The prompt: comparing rules-only behavior against `ayghri/i-have-adhd`'s opt-in skill, which duplicates our ten response-shaping directives, the skill still visibly changed output when invoked. If `response-clarity` is `alwaysApply: true`, why would an invoked skill that says the same things behave differently? Three mechanisms: position (the always-on rule sits buried among ~25 siblings thousands of tokens back, the skill invocation lands fresh right before the turn), salience (an explicit `/i-have-adhd` invocation is a "do this now" spike, an always-on rule is passive background), and richness (the skill kept Bad/Good example pairs and a Pre-send checklist our compression discipline had stripped). `alwaysApply: true` is not the same as reliably-applied.
+
+The active ingredient was the skill's Pre-send checklist — a mechanized audit, not a passive directive. Most of it already lived in our rule (an announcing first sentence is Lead With the Action, an "anything else?" closer is Close With One Next Step, a by-the-way sidebar is Defer secondary), so only the non-duplicative items landed to keep clear of `context-writing-style`'s no-duplication rule: the two new deletions and the verify gate. We did not vendor the skill — it is a separate MIT plugin, and copying it would violate `dependency-management` No Vendoring; anyone wanting the toggle installs it alongside.
+
 ## 0.3.129 — 2026-07-28
 
 ### Rules — First-Party Co-Shipped Dependency Carve-Out

--- a/rules/response-clarity.md
+++ b/rules/response-clarity.md
@@ -36,6 +36,13 @@ description: How agents shape their responses to the user — action-first, numb
 - No recap, no pleasantries, no closer
 - End when the answer is done
 
+## Pre-Send Check
+
+- Cut hedging adverbs that carry no uncertainty ("perhaps", "might", "possibly")
+- Keep a hedge that carries real uncertainty
+- Replace an idiom or figurative phrase ("circle back", "on the same page") with the literal action
+- Before sending, verify the first line names the next action and the last line names what changed
+
 ## Exceptions
 
 - Explanation requested — give full detail, still no preamble

--- a/rules/response-clarity.md
+++ b/rules/response-clarity.md
@@ -18,6 +18,9 @@ description: How agents shape their responses to the user — action-first, numb
 - Cap an unranked list at 5 items
 - Split a longer list into "do now" and "later" tiers
 - Defer secondary issues — finish the primary problem, then offer the rest as separate follow-ups
+- Cut hedging adverbs that carry no uncertainty ("perhaps", "might", "possibly")
+- Keep a hedge that carries real uncertainty
+- Replace an idiom or figurative phrase ("circle back", "on the same page") with the literal action
 
 ## Show State and Progress
 
@@ -35,13 +38,6 @@ description: How agents shape their responses to the user — action-first, numb
 - End with one concrete action the user can take in two minutes or less
 - No recap, no pleasantries, no closer
 - End when the answer is done
-
-## Pre-Send Check
-
-- Cut hedging adverbs that carry no uncertainty ("perhaps", "might", "possibly")
-- Keep a hedge that carries real uncertainty
-- Replace an idiom or figurative phrase ("circle back", "on the same page") with the literal action
-- Before sending, verify the first line names the next action and the last line names what changed
 
 ## Exceptions
 


### PR DESCRIPTION
## What

Adds three prose-hygiene directives to `Lead With the Action` in `rules/response-clarity.md`: cut noise-hedges, keep real-uncertainty hedges, replace idioms with the literal action.

(Earlier drafts of this PR added a dedicated "Pre-Send Check" section with a first-line/last-line verify gate — dropped during review, see below.)

## Why

Comparing rules-only behavior against `ayghri/i-have-adhd` — an opt-in skill that duplicates our ten response-shaping directives — the skill still visibly changed output when invoked, even though `response-clarity` is `alwaysApply: true`. Why would an invoked skill saying the same things behave differently?

1. **Position** — the always-on rule sits buried among ~25 siblings thousands of tokens back; the skill invocation lands fresh right before the turn.
2. **Salience** — an explicit `/i-have-adhd` invocation is a "do this now" spike; an always-on rule is passive background.
3. **Richness** — the skill kept Bad/Good example pairs and a Pre-send checklist our `context-writing-style` compression had stripped.

`alwaysApply: true` is not the same as reliably-applied.

## Scope narrowed under review

Most of the skill's Pre-send checklist already lived in our rule (announcing first sentence → Lead With the Action; "anything else?" closer → Close With One Next Step; by-the-way → Defer secondary), so restating it would violate `context-writing-style`'s no-duplication rule. The verify gate contradicted `Close With One Next Step` and re-checks directives the rule already states — dropped. The only portable, net-new content was the two deletions, folded into the existing section (no 7th H2, staying within the section budget).

Not vendored: `i-have-adhd` is a separate MIT plugin; copying it would violate `dependency-management` No Vendoring.

Follow-up: #253 (swap "might" for a true filler adverb in the example list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GummAyubViVFrn5TVEUWEi