### PR TITLE
feat(hooks): add resurface-response-clarity re-surfacing hook

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -34,5 +34,18 @@
     "rules/review-severity.md",
     "rules/response-clarity.md",
     "rules/ship-on-green.md"
-  ]
+  ],
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash",
+            "args": ["${TESSL_PLUGIN_DIR}/hooks/resurface-response-clarity.sh"]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Hooks — resurface-response-clarity (closes #254)
+
+New plugin hook `hooks/resurface-response-clarity.sh`, wired as a Tessl generic `UserPromptSubmit` hook in `.tessl-plugin/plugin.json`. It re-injects a compact `response-clarity` reminder every N turns (default 5, first fire on turn 1) via the consensus `additionalContext` output field, which Tessl translates into each agent's native context-injection form.
+
+#254 found that an `alwaysApply: true` rule is not the same as a reliably-applied one: comparing rules-only behavior against `ayghri/i-have-adhd`'s opt-in skill (which duplicates our ten response-shaping directives), the invoked skill still changed output. The delta traced to loading mechanics — position (the rule sits buried among ~25 siblings thousands of tokens back), salience (an explicit invocation is a spike, an always-on rule is passive), and richness — not to rule text. Porting the skill's text into the rule was mostly blocked by `context-writing-style`'s no-duplication rule, so the lever is how the rule loads, not what it says. This hook re-surfaces the directives near the turn to counter the decay.
+
+Chosen the generic `hooks` tier over `nativeHooks.claude-code` deliberately: Tessl's own translation maps the consensus `additionalContext` to Claude Code's `hookSpecificOutput.additionalContext` and to other agents' `systemMessage`, so context injection is portable. The event fires on Claude Code and Codex; agents without a prompt-submit event (Cursor, Gemini) simply don't install it. The hook is scoped to coding-policy installs, never blocks a prompt (always exits 0, never 2), and degrades to a silent no-op if its state dir or `jq` is unavailable. Per-session turn state schema: `hooks/state-schema.md`.
+
 ## 0.3.132 — 2026-08-05
 
 ### Rules — fix hedge examples in response-clarity (closes #253)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Coding policy plugin for Baruch's AI agents. Language-agnostic code quality rule
 
 ## What's New
 
+- `resurface-response-clarity` hook — a Tessl generic `UserPromptSubmit` hook that periodically re-injects the `response-clarity` directives near the turn, countering the salience decay of an always-on rule buried in context (issue #254). Fires on Claude Code + Codex, only where coding-policy is installed
 - Policy review runs on the OpenAI Codex CLI authenticated by a ChatGPT subscription (no API key) via `.github/workflows/review-codex.yml`, reviewing every PR against the in-tree `rules/*.md`; Copilot stays as the complementary code-quality lane
 - 24 rules — 18 always-on, 6 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 10 covering code quality, 7 covering plugin authoring, 1 covering concurrency, 1 covering review discipline, 1 covering reviewer-feedback reading, 1 covering review severity, 1 covering external-repo action scope, 1 covering response communication, 1 covering merge/ship autonomy
 - `release` skill — structured PR + merge workflow gated on the Codex policy review's blocking findings; Copilot is the complementary code-quality lane and is always advisory
@@ -59,6 +60,12 @@ tessl install jbaruch/coding-policy
 | [install-reviewer](skills/install-reviewer/SKILL.md) | Enroll a consumer repo in the central fleet policy reviewer — scaffold the `.github/fleet-review-enabled` marker, a thin `.github/workflows/review-trigger.yml` (fires an immediate PR-time review in `coding-policy`), and `.github/copilot-instructions.md`, then open a PR. The `coding-policy-fleet-reviewer` GitHub App reviews against the `jbaruch/coding-policy` rules with the Codex CLI on a ChatGPT subscription (no API key). The Codex credential lives only in `coding-policy`; the consumer sets one stable `FLEET_DISPATCH_TOKEN` (a narrow PAT). Supports `--override` for in-place upgrades. |
 | [adopt-fork-pr](skills/adopt-fork-pr/SKILL.md) | Classify a PR by number. Same-repo PRs pass through to the reviewer; fork PRs get adopted into the base repo as a same-repo PR, preserving the contributor's commits. |
 | [migrate-to-plugin](skills/migrate-to-plugin/SKILL.md) | Migrate a legacy `tile.json` plugin to the `.tessl-plugin/plugin.json` form: runs `tessl plugin migrate`, renames `.tileignore`, removes the obsolete `tile.json`, re-lints, then reconciles residual "tile" wording to "plugin" while preserving contract surfaces. |
+
+### Hooks
+
+| Hook | Event | Description |
+| ---- | ----- | ----------- |
+| [resurface-response-clarity](hooks/resurface-response-clarity.sh) | UserPromptSubmit | Re-injects a compact `response-clarity` reminder every few turns (Claude Code + Codex) to counter the salience decay of an always-on rule buried in context. State schema: [hooks/state-schema.md](hooks/state-schema.md) |
 
 ## Philosophy
 

--- a/hooks/resurface-response-clarity.sh
+++ b/hooks/resurface-response-clarity.sh
@@ -63,6 +63,13 @@ emit() {
 main() {
   local input session file count
 
+  # Validate the interval before any arithmetic — a non-numeric value would
+  # abort the hook under set -e/set -u and break the never-block contract.
+  if ! [[ "$RESURFACE_INTERVAL" =~ ^[1-9][0-9]*$ ]]; then
+    warn "RESURFACE_INTERVAL='${RESURFACE_INTERVAL}' is not a positive integer — using 5"
+    RESURFACE_INTERVAL=5
+  fi
+
   input="$(cat)" || input=""
 
   session="default"

--- a/hooks/resurface-response-clarity.sh
+++ b/hooks/resurface-response-clarity.sh
@@ -32,32 +32,27 @@ SCHEMA_VERSION=1
 RESURFACE_INTERVAL="${RESURFACE_INTERVAL:-5}"
 STATE_DIR="${RESURFACE_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-resurface}"
 
-# The reminder injected on a fire turn. Must stay free of " and \ so the
-# jq-absent fallback in emit() can hand-build valid JSON.
+# The reminder injected on a fire turn.
 REMINDER='response-clarity is in effect — lead with the action (command, edit, or answer; no preamble); number multi-step work, one action per step; cap lists at 5; restate progress across turns; report errors plainly (expected vs actual); end with one concrete next step; no recap, no closer.'
 
 warn() { printf 'resurface-response-clarity: %s\n' "$1" >&2; }
 
-# Echo the stored turn_count for a session file, or 0 if absent/unreadable/corrupt.
+# Echo the stored turn_count for a session file, or 0 if absent/unreadable/
+# corrupt/version-mismatched. Only a record stamped with the accepted
+# SCHEMA_VERSION is trusted; any other version is no usable prior state
+# (hooks/state-schema.md Migration; rules/stateful-artifacts.md Migration Policy).
 read_count() {
   local f="$1" c
   [[ -r "$f" ]] || { echo 0; return; }
-  if command -v jq >/dev/null 2>&1; then
-    c="$(jq -r '.turn_count // 0' "$f" 2>/dev/null || echo 0)"
-  else
-    c=0
-  fi
+  c="$(jq -r --argjson v "$SCHEMA_VERSION" \
+    'if (.schema_version == $v) then (.turn_count // 0) else 0 end' \
+    "$f" 2>/dev/null || echo 0)"
   [[ "$c" =~ ^[0-9]+$ ]] || c=0
   echo "$c"
 }
 
 emit() {
-  if command -v jq >/dev/null 2>&1; then
-    jq -n --arg c "$REMINDER" '{additionalContext: $c}'
-  else
-    # jq absent: REMINDER is guaranteed free of " and \, so this is valid JSON.
-    printf '{"additionalContext":"%s"}\n' "$REMINDER"
-  fi
+  jq -n --arg c "$REMINDER" '{additionalContext: $c}'
 }
 
 main() {
@@ -70,13 +65,17 @@ main() {
     RESURFACE_INTERVAL=5
   fi
 
+  # jq maintains the JSON turn counter; without it the hook can't track cadence
+  # and would fire every turn, so degrade to a clean no-op instead.
+  if ! command -v jq >/dev/null 2>&1; then
+    warn "jq not found — response-clarity re-surfacing disabled this session"
+    exit 0
+  fi
+
   input="$(cat)" || input=""
 
-  session="default"
-  if command -v jq >/dev/null 2>&1; then
-    # Explicit fallback on parse failure — not blanket suppression.
-    session="$(printf '%s' "$input" | jq -r '.session_id // "default"' 2>/dev/null || echo default)"
-  fi
+  # Explicit fallback on parse failure — not blanket suppression.
+  session="$(printf '%s' "$input" | jq -r '.session_id // "default"' 2>/dev/null || echo default)"
   [[ -n "$session" ]] || session="default"
   # Sanitize for use as a filename component.
   session="${session//[^A-Za-z0-9_-]/_}"
@@ -88,7 +87,9 @@ main() {
   file="${STATE_DIR}/${session}.json"
 
   count="$(read_count "$file")"
-  count=$((count + 1))
+  # Force base-10: a digit string like "08" would otherwise be read as octal
+  # and abort under set -e.
+  count=$((10#$count + 1))
 
   if ! printf '{"schema_version":%d,"session_id":"%s","turn_count":%d}\n' \
         "$SCHEMA_VERSION" "$session" "$count" > "$file"; then

--- a/hooks/resurface-response-clarity.sh
+++ b/hooks/resurface-response-clarity.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Re-surface the response-clarity directives every Nth user prompt.
+#
+# Tessl generic UserPromptSubmit hook. Tessl installs it on every agent that
+# has a prompt-submit event (Claude Code, Codex); agents without one (Cursor,
+# Gemini) simply don't get it. Reads the consensus hook payload on stdin,
+# maintains a per-session turn counter, and on a fire turn emits
+# {"additionalContext": <reminder>} — which Tessl translates into each agent's
+# native context-injection form (Claude `hookSpecificOutput.additionalContext`,
+# others `systemMessage`). Every other turn it stays silent.
+#
+# Why: rules/response-clarity.md is alwaysApply, but an always-on rule buried
+# in the context wall loses salience over a long session (issue #254). This
+# re-injects a compact reminder near the turn to counter that decay.
+#
+# Contract:
+#   stdin : consensus hook JSON. Reads `.session_id` (string). Missing or
+#           unparsable => session "default" (counter shared, still functions).
+#   stdout: on a fire turn, one JSON object {"additionalContext": "<text>"};
+#           otherwise nothing.
+#   exit  : ALWAYS 0. Never 2 — exit 2 would block the user's prompt. Best
+#           effort: an internal problem warns on stderr and no-ops, never
+#           blocks (rules/error-handling.md — best-effort work continues past a
+#           failure with a stderr warning).
+#   state : $RESURFACE_STATE_DIR (default ${TMPDIR:-/tmp}/coding-policy-resurface),
+#           one JSON file per session. Schema: hooks/state-schema.md.
+#   env   : RESURFACE_INTERVAL (default 5) — fire on turn 1, then every Nth.
+#           RESURFACE_STATE_DIR — state location (overridden by tests).
+set -euo pipefail
+
+SCHEMA_VERSION=1
+RESURFACE_INTERVAL="${RESURFACE_INTERVAL:-5}"
+STATE_DIR="${RESURFACE_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-resurface}"
+
+# The reminder injected on a fire turn. Must stay free of " and \ so the
+# jq-absent fallback in emit() can hand-build valid JSON.
+REMINDER='response-clarity is in effect — lead with the action (command, edit, or answer; no preamble); number multi-step work, one action per step; cap lists at 5; restate progress across turns; report errors plainly (expected vs actual); end with one concrete next step; no recap, no closer.'
+
+warn() { printf 'resurface-response-clarity: %s\n' "$1" >&2; }
+
+# Echo the stored turn_count for a session file, or 0 if absent/unreadable/corrupt.
+read_count() {
+  local f="$1" c
+  [[ -r "$f" ]] || { echo 0; return; }
+  if command -v jq >/dev/null 2>&1; then
+    c="$(jq -r '.turn_count // 0' "$f" 2>/dev/null || echo 0)"
+  else
+    c=0
+  fi
+  [[ "$c" =~ ^[0-9]+$ ]] || c=0
+  echo "$c"
+}
+
+emit() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg c "$REMINDER" '{additionalContext: $c}'
+  else
+    # jq absent: REMINDER is guaranteed free of " and \, so this is valid JSON.
+    printf '{"additionalContext":"%s"}\n' "$REMINDER"
+  fi
+}
+
+main() {
+  local input session file count
+
+  input="$(cat)" || input=""
+
+  session="default"
+  if command -v jq >/dev/null 2>&1; then
+    # Explicit fallback on parse failure — not blanket suppression.
+    session="$(printf '%s' "$input" | jq -r '.session_id // "default"' 2>/dev/null || echo default)"
+  fi
+  [[ -n "$session" ]] || session="default"
+  # Sanitize for use as a filename component.
+  session="${session//[^A-Za-z0-9_-]/_}"
+
+  if ! mkdir -p "$STATE_DIR"; then
+    warn "cannot create state dir ${STATE_DIR} — skipping re-surface this turn"
+    exit 0
+  fi
+  file="${STATE_DIR}/${session}.json"
+
+  count="$(read_count "$file")"
+  count=$((count + 1))
+
+  if ! printf '{"schema_version":%d,"session_id":"%s","turn_count":%d}\n' \
+        "$SCHEMA_VERSION" "$session" "$count" > "$file"; then
+    warn "cannot write state file ${file} — re-surface may repeat"
+  fi
+
+  # Fire on turn 1, then every RESURFACE_INTERVAL turns: (count-1) % N == 0.
+  # Guarding N>0 keeps a misconfigured interval of 0 from a divide-by-zero.
+  if (( RESURFACE_INTERVAL > 0 && (count - 1) % RESURFACE_INTERVAL == 0 )); then
+    emit
+  fi
+  exit 0
+}
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && main "$@"

--- a/hooks/state-schema.md
+++ b/hooks/state-schema.md
@@ -1,0 +1,25 @@
+# resurface-response-clarity state schema
+
+Per-session turn counter written and read by `hooks/resurface-response-clarity.sh` — the sole owner.
+
+## Location
+
+- `$RESURFACE_STATE_DIR/<session>.json` (default `${TMPDIR:-/tmp}/coding-policy-resurface/`)
+- One file per hook session; `<session>` is the sanitized `session_id` from the hook payload
+- Ephemeral — safe to delete; a missing file means "first turn"
+
+## Fields
+
+- `schema_version` (int) — currently `1`
+- `session_id` (string) — sanitized session id (the filename stem)
+- `turn_count` (int) — cumulative UserPromptSubmit count for this session
+
+## Writer / reader contract
+
+- The hook is the only writer and the only reader
+- On an absent, unreadable, or corrupt file the hook treats `turn_count` as `0` (no prior state) — the next turn becomes turn 1 and fires
+- Hints-not-authority does not apply — the count is authoritative for this session; it is never cross-checked against an external source
+
+## Migration
+
+- Only the hook migrates. On a `schema_version` it does not recognize it treats the record as no usable prior state (count `0`) and rewrites at the current version on the next turn

--- a/hooks/state-schema.md
+++ b/hooks/state-schema.md
@@ -18,7 +18,7 @@ Per-session turn counter written and read by `hooks/resurface-response-clarity.s
 
 - The hook is the only writer and the only reader
 - On an absent, unreadable, or corrupt file the hook treats `turn_count` as `0` (no prior state) — the next turn becomes turn 1 and fires
-- Hints-not-authority does not apply — the count is authoritative for this session; it is never cross-checked against an external source
+- Staleness is tolerable per `rules/stateful-artifacts.md` Hints, Not Authority — the counter has no external source to verify against, and a stale or reset count only shifts the reminder cadence (a reminder fires a turn early or late), never a correctness impact
 
 ## Migration
 

--- a/hooks/tests/test_resurface_response_clarity.sh
+++ b/hooks/tests/test_resurface_response_clarity.sh
@@ -49,6 +49,13 @@ run() {
 
 payload() { printf '{"session_id":"%s","hook_event_name":"UserPromptSubmit","cwd":"/x","prompt":"hi"}' "$1"; }
 
+# seed_turn <session> <turn> — pre-write state so the next hook call for that
+# session lands on <turn>. Keeps each cadence check independent (its own
+# session + seeded state), so no check depends on another having run first
+# (rules/error-handling.md aggregate carve-out precondition 1; testing-standards
+# Independence).
+seed_turn() { printf '{"schema_version":1,"session_id":"%s","turn_count":%d}' "$1" "$(( $2 - 1 ))" > "${STATE_DIR}/$1.json"; }
+
 pass() { PASS_COUNT=$((PASS_COUNT + 1)); }
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  ✗ FAIL: $1" >&2; }
 
@@ -70,14 +77,14 @@ check_silent() { # $1=label $2=stdin
 
 echo "Testing resurface-response-clarity.sh" >&2
 
-# 1-3: default cadence (N=5) — fire on 1 and 6, silent on 2..5.
+# 1-3: default cadence (N=5) — fire on turn 1 and 6, silent on 2..5. Each check
+# uses its own session with seeded state, so the checks are order-independent.
 unset RESURFACE_INTERVAL
-check_fires  "turn 1 fires"        "$(payload s_cadence)"
-check_silent "turn 2 silent"       "$(payload s_cadence)"
-check_silent "turn 3 silent"       "$(payload s_cadence)"
-check_silent "turn 4 silent"       "$(payload s_cadence)"
-check_silent "turn 5 silent"       "$(payload s_cadence)"
-check_fires  "turn 6 fires again"  "$(payload s_cadence)"
+check_fires  "turn 1 fires"                          "$(payload cad1)"
+seed_turn cad2 2; check_silent "turn 2 silent"       "$(payload cad2)"
+seed_turn cad3 3; check_silent "turn 3 silent"       "$(payload cad3)"
+seed_turn cad5 5; check_silent "turn 5 silent"       "$(payload cad5)"
+seed_turn cad6 6; check_fires  "turn 6 fires again"  "$(payload cad6)"
 
 # 5: missing session_id — still fires on its first turn.
 check_fires "missing session_id fires" '{"hook_event_name":"UserPromptSubmit","cwd":"/x","prompt":"hi"}'
@@ -107,13 +114,13 @@ check_fires "unknown schema_version ignores turn_count and fires" "$(payload s_v
 printf '{"schema_version":1,"session_id":"s_oct","turn_count":"08"}' > "${STATE_DIR}/s_oct.json"
 check_silent "octal-looking count is base-10 and does not crash" "$(payload s_oct)"
 
-# 8: interval override N=2 — fire on 1,3,5; silent on 2,4.
+# 8: interval override N=2 — fires on odd turns. Independent seeded state per check.
 export RESURFACE_INTERVAL=2
-check_fires  "N=2 turn 1 fires"  "$(payload s_n2)"
-check_silent "N=2 turn 2 silent" "$(payload s_n2)"
-check_fires  "N=2 turn 3 fires"  "$(payload s_n2)"
-check_silent "N=2 turn 4 silent" "$(payload s_n2)"
-check_fires  "N=2 turn 5 fires"  "$(payload s_n2)"
+check_fires  "N=2 turn 1 fires"                     "$(payload n2t1)"
+seed_turn n2t2 2; check_silent "N=2 turn 2 silent"  "$(payload n2t2)"
+seed_turn n2t3 3; check_fires  "N=2 turn 3 fires"   "$(payload n2t3)"
+seed_turn n2t4 4; check_silent "N=2 turn 4 silent"  "$(payload n2t4)"
+seed_turn n2t5 5; check_fires  "N=2 turn 5 fires"   "$(payload n2t5)"
 unset RESURFACE_INTERVAL
 
 # 8b: invalid RESURFACE_INTERVAL — never aborts (exit 0), defaults to 5, fires on turn 1.

--- a/hooks/tests/test_resurface_response_clarity.sh
+++ b/hooks/tests/test_resurface_response_clarity.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Outcome-based tests for resurface-response-clarity.sh.
+#
+# Covers the behaviors the hook promises:
+#   1. Turn 1 fires — emits {"additionalContext": ...} containing the reminder.
+#   2. Turns 2..N stay silent (empty stdout).
+#   3. Turn N+1 fires again (every-Nth cadence, first fire on turn 1).
+#   4. Exit code is always 0 — never 2 (a block would drop the user's prompt).
+#   5. Missing session_id => session "default", still counts and fires.
+#   6. Malformed (non-JSON) stdin => no crash, exit 0, treated as "default".
+#   7. Corrupt state file => treated as count 0, next turn fires.
+#   8. RESURFACE_INTERVAL override respected (N=2 fires on 1,3,5).
+#   9. Emitted output is valid JSON with exactly the additionalContext key.
+#  10. Determinism — a fixed session's fire pattern is identical across runs.
+#
+# Black-box approach: the hook is a stdin->stdout filter, so each case pipes a
+# JSON payload to `bash <script>` and inspects stdout + exit code. State is
+# isolated via RESURFACE_STATE_DIR (a temp dir) plus a distinct session_id per
+# case, so counts never bleed between tests.
+#
+# Run: bash hooks/tests/test_resurface_response_clarity.sh
+# Exit 0 on all-pass; non-zero with a per-test diagnostic on failure.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/resurface-response-clarity.sh"
+[[ -f "$SCRIPT" && -r "$SCRIPT" ]] || { echo "fatal: hook not found/readable at $SCRIPT" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "fatal: jq is required to run these tests" >&2; exit 2; }
+
+STATE_DIR="$(mktemp -d -t resurface-test.XXXXXX)"
+export RESURFACE_STATE_DIR="$STATE_DIR"
+
+cleanup() {
+  if [[ -n "${STATE_DIR:-}" ]] && ! rm -rf "$STATE_DIR"; then
+    echo "warning: could not remove temp dir ${STATE_DIR} — remove it by hand" >&2
+  fi
+  return 0
+}
+trap cleanup EXIT
+
+FAIL_COUNT=0
+PASS_COUNT=0
+
+# run <stdin-json> -> sets OUT (stdout) and RC (exit code)
+run() {
+  OUT="$(printf '%s' "$1" | bash "$SCRIPT")"
+  RC=$?
+}
+
+payload() { printf '{"session_id":"%s","hook_event_name":"UserPromptSubmit","cwd":"/x","prompt":"hi"}' "$1"; }
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  ✗ FAIL: $1" >&2; }
+
+check_fires() { # $1=label $2=stdin
+  run "$2"
+  if [[ $RC -ne 0 ]]; then fail "$1: expected exit 0, got $RC"; return; fi
+  if ! printf '%s' "$OUT" | jq -e '.additionalContext | test("response-clarity")' >/dev/null 2>&1; then
+    fail "$1: expected additionalContext mentioning response-clarity, got: ${OUT}"; return
+  fi
+  pass
+}
+
+check_silent() { # $1=label $2=stdin
+  run "$2"
+  if [[ $RC -ne 0 ]]; then fail "$1: expected exit 0, got $RC"; return; fi
+  if [[ -n "$OUT" ]]; then fail "$1: expected empty stdout, got: ${OUT}"; return; fi
+  pass
+}
+
+echo "Testing resurface-response-clarity.sh" >&2
+
+# 1-3: default cadence (N=5) — fire on 1 and 6, silent on 2..5.
+unset RESURFACE_INTERVAL
+check_fires  "turn 1 fires"        "$(payload s_cadence)"
+check_silent "turn 2 silent"       "$(payload s_cadence)"
+check_silent "turn 3 silent"       "$(payload s_cadence)"
+check_silent "turn 4 silent"       "$(payload s_cadence)"
+check_silent "turn 5 silent"       "$(payload s_cadence)"
+check_fires  "turn 6 fires again"  "$(payload s_cadence)"
+
+# 5: missing session_id — still fires on its first turn.
+check_fires "missing session_id fires" '{"hook_event_name":"UserPromptSubmit","cwd":"/x","prompt":"hi"}'
+
+# 6: malformed stdin — no crash, exit 0, fires (treated as default session).
+#    Uses a fresh state dir so the earlier default-session turn doesn't count.
+(
+  export RESURFACE_STATE_DIR="$(mktemp -d -t resurface-bad.XXXXXX)"
+  OUT="$(printf '%s' 'not json at all' | bash "$SCRIPT")"; RC=$?
+  rm -rf "$RESURFACE_STATE_DIR"
+  [[ $RC -eq 0 ]] || { echo "  ✗ FAIL: malformed stdin: expected exit 0, got $RC" >&2; exit 1; }
+  printf '%s' "$OUT" | jq -e '.additionalContext' >/dev/null 2>&1 || { echo "  ✗ FAIL: malformed stdin: expected a fire" >&2; exit 1; }
+) && pass || fail "malformed stdin handling"
+
+# 7: corrupt state file — treated as count 0, so the next turn is turn 1 and fires.
+printf 'garbage{not json' > "${STATE_DIR}/s_corrupt.json"
+check_fires "corrupt state fires" "$(payload s_corrupt)"
+
+# 8: interval override N=2 — fire on 1,3,5; silent on 2,4.
+export RESURFACE_INTERVAL=2
+check_fires  "N=2 turn 1 fires"  "$(payload s_n2)"
+check_silent "N=2 turn 2 silent" "$(payload s_n2)"
+check_fires  "N=2 turn 3 fires"  "$(payload s_n2)"
+check_silent "N=2 turn 4 silent" "$(payload s_n2)"
+check_fires  "N=2 turn 5 fires"  "$(payload s_n2)"
+unset RESURFACE_INTERVAL
+
+# 9: emitted output is valid JSON with exactly one key (additionalContext).
+run "$(payload s_shape)"
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e 'keys == ["additionalContext"]' >/dev/null 2>&1; then
+  pass
+else
+  fail "output shape: expected single-key additionalContext JSON, got: ${OUT}"
+fi
+
+# 10: determinism — two independent sessions fed the same turn sequence
+#     produce identical fire/silent patterns.
+det() { # emits F/S per turn for a fresh session in a fresh state dir
+  local dir sess out i pat=""
+  dir="$(mktemp -d -t resurface-det.XXXXXX)"
+  sess="$1"
+  for i in 1 2 3 4 5 6; do
+    out="$(printf '{"session_id":"%s","prompt":"hi"}' "$sess" | RESURFACE_STATE_DIR="$dir" bash "$SCRIPT")"
+    [[ -n "$out" ]] && pat+="F" || pat+="S"
+  done
+  rm -rf "$dir"
+  printf '%s' "$pat"
+}
+P1="$(det da)"; P2="$(det db)"
+if [[ "$P1" == "FSSSSF" && "$P1" == "$P2" ]]; then
+  pass
+else
+  fail "determinism: expected FSSSSF twice, got '${P1}' and '${P2}'"
+fi
+
+echo "─────────────────────────────────────────────" >&2
+if [[ $FAIL_COUNT -gt 0 ]]; then
+  echo "FAILED: ${FAIL_COUNT} failed, ${PASS_COUNT} passed" >&2
+  exit 1
+fi
+echo "PASSED: all ${PASS_COUNT} checks" >&2

--- a/hooks/tests/test_resurface_response_clarity.sh
+++ b/hooks/tests/test_resurface_response_clarity.sh
@@ -54,7 +54,12 @@ payload() { printf '{"session_id":"%s","hook_event_name":"UserPromptSubmit","cwd
 # session + seeded state), so no check depends on another having run first
 # (rules/error-handling.md aggregate carve-out precondition 1; testing-standards
 # Independence).
-seed_turn() { printf '{"schema_version":1,"session_id":"%s","turn_count":%d}' "$1" "$(( $2 - 1 ))" > "${STATE_DIR}/$1.json"; }
+seed_turn() {
+  if ! printf '{"schema_version":1,"session_id":"%s","turn_count":%d}' "$1" "$(( $2 - 1 ))" > "${STATE_DIR}/$1.json"; then
+    echo "fatal: seed_turn write failed for session $1" >&2
+    exit 2
+  fi
+}
 
 pass() { PASS_COUNT=$((PASS_COUNT + 1)); }
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo "  ✗ FAIL: $1" >&2; }
@@ -90,15 +95,16 @@ seed_turn cad6 6; check_fires  "turn 6 fires again"  "$(payload cad6)"
 check_fires "missing session_id fires" '{"hook_event_name":"UserPromptSubmit","cwd":"/x","prompt":"hi"}'
 
 # 6: malformed stdin — no crash, exit 0, fires (treated as default session).
-#    Uses a fresh state dir so the earlier default-session turn doesn't count.
-(
-  bad_dir="$(mktemp -d -t resurface-bad.XXXXXX)" || { echo "  ✗ FAIL: malformed stdin: mktemp failed" >&2; exit 1; }
+#    Own state dir so the earlier default-session turn doesn't count. The
+#    subshell uses local names (sub_out/sub_rc) to stay clear of outer OUT/RC.
+if (
+  bad_dir="$(mktemp -d -t resurface-bad.XXXXXX)" || { echo "  ✗ malformed stdin: mktemp failed" >&2; exit 1; }
   export RESURFACE_STATE_DIR="$bad_dir"
-  OUT="$(printf '%s' 'not json at all' | bash "$SCRIPT")"; RC=$?
+  sub_out="$(printf '%s' 'not json at all' | bash "$SCRIPT")"; sub_rc=$?
   rm -rf "$RESURFACE_STATE_DIR"
-  [[ $RC -eq 0 ]] || { echo "  ✗ FAIL: malformed stdin: expected exit 0, got $RC" >&2; exit 1; }
-  printf '%s' "$OUT" | jq -e '.additionalContext' >/dev/null 2>&1 || { echo "  ✗ FAIL: malformed stdin: expected a fire" >&2; exit 1; }
-) && pass || fail "malformed stdin handling"
+  [[ $sub_rc -eq 0 ]] || { echo "  ✗ malformed stdin: expected exit 0, got $sub_rc" >&2; exit 1; }
+  printf '%s' "$sub_out" | jq -e '.additionalContext' >/dev/null 2>&1 || { echo "  ✗ malformed stdin: expected a fire" >&2; exit 1; }
+); then pass; else fail "malformed stdin handling"; fi
 
 # 7: corrupt state file — treated as count 0, so the next turn is turn 1 and fires.
 printf 'garbage{not json' > "${STATE_DIR}/s_corrupt.json"
@@ -139,12 +145,12 @@ fi
 # 10: determinism — two independent sessions fed the same turn sequence
 #     produce identical fire/silent patterns.
 det() { # emits F/S per turn for a fresh session in a fresh state dir
-  local dir sess out i pat=""
+  local dir sess out pat=""
   dir="$(mktemp -d -t resurface-det.XXXXXX)" || { echo "  ✗ FAIL: det: mktemp failed" >&2; return 1; }
   sess="$1"
-  for i in 1 2 3 4 5 6; do
+  for _ in 1 2 3 4 5 6; do
     out="$(printf '{"session_id":"%s","prompt":"hi"}' "$sess" | RESURFACE_STATE_DIR="$dir" bash "$SCRIPT")"
-    [[ -n "$out" ]] && pat+="F" || pat+="S"
+    if [[ -n "$out" ]]; then pat+="F"; else pat+="S"; fi
   done
   rm -rf "$dir"
   printf '%s' "$pat"

--- a/hooks/tests/test_resurface_response_clarity.sh
+++ b/hooks/tests/test_resurface_response_clarity.sh
@@ -97,6 +97,16 @@ check_fires "missing session_id fires" '{"hook_event_name":"UserPromptSubmit","c
 printf 'garbage{not json' > "${STATE_DIR}/s_corrupt.json"
 check_fires "corrupt state fires" "$(payload s_corrupt)"
 
+# 7b: unrecognized schema_version — no usable prior state (count 0) despite a
+#     high turn_count, so the next turn is turn 1 and fires (Migration Policy).
+printf '{"schema_version":999,"session_id":"s_ver","turn_count":42}' > "${STATE_DIR}/s_ver.json"
+check_fires "unknown schema_version ignores turn_count and fires" "$(payload s_ver)"
+
+# 7c: parseable but octal-looking count ("08") — read base-10 (=8), no crash;
+#     next turn is 9, not a fire turn (N=5), so silent (proves no octal abort).
+printf '{"schema_version":1,"session_id":"s_oct","turn_count":"08"}' > "${STATE_DIR}/s_oct.json"
+check_silent "octal-looking count is base-10 and does not crash" "$(payload s_oct)"
+
 # 8: interval override N=2 — fire on 1,3,5; silent on 2,4.
 export RESURFACE_INTERVAL=2
 check_fires  "N=2 turn 1 fires"  "$(payload s_n2)"

--- a/hooks/tests/test_resurface_response_clarity.sh
+++ b/hooks/tests/test_resurface_response_clarity.sh
@@ -27,7 +27,7 @@ SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/resurface-response-clarity.sh"
 [[ -f "$SCRIPT" && -r "$SCRIPT" ]] || { echo "fatal: hook not found/readable at $SCRIPT" >&2; exit 2; }
 command -v jq >/dev/null 2>&1 || { echo "fatal: jq is required to run these tests" >&2; exit 2; }
 
-STATE_DIR="$(mktemp -d -t resurface-test.XXXXXX)"
+STATE_DIR="$(mktemp -d -t resurface-test.XXXXXX)" || { echo "fatal: mktemp failed for state dir" >&2; exit 2; }
 export RESURFACE_STATE_DIR="$STATE_DIR"
 
 cleanup() {
@@ -85,7 +85,8 @@ check_fires "missing session_id fires" '{"hook_event_name":"UserPromptSubmit","c
 # 6: malformed stdin — no crash, exit 0, fires (treated as default session).
 #    Uses a fresh state dir so the earlier default-session turn doesn't count.
 (
-  export RESURFACE_STATE_DIR="$(mktemp -d -t resurface-bad.XXXXXX)"
+  bad_dir="$(mktemp -d -t resurface-bad.XXXXXX)" || { echo "  ✗ FAIL: malformed stdin: mktemp failed" >&2; exit 1; }
+  export RESURFACE_STATE_DIR="$bad_dir"
   OUT="$(printf '%s' 'not json at all' | bash "$SCRIPT")"; RC=$?
   rm -rf "$RESURFACE_STATE_DIR"
   [[ $RC -eq 0 ]] || { echo "  ✗ FAIL: malformed stdin: expected exit 0, got $RC" >&2; exit 1; }
@@ -105,6 +106,11 @@ check_silent "N=2 turn 4 silent" "$(payload s_n2)"
 check_fires  "N=2 turn 5 fires"  "$(payload s_n2)"
 unset RESURFACE_INTERVAL
 
+# 8b: invalid RESURFACE_INTERVAL — never aborts (exit 0), defaults to 5, fires on turn 1.
+export RESURFACE_INTERVAL=not-a-number
+check_fires "invalid interval defaults and fires" "$(payload s_badN)"
+unset RESURFACE_INTERVAL
+
 # 9: emitted output is valid JSON with exactly one key (additionalContext).
 run "$(payload s_shape)"
 if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e 'keys == ["additionalContext"]' >/dev/null 2>&1; then
@@ -117,7 +123,7 @@ fi
 #     produce identical fire/silent patterns.
 det() { # emits F/S per turn for a fresh session in a fresh state dir
   local dir sess out i pat=""
-  dir="$(mktemp -d -t resurface-det.XXXXXX)"
+  dir="$(mktemp -d -t resurface-det.XXXXXX)" || { echo "  ✗ FAIL: det: mktemp failed" >&2; return 1; }
   sess="$1"
   for i in 1 2 3 4 5 6; do
     out="$(printf '{"session_id":"%s","prompt":"hi"}' "$sess" | RESURFACE_STATE_DIR="$dir" bash "$SCRIPT")"

--- a/rules/skill-authoring.md
+++ b/rules/skill-authoring.md
@@ -85,5 +85,7 @@ Optional fields:
 - `rules` — directory path (`"rules/"`) or array of rule-file paths (`"rules/<name>.md"`); every `.md` file in a declared directory is included
 - `repository`, `homepage`, `license` — provenance and discovery metadata
 - `author` — object with `name`, `email`, `url`
+- `hooks` — cross-agent hook declarations keyed by event (`PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, `Stop`), each mapping to hook groups (`matcher` optional, `hooks` array of `{type:"command", command, args?}`); Tessl translates the consensus payload to each agent's native form
+- `nativeHooks` — per-agent hook declarations keyed by agent id (`claude-code`), same group shape, written straight to that agent's native config
 
 `alwaysApply` and `applyTo:` are not manifest fields — rule scope lives in the rule file frontmatter per `rules/rule-frontmatter.md`.

--- a/scripts/run-diagnostics.sh
+++ b/scripts/run-diagnostics.sh
@@ -22,7 +22,7 @@
 # Output:
 #   stderr: each engine's native findings plus per-engine progress.
 # Usage: scripts/run-diagnostics.sh [base-dir]
-#   base-dir  Tree whose skills/, scripts/, .github/actions/, and
+#   base-dir  Tree whose skills/, scripts/, hooks/, .github/actions/, and
 #             .github/codex-review/ are scanned for shell scripts.
 #             Defaults to the repo root. The
 #             optional arg exists so the runner's own test can point it at
@@ -65,6 +65,9 @@ main() {
   local roots=()
   [[ -d "$base/skills" ]] && roots+=("$base/skills")
   [[ -d "$base/scripts" ]] && roots+=("$base/scripts")
+  # First-party hook scripts (hooks/*.sh + their tests) — gate them at the
+  # same zero-findings bar as every other shipped shell script.
+  [[ -d "$base/hooks" ]] && roots+=("$base/hooks")
   # Composite-action bodies extracted to real scripts per
   # rules/script-delegation.md (e.g. skill-review/review-skills.sh) — gate
   # them too so an action script is held to the same zero-findings bar.
@@ -76,7 +79,7 @@ main() {
   # "clean" (#199).
   [[ -d "$base/.github/codex-review" ]] && roots+=("$base/.github/codex-review")
   if [[ ${#roots[@]} -eq 0 ]]; then
-    echo "run-diagnostics: none of skills/, scripts/, .github/actions/, .github/codex-review/ found under $base" >&2
+    echo "run-diagnostics: none of skills/, scripts/, hooks/, .github/actions/, .github/codex-review/ found under $base" >&2
     return 2
   fi
 


### PR DESCRIPTION
Closes #254.

## What

A Tessl **generic** `UserPromptSubmit` hook (`hooks/resurface-response-clarity.sh`) that re-injects a compact `response-clarity` reminder every N turns (default 5, first fire on turn 1), scoped to coding-policy installs.

- Wired in `.tessl-plugin/plugin.json` under the cross-agent `hooks` tier.
- Emits the consensus `additionalContext` output, which Tessl translates into each agent's native form (Claude Code `hookSpecificOutput.additionalContext`, others `systemMessage`) — so context injection is **portable**, not Claude-only.
- Fires on **Claude Code + Codex**; agents without a prompt-submit event (Cursor, Gemini) simply don't install it.
- **Never blocks a prompt** — always exits 0, never 2. Degrades to a silent no-op if the state dir or `jq` is unavailable.
- Per-session turn counter with a documented schema (`hooks/state-schema.md`, per `stateful-artifacts`).

## Why

#254 concluded that `alwaysApply: true` ≠ reliably-applied. An opt-in skill duplicating our response-shaping directives still changed output when invoked; the delta traced to **loading mechanics** (position, salience, richness), not rule text — and porting the text into the rule was blocked by `context-writing-style`'s no-duplication rule. So the lever is *how the rule loads*. This hook re-surfaces the directives near the turn to counter the salience decay.

The generic-vs-native tier choice and the full hook I/O contract are documented on #254 (reverse-engineered from the `tessl` binary's translation code).

## Tests

- `hooks/tests/test_resurface_response_clarity.sh` — 16 checks: cadence (fire on 1 and N+1, silent between), always-exit-0, missing/malformed stdin, corrupt state, interval override, output shape, determinism.
- Full suite green (21 suites), shellcheck + pyright clean, `tessl plugin lint` valid, and `tessl plugin pack` confirms the hook files ship.

## Verified by contract, not live

The end-to-end `tessl hook run` → script → per-agent `additionalContext` translation is confirmed from Tessl's own binary (v0.94.0) and the dispatch probe; it could not be executed live in the sandbox (Tessl couldn't spawn the child there). The script itself is fully unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GummAyubViVFrn5TVEUWEi