### PR TITLE
feat(rules): add OS-Package Runtime Carve-Out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### Rules — OS-Package Runtime Carve-Out
+
+New carve-out in `dependency-management` for packages installed from a container base image's own package manager — `apt-get install ffmpeg`, `apk add`, `dnf install`.
+
+The distinction that earns it: Debian's archive serves only the current version of a package. `ffmpeg=7.1.1-1+deb13u1` resolves today and stops resolving the day a security update supersedes it, at which point every build of that image fails outright. That is the inverse of what Pinning is for — the pin does not freeze behaviour, it schedules an outage. A distro that serves historical versions does not meet the test, and the carve-out says so.
+
+None of the three existing carve-outs reach this. Adversarial-Freshness wants a dependency tracking an opponent. Runtime-Managed Manifest wants a file a tool rewrites. First-Party Co-Shipped wants shared ownership of both sides. What is specific here is the archive-retention behaviour of the distro, which none of them describe.
+
+Preconditions keep it from becoming "apt is exempt". The base image must be pinned and scanner-tracked (precondition 2) — the distro release is what bounds these package versions, so floating both ends is unbounded, not carved out. The image must be rebuilt on a recurring cadence (3), which is what actually delivers the security updates a pin would have blocked. And the deploy gate (4) fails on an unpinned base or on any OS package outside the recorded set, so the covered surface cannot quietly grow. Language package managers in the same image — pip, npm, gem — pin normally regardless of what installs them.
+
+Raised by the fleet reviewer on `jbaruch/nanoclaw` #896, which documented `ffmpeg` as deliberately unversioned in the audible-backup sidecar and correctly got blocked for claiming an exception the policy did not define.
+
 ## 0.3.129 — 2026-07-28
 
 ### Rules — First-Party Co-Shipped Dependency Carve-Out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ None of the three existing carve-outs reach this. Adversarial-Freshness wants a 
 
 Preconditions keep it from becoming "apt is exempt". The base image must be pinned and scanner-tracked (precondition 2) — the distro release is what bounds these package versions, so floating both ends is unbounded, not carved out. The image must be rebuilt on a recurring cadence (3), which is what actually delivers the security updates a pin would have blocked. And the deploy gate (4) fails on an unpinned base or on any OS package outside the recorded set, so the covered surface cannot quietly grow. Language package managers in the same image — pip, npm, gem — pin normally regardless of what installs them.
 
+Two review findings sharpened the text. Precondition 4 originally said the gate fails when "an OS package outside the recorded set appears in that image", which is unimplementable as written: every base image already carries hundreds of packages, and the package manager resolves transitive dependencies that shift across security updates. It now scopes to packages the image EXPLICITLY installs — operands of its install command — with base contents and transitive resolution out of scope. And "shared-library contract, not a versioned API" was self-contradictory, since a shared library is precisely an ABI; the applicability test now distinguishes a distro-managed ABI from a semver-governed source API the project compiles against.
+
+Rationale moved here from the rule body per `context-writing-style`: a pin does not freeze behaviour in this shape, it schedules an outage. The base-pinning precondition exists because the distro release is what bounds the package versions, so floating both ends is unbounded rather than carved out. The rebuild cadence is what actually delivers the security updates a pin would have blocked.
+
 Raised by the fleet reviewer on `jbaruch/nanoclaw` #896, which documented `ffmpeg` as deliberately unversioned in the audible-backup sidecar and correctly got blocked for claiming an exception the policy did not define.
 
 ## 0.3.129 — 2026-07-28

--- a/rules/dependency-management.md
+++ b/rules/dependency-management.md
@@ -77,15 +77,15 @@ alwaysApply: true
 ## OS-Package Runtime Carve-Out
 
 - Narrow exception for a package installed from the base image's OS package manager inside a container image (`apt-get install`, `apk add`, `dnf install`)
-- Applies when the distro archive serves only the current version of a package, so a literal version pin stops resolving at the next security update — the pin turns a working build into a hard failure rather than a reproducible one
-- The consumed surface is a command-line or shared-library contract, not a versioned API
+- Applies when the distro archive serves only the current version of a package, so a literal version pin stops resolving at the next security update
+- The consumed surface is a command-line invocation or a distro-managed ABI, not a semver-governed source API the project compiles or imports against
 - The covered install MAY omit the version specifier
 - The exemption reaches the named packages alone — never a language package manager in the same image (`pip`, `npm`, `gem`), which pins normally
 - Preconditions (each covered image, all required):
   1. The project documents an authority-of-record rule in its own plugin naming every covered image, the exact package set, and the rebuild cadence that stands in for a pin
-  2. The image's base is pinned to a specific tag or digest and scanner-tracked — the distro release is what bounds these package versions, so a floating base plus floating packages is unbounded
-  3. The image is rebuilt on a stated recurring cadence, so the package tracks the distro's current security state rather than the date someone last edited the manifest
-  4. A deploy-time check fails the deployment when a covered image's base is unpinned, and when an OS package outside the recorded set appears in that image
+  2. The image's base is pinned to a specific tag or digest and scanner-tracked
+  3. The image is rebuilt on a stated recurring cadence
+  4. A deploy-time check fails the deployment when a covered image's base is unpinned, and when a package the image EXPLICITLY installs (an operand of its package-manager install command) falls outside the recorded set. Packages already present in the base image, and transitive dependencies the package manager resolves, are out of scope
   5. The check runs as a deterministic script per `rules/script-delegation.md`, not agent judgment
 - "Pinning apt is annoying" does NOT qualify — the archive-retention failure mode is the test, and a distro that serves historical versions does not meet it
 - A language-ecosystem dependency does NOT qualify, whatever installs it

--- a/rules/dependency-management.md
+++ b/rules/dependency-management.md
@@ -74,6 +74,23 @@ alwaysApply: true
 - A consumed surface the owner does not control end-to-end does NOT qualify
 - Every other dependency in the repo still pins with a stated renewal mechanism
 
+## OS-Package Runtime Carve-Out
+
+- Narrow exception for a package installed from the base image's OS package manager inside a container image (`apt-get install`, `apk add`, `dnf install`)
+- Applies when the distro archive serves only the current version of a package, so a literal version pin stops resolving at the next security update — the pin turns a working build into a hard failure rather than a reproducible one
+- The consumed surface is a command-line or shared-library contract, not a versioned API
+- The covered install MAY omit the version specifier
+- The exemption reaches the named packages alone — never a language package manager in the same image (`pip`, `npm`, `gem`), which pins normally
+- Preconditions (each covered image, all required):
+  1. The project documents an authority-of-record rule in its own plugin naming every covered image, the exact package set, and the rebuild cadence that stands in for a pin
+  2. The image's base is pinned to a specific tag or digest and scanner-tracked — the distro release is what bounds these package versions, so a floating base plus floating packages is unbounded
+  3. The image is rebuilt on a stated recurring cadence, so the package tracks the distro's current security state rather than the date someone last edited the manifest
+  4. A deploy-time check fails the deployment when a covered image's base is unpinned, and when an OS package outside the recorded set appears in that image
+  5. The check runs as a deterministic script per `rules/script-delegation.md`, not agent judgment
+- "Pinning apt is annoying" does NOT qualify — the archive-retention failure mode is the test, and a distro that serves historical versions does not meet it
+- A language-ecosystem dependency does NOT qualify, whatever installs it
+- Every other dependency in the repo still pins with a stated renewal mechanism
+
 ## Same-Repo Reusable-Workflow Action Carve-Out
 
 - Narrow exception for a reusable workflow (`on: workflow_call`) referencing a composite action in its OWN repository


### PR DESCRIPTION
## What

Adds an **OS-Package Runtime Carve-Out** to `rules/dependency-management.md`: a package installed from a container base image's own package manager may omit the version specifier, under five preconditions.

## Why this one is different from "pinning is inconvenient"

Debian's archive serves only the **current** version of a package. So:

```dockerfile
RUN apt-get install -y ffmpeg=7.1.1-1+deb13u1
```

resolves today, and stops resolving the day a security update supersedes it — at which point *every build of that image fails outright*. The pin doesn't freeze behaviour, it schedules an outage. That's the inverse of what Pinning exists to buy.

The archive-retention behaviour is the test, and the rule says so explicitly: a distro that serves historical versions does **not** qualify, and neither does "pinning apt is annoying".

## Why the existing three don't reach it

- **Adversarial-Freshness** — wants a dependency tracking an actively-adapting opponent.
- **Runtime-Managed Manifest** — wants a manifest a tool rewrites at runtime.
- **First-Party Co-Shipped** — wants the same owner on both sides.

What's specific here is the distro's archive behaviour, which none of them describe.

## What stops it becoming "apt is exempt"

- **Precondition 2 — the base must be pinned and scanner-tracked.** The distro release is what bounds these package versions. Floating the base *and* the packages is unbounded, and explicitly not carved out.
- **Precondition 3 — a stated rebuild cadence.** This is what actually delivers the security updates a pin would have blocked; without it the exemption is just staleness with paperwork.
- **Precondition 4 — the deploy gate fails on an unpinned base, and on any OS package outside the recorded set,** so the covered surface can't quietly grow one `apt-get install` at a time.
- Language package managers in the same image — `pip`, `npm`, `gem` — pin normally regardless of what installs them.

## Origin

The fleet reviewer blocked `jbaruch/nanoclaw` #896 for documenting `ffmpeg` as deliberately unversioned in the audible-backup sidecar while claiming an exception the policy doesn't define. It was right to. This is the missing definition, plus the consumer-side authority rule and gate in `jbaruch/nanoclaw-host` and `jbaruch/nanoclaw`.
