### PR TITLE
feat(hooks): add check-policy-freshness SessionStart hook

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -34,5 +34,18 @@
     "rules/review-severity.md",
     "rules/response-clarity.md",
     "rules/ship-on-green.md"
-  ]
+  ],
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash",
+            "args": ["${TESSL_PLUGIN_DIR}/hooks/check-policy-freshness.sh"]
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Hooks — check-policy-freshness (SessionStart staleness warning)
+
+New `hooks/check-policy-freshness.sh`, wired as a Tessl `SessionStart` hook. It runs `tessl outdated --json` and, when installed plugins are behind the registry, injects a one-line `tessl update` reminder via `additionalContext`. Informative only — never blocks (always exits 0), degrades to a silent no-op if `tessl`/`jq` are absent or the registry check fails.
+
+This is the first hook built on the "a hook DOES a deterministic thing at a lifecycle event" principle, after the resurface hook was reverted for re-stating a rule the model already had. It targets a measured problem: fleet repos silently drift onto stale policy versions with nothing flagging it (a consumer was observed running 0.3.138 while 0.3.139 was published). `SessionStart` fires once per session — no per-turn tax — and the registry check is throttled to once per `FRESHNESS_THROTTLE_HOURS` (default 24h) so most session starts skip the network call.
+
 ## 0.3.139 — 2026-08-08
 
 ### Hooks — revert resurface-response-clarity (reverts #254/#256)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Hooks — check-policy-freshness (SessionStart staleness warning)
 
-New `hooks/check-policy-freshness.sh`, wired as a Tessl `SessionStart` hook. It runs `tessl outdated --json` and, when installed plugins are behind the registry, injects a one-line `tessl update` reminder via `additionalContext`. Informative only — never blocks (always exits 0), degrades to a silent no-op if `tessl`/`jq` are absent or the registry check fails.
+New `hooks/check-policy-freshness.sh`, wired as a Tessl `SessionStart` hook. It runs `tessl outdated --json` and, when installed plugins are behind the registry, injects a short `tessl update` reminder via `additionalContext` (one line per outdated plugin). Informative only — never blocks (always exits 0), degrades to a silent no-op if `tessl`/`jq` are absent or the registry check fails.
 
 This is the first hook built on the "a hook DOES a deterministic thing at a lifecycle event" principle, after the resurface hook was reverted for re-stating a rule the model already had. It targets a measured problem: fleet repos silently drift onto stale policy versions with nothing flagging it (a consumer was observed running 0.3.138 while 0.3.139 was published). `SessionStart` fires once per session — no per-turn tax — and the registry check is throttled to once per `FRESHNESS_THROTTLE_HOURS` (default 24h) so most session starts skip the network call.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Coding policy plugin for Baruch's AI agents. Language-agnostic code quality rule
 
 ## What's New
 
+- `check-policy-freshness` hook — a Tessl `SessionStart` hook that runs `tessl outdated` and warns (throttled to once/day) when installed plugins are behind the registry, so repos don't silently drift onto stale policy. Informative only, never blocks
 - Policy review runs on the OpenAI Codex CLI authenticated by a ChatGPT subscription (no API key) via `.github/workflows/review-codex.yml`, reviewing every PR against the in-tree `rules/*.md`; Copilot stays as the complementary code-quality lane
 - 24 rules — 18 always-on, 6 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 10 covering code quality, 7 covering plugin authoring, 1 covering concurrency, 1 covering review discipline, 1 covering reviewer-feedback reading, 1 covering review severity, 1 covering external-repo action scope, 1 covering response communication, 1 covering merge/ship autonomy
 - `release` skill — structured PR + merge workflow gated on the Codex policy review's blocking findings; Copilot is the complementary code-quality lane and is always advisory
@@ -59,6 +60,12 @@ tessl install jbaruch/coding-policy
 | [install-reviewer](skills/install-reviewer/SKILL.md) | Enroll a consumer repo in the central fleet policy reviewer — scaffold the `.github/fleet-review-enabled` marker, a thin `.github/workflows/review-trigger.yml` (fires an immediate PR-time review in `coding-policy`), and `.github/copilot-instructions.md`, then open a PR. The `coding-policy-fleet-reviewer` GitHub App reviews against the `jbaruch/coding-policy` rules with the Codex CLI on a ChatGPT subscription (no API key). The Codex credential lives only in `coding-policy`; the consumer sets one stable `FLEET_DISPATCH_TOKEN` (a narrow PAT). Supports `--override` for in-place upgrades. |
 | [adopt-fork-pr](skills/adopt-fork-pr/SKILL.md) | Classify a PR by number. Same-repo PRs pass through to the reviewer; fork PRs get adopted into the base repo as a same-repo PR, preserving the contributor's commits. |
 | [migrate-to-plugin](skills/migrate-to-plugin/SKILL.md) | Migrate a legacy `tile.json` plugin to the `.tessl-plugin/plugin.json` form: runs `tessl plugin migrate`, renames `.tileignore`, removes the obsolete `tile.json`, re-lints, then reconciles residual "tile" wording to "plugin" while preserving contract surfaces. |
+
+### Hooks
+
+| Hook | Event | Description |
+| ---- | ----- | ----------- |
+| [check-policy-freshness](hooks/check-policy-freshness.sh) | SessionStart | Warns (throttled once/day) when installed Tessl plugins are behind the registry — a `tessl update` reminder at session start. Informative only, never blocks. |
 
 ## Philosophy
 

--- a/hooks/check-policy-freshness.sh
+++ b/hooks/check-policy-freshness.sh
@@ -2,8 +2,8 @@
 # Warn at session start when installed Tessl plugins are behind the registry.
 #
 # A SessionStart hook: runs `tessl outdated --json`, and if anything is behind,
-# injects a one-line notice via additionalContext so the agent/user sees it and
-# can `tessl update`. Fleet repos silently drift to stale policy versions with
+# injects a short notice via additionalContext so the agent/user sees it and can
+# `tessl update`. Fleet repos silently drift to stale policy versions with
 # nothing flagging it (observed: consumers running an old coding-policy while a
 # newer one is published); this surfaces that the moment a session opens.
 #
@@ -17,6 +17,7 @@
 # Contract:
 #   stdin : consensus SessionStart JSON — not read (the script needs none of it).
 #   stdout: on a fire, one JSON object {"additionalContext": "<notice>"}; else nothing.
+#           The notice may span multiple lines (a header plus one line per plugin).
 #   exit  : always 0. Every best-effort failure emits an actionable stderr warning
 #           and continues/no-ops (rules/error-handling.md Shell Error Handling).
 #   state : $FRESHNESS_STATE_DIR/last-check (default ${TMPDIR:-/tmp}/coding-policy-freshness),
@@ -32,15 +33,28 @@ warn() { printf 'check-policy-freshness: %s\n' "$1" >&2; }
 
 # jq and tessl are both required to produce a signal; a missing optional tool is
 # an expected environment condition, not a failure — warn and no-op.
-command -v jq >/dev/null 2>&1 || { warn "jq not found — skipping freshness check"; exit 0; }
-command -v tessl >/dev/null 2>&1 || { warn "tessl not found — skipping freshness check"; exit 0; }
+command -v jq >/dev/null 2>&1 || { warn "jq not found — install jq to enable the freshness check"; exit 0; }
+command -v tessl >/dev/null 2>&1 || { warn "tessl not found — install the Tessl CLI to enable the freshness check"; exit 0; }
 
 if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
   warn "FRESHNESS_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 24"
   THROTTLE_HOURS=24
 fi
 
-now="${FRESHNESS_NOW:-$(date +%s)}"
+# Resolve the clock. A test may inject FRESHNESS_NOW; otherwise read the system
+# clock and handle its failure. Validate the result as an integer before any
+# arithmetic so a malformed value can't abort the hook under set -e.
+if [[ -n "${FRESHNESS_NOW:-}" ]]; then
+  now="$FRESHNESS_NOW"
+elif ! now="$(date +%s)"; then
+  warn "cannot read the system clock — skipping freshness check"
+  exit 0
+fi
+if ! [[ "$now" =~ ^[0-9]+$ ]]; then
+  warn "clock value '${now}' is not an integer — unset FRESHNESS_NOW; skipping freshness check"
+  exit 0
+fi
+
 stamp="${STATE_DIR}/last-check"
 
 # Throttle: skip the registry call if we checked within the window.
@@ -56,20 +70,21 @@ fi
 # Record the check up front so a slow/failed registry call still throttles the
 # next session rather than hammering the registry on every start.
 if mkdir -p "$STATE_DIR"; then
-  printf '%s\n' "$now" > "$stamp" || warn "cannot write throttle stamp ${stamp} — will re-check next session"
+  printf '%s\n' "$now" > "$stamp" ||
+    warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-check next session"
 else
-  warn "cannot create state dir ${STATE_DIR} — freshness check will not throttle"
+  warn "cannot create state dir ${STATE_DIR} — check permissions or set FRESHNESS_STATE_DIR; freshness check will not throttle"
 fi
 
 # Silence tessl's own diagnostic but explicitly handle the failure and warn —
 # an offline/registry error is a no-op, not a broken session.
 if ! out="$(tessl outdated --json 2>/dev/null)"; then
-  warn "tessl outdated failed (offline or registry error) — skipping freshness check"
+  warn "tessl outdated failed — check connectivity and retry \`tessl outdated\`; skipping freshness check"
   exit 0
 fi
 
-# Build a compact notice line per outdated plugin. Empty list => silent. A parse
-# failure is surfaced, not swallowed as "nothing outdated".
+# Build a notice line per outdated plugin. Empty list => silent. A parse failure
+# is surfaced, not swallowed as "nothing outdated".
 if ! notice="$(printf '%s' "$out" | jq -r '
   (.outdated // [])
   | map("- \(.current.tile.workspaceName)/\(.current.tile.tileName) \(.current.tile.version) -> \(.update.version)")
@@ -77,10 +92,14 @@ if ! notice="$(printf '%s' "$out" | jq -r '
       "Plugin updates available (run `tessl update`):\n" + (. | join("\n"))
     end
 ' 2>/dev/null)"; then
-  warn "could not parse tessl outdated output — skipping freshness check"
+  warn "could not parse \`tessl outdated --json\` output — run it manually to inspect; skipping freshness check"
   exit 0
 fi
 
 [[ -n "$notice" ]] || exit 0
-jq -n --arg c "$notice" '{additionalContext: $c}'
+
+if ! jq -n --arg c "$notice" '{additionalContext: $c}'; then
+  warn "could not emit the update notice as JSON — skipping freshness check"
+  exit 0
+fi
 exit 0

--- a/hooks/check-policy-freshness.sh
+++ b/hooks/check-policy-freshness.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Warn at session start when installed Tessl plugins are behind the registry.
+#
+# A SessionStart hook: runs `tessl outdated --json`, and if anything is behind,
+# injects a one-line notice via additionalContext so the agent/user sees it and
+# can `tessl update`. Fleet repos silently drift to stale policy versions with
+# nothing flagging it (observed: consumers running an old coding-policy while a
+# newer one is published); this surfaces that the moment a session opens.
+#
+# Design choices, learned from the reverted resurface hook:
+#   - It DOES something (checks registry state), it does not re-state a rule.
+#   - SessionStart fires once per session, not per turn — no per-turn fleet tax.
+#   - Throttled: a registry check runs at most once per FRESHNESS_THROTTLE_HOURS
+#     (default 24h) across sessions, so most session starts skip the network call.
+#   - Informative only. Never blocks (always exits 0), never exits 2.
+#
+# Contract:
+#   stdin : consensus SessionStart JSON (unused beyond being drained).
+#   stdout: on a fire, one JSON object {"additionalContext": "<notice>"}; else nothing.
+#   exit  : always 0. Degrades to a silent no-op if tessl/jq are missing, the
+#           check errors, or the state dir is unwritable.
+#   state : $FRESHNESS_STATE_DIR/last-check (default ${TMPDIR:-/tmp}/coding-policy-freshness),
+#           a single epoch-seconds throttle stamp.
+#   env   : FRESHNESS_THROTTLE_HOURS (default 24), FRESHNESS_STATE_DIR (tests).
+set -euo pipefail
+
+THROTTLE_HOURS="${FRESHNESS_THROTTLE_HOURS:-24}"
+STATE_DIR="${FRESHNESS_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-freshness}"
+
+warn() { printf 'check-policy-freshness: %s\n' "$1" >&2; }
+
+cat >/dev/null 2>&1 || true   # drain stdin; we don't need its fields
+
+# jq and tessl are both required to produce a signal; without either, no-op.
+command -v jq >/dev/null 2>&1 || exit 0
+command -v tessl >/dev/null 2>&1 || exit 0
+
+if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
+  warn "FRESHNESS_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 24"
+  THROTTLE_HOURS=24
+fi
+
+now="$(date +%s)"
+stamp="${STATE_DIR}/last-check"
+
+# Throttle: skip the registry call if we checked within the window.
+if [[ -r "$stamp" ]]; then
+  last=""
+  read -r last < "$stamp" 2>/dev/null || last=""
+  [[ "$last" =~ ^[0-9]+$ ]] || last=0
+  if (( now - last < THROTTLE_HOURS * 3600 )); then
+    exit 0
+  fi
+fi
+
+# Record the check up front so a slow/failed registry call still throttles the
+# next session rather than hammering the registry on every start.
+if mkdir -p "$STATE_DIR" 2>/dev/null; then
+  printf '%s\n' "$now" > "$stamp" 2>/dev/null || warn "cannot write throttle stamp ${stamp}"
+fi
+
+# Explicit fallback: a tessl/network failure is a no-op, not a broken session.
+out="$(tessl outdated --json 2>/dev/null)" || exit 0
+
+# Build a compact notice line per outdated plugin. Empty list => silent.
+notice="$(printf '%s' "$out" | jq -r '
+  (.outdated // [])
+  | map("- \(.current.tile.workspaceName)/\(.current.tile.tileName) \(.current.tile.version) -> \(.update.version)")
+  | if length == 0 then empty else
+      "Plugin updates available (run `tessl update`):\n" + (. | join("\n"))
+    end
+' 2>/dev/null)" || exit 0
+
+[[ -n "$notice" ]] || exit 0
+jq -n --arg c "$notice" '{additionalContext: $c}'
+exit 0

--- a/hooks/check-policy-freshness.sh
+++ b/hooks/check-policy-freshness.sh
@@ -15,13 +15,14 @@
 #   - Informative only. Never blocks (always exits 0), never exits 2.
 #
 # Contract:
-#   stdin : consensus SessionStart JSON (unused beyond being drained).
+#   stdin : consensus SessionStart JSON — not read (the script needs none of it).
 #   stdout: on a fire, one JSON object {"additionalContext": "<notice>"}; else nothing.
-#   exit  : always 0. Degrades to a silent no-op if tessl/jq are missing, the
-#           check errors, or the state dir is unwritable.
+#   exit  : always 0. Every best-effort failure emits an actionable stderr warning
+#           and continues/no-ops (rules/error-handling.md Shell Error Handling).
 #   state : $FRESHNESS_STATE_DIR/last-check (default ${TMPDIR:-/tmp}/coding-policy-freshness),
 #           a single epoch-seconds throttle stamp.
-#   env   : FRESHNESS_THROTTLE_HOURS (default 24), FRESHNESS_STATE_DIR (tests).
+#   env   : FRESHNESS_THROTTLE_HOURS (default 24), FRESHNESS_STATE_DIR (tests),
+#           FRESHNESS_NOW (test-only injected clock; defaults to `date +%s`).
 set -euo pipefail
 
 THROTTLE_HOURS="${FRESHNESS_THROTTLE_HOURS:-24}"
@@ -29,24 +30,23 @@ STATE_DIR="${FRESHNESS_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-freshness}"
 
 warn() { printf 'check-policy-freshness: %s\n' "$1" >&2; }
 
-cat >/dev/null 2>&1 || true   # drain stdin; we don't need its fields
-
-# jq and tessl are both required to produce a signal; without either, no-op.
-command -v jq >/dev/null 2>&1 || exit 0
-command -v tessl >/dev/null 2>&1 || exit 0
+# jq and tessl are both required to produce a signal; a missing optional tool is
+# an expected environment condition, not a failure — warn and no-op.
+command -v jq >/dev/null 2>&1 || { warn "jq not found — skipping freshness check"; exit 0; }
+command -v tessl >/dev/null 2>&1 || { warn "tessl not found — skipping freshness check"; exit 0; }
 
 if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
   warn "FRESHNESS_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 24"
   THROTTLE_HOURS=24
 fi
 
-now="$(date +%s)"
+now="${FRESHNESS_NOW:-$(date +%s)}"
 stamp="${STATE_DIR}/last-check"
 
 # Throttle: skip the registry call if we checked within the window.
 if [[ -r "$stamp" ]]; then
   last=""
-  read -r last < "$stamp" 2>/dev/null || last=""
+  read -r last < "$stamp" || last=""
   [[ "$last" =~ ^[0-9]+$ ]] || last=0
   if (( now - last < THROTTLE_HOURS * 3600 )); then
     exit 0
@@ -55,21 +55,31 @@ fi
 
 # Record the check up front so a slow/failed registry call still throttles the
 # next session rather than hammering the registry on every start.
-if mkdir -p "$STATE_DIR" 2>/dev/null; then
-  printf '%s\n' "$now" > "$stamp" 2>/dev/null || warn "cannot write throttle stamp ${stamp}"
+if mkdir -p "$STATE_DIR"; then
+  printf '%s\n' "$now" > "$stamp" || warn "cannot write throttle stamp ${stamp} — will re-check next session"
+else
+  warn "cannot create state dir ${STATE_DIR} — freshness check will not throttle"
 fi
 
-# Explicit fallback: a tessl/network failure is a no-op, not a broken session.
-out="$(tessl outdated --json 2>/dev/null)" || exit 0
+# Silence tessl's own diagnostic but explicitly handle the failure and warn —
+# an offline/registry error is a no-op, not a broken session.
+if ! out="$(tessl outdated --json 2>/dev/null)"; then
+  warn "tessl outdated failed (offline or registry error) — skipping freshness check"
+  exit 0
+fi
 
-# Build a compact notice line per outdated plugin. Empty list => silent.
-notice="$(printf '%s' "$out" | jq -r '
+# Build a compact notice line per outdated plugin. Empty list => silent. A parse
+# failure is surfaced, not swallowed as "nothing outdated".
+if ! notice="$(printf '%s' "$out" | jq -r '
   (.outdated // [])
   | map("- \(.current.tile.workspaceName)/\(.current.tile.tileName) \(.current.tile.version) -> \(.update.version)")
   | if length == 0 then empty else
       "Plugin updates available (run `tessl update`):\n" + (. | join("\n"))
     end
-' 2>/dev/null)" || exit 0
+' 2>/dev/null)"; then
+  warn "could not parse tessl outdated output — skipping freshness check"
+  exit 0
+fi
 
 [[ -n "$notice" ]] || exit 0
 jq -n --arg c "$notice" '{additionalContext: $c}'

--- a/hooks/tests/test_check_policy_freshness.sh
+++ b/hooks/tests/test_check_policy_freshness.sh
@@ -70,15 +70,24 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle active: call ins
 run "$d" STUB_JSON="$OUTDATED" FRESHNESS_NOW=1090000            # +25h, past window
 if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext' >/dev/null 2>&1; then pass; else fail "throttle expired: call past window should fire, got OUT=$OUT"; fi
 
-# 4. tessl missing -> silent no-op (PATH without the stub, and without real tessl)
+# 4. tessl missing -> silent no-op. Build a minimal PATH with symlinks to the
+#    tools the hook needs (jq present so it passes that check) but NO tessl, so
+#    the test is environment-independent rather than assuming /usr/bin contents.
+minbin="$TMP/minbin"; mkdir -p "$minbin"
+for t in bash jq date mkdir; do ln -s "$(command -v "$t")" "$minbin/$t"; done
 d="$TMP/c4"
-OUT="$(env "PATH=/usr/bin:/bin" FRESHNESS_STATE_DIR="$d" bash "$SCRIPT" </dev/null 2>/dev/null)"; RC=$?
+OUT="$(env "PATH=$minbin" FRESHNESS_STATE_DIR="$d" bash "$SCRIPT" </dev/null 2>/dev/null)"; RC=$?
 if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "tessl missing: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
 
 # 5. tessl errors -> silent no-op
 d="$TMP/c5"
 run "$d" STUB_JSON="$OUTDATED" STUB_EXIT=1
 if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "tessl error: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+# 6. malformed injected clock -> no-op, exit 0 (never aborts SessionStart).
+d="$TMP/c6"
+run "$d" STUB_JSON="$OUTDATED" FRESHNESS_NOW="not-a-number"
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "invalid clock: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
 
 echo "─────────────────────────────────────────────" >&2
 if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi

--- a/hooks/tests/test_check_policy_freshness.sh
+++ b/hooks/tests/test_check_policy_freshness.sh
@@ -7,7 +7,8 @@
 # Covers:
 #   1. Outdated present  -> emits additionalContext naming the plugin + new version.
 #   2. Nothing outdated  -> silent (empty stdout), exit 0.
-#   3. Throttle          -> a second call within the window is silent even if outdated.
+#   3. Throttle          -> with an injected fixed clock (FRESHNESS_NOW): a call
+#                           inside the window is silent, a call past it fires again.
 #   4. tessl missing     -> silent no-op, exit 0 (no crash).
 #   5. tessl errors      -> silent no-op, exit 0 (network/registry failure tolerated).
 #
@@ -58,12 +59,16 @@ d="$TMP/c2"
 run "$d" STUB_JSON="$EMPTY"
 if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "empty outdated: expected silence, got RC=$RC OUT=$OUT"; fi
 
-# 3. throttle -> second call within window is silent
+# 3. throttle -> deterministic via an injected clock (FRESHNESS_NOW), not the
+#    real wall clock. First call stamps t; a call 1h later is throttled; a call
+#    25h later (past the 24h window) fires again.
 d="$TMP/c3"
-run "$d" STUB_JSON="$OUTDATED"   # first call fires + writes stamp
+run "$d" STUB_JSON="$OUTDATED" FRESHNESS_NOW=1000000            # fires, stamps 1000000
 [[ -n "$OUT" ]] || fail "throttle setup: first call should have fired"
-run "$d" STUB_JSON="$OUTDATED"   # second call within window
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle: second call should be silent, got OUT=$OUT"; fi
+run "$d" STUB_JSON="$OUTDATED" FRESHNESS_NOW=1003600            # +1h, inside 24h window
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle active: call inside window should be silent, got OUT=$OUT"; fi
+run "$d" STUB_JSON="$OUTDATED" FRESHNESS_NOW=1090000            # +25h, past window
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext' >/dev/null 2>&1; then pass; else fail "throttle expired: call past window should fire, got OUT=$OUT"; fi
 
 # 4. tessl missing -> silent no-op (PATH without the stub, and without real tessl)
 d="$TMP/c4"

--- a/hooks/tests/test_check_policy_freshness.sh
+++ b/hooks/tests/test_check_policy_freshness.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Outcome-based tests for check-policy-freshness.sh.
+#
+# The hook shells out to `tessl outdated --json`, so tests put a stub `tessl` on
+# PATH (real jq/bash/date stay resolvable) and drive it via STUB_JSON / STUB_EXIT.
+#
+# Covers:
+#   1. Outdated present  -> emits additionalContext naming the plugin + new version.
+#   2. Nothing outdated  -> silent (empty stdout), exit 0.
+#   3. Throttle          -> a second call within the window is silent even if outdated.
+#   4. tessl missing     -> silent no-op, exit 0 (no crash).
+#   5. tessl errors      -> silent no-op, exit 0 (network/registry failure tolerated).
+#
+# Run: bash hooks/tests/test_check_policy_freshness.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/check-policy-freshness.sh"
+[[ -f "$SCRIPT" && -r "$SCRIPT" ]] || { echo "fatal: hook not found/readable at $SCRIPT" >&2; exit 2; }
+command -v jq >/dev/null 2>&1 || { echo "fatal: jq required for these tests" >&2; exit 2; }
+
+TMP="$(mktemp -d -t freshness-test.XXXXXX)" || { echo "fatal: mktemp failed" >&2; exit 2; }
+cleanup() { [[ -n "${TMP:-}" ]] && ! rm -rf "$TMP" && echo "warn: could not remove $TMP" >&2; return 0; }
+trap cleanup EXIT
+
+# A stub `tessl` that echoes $STUB_JSON for `outdated`, or exits $STUB_EXIT.
+STUBBIN="$TMP/bin"; mkdir -p "$STUBBIN"
+cat > "$STUBBIN/tessl" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "outdated" ]]; then
+  [[ -n "${STUB_EXIT:-}" ]] && exit "$STUB_EXIT"
+  printf '%s' "${STUB_JSON:-}"
+fi
+STUB
+chmod +x "$STUBBIN/tessl"
+
+OUTDATED='{"outdated":[{"current":{"tile":{"workspaceName":"jbaruch","tileName":"coding-policy","version":"0.3.138"}},"update":{"version":"0.3.139"}}]}'
+EMPTY='{"outdated":[]}'
+
+FAIL=0; PASS=0
+pass() { PASS=$((PASS+1)); }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ FAIL: $1" >&2; }
+
+# run <state-dir> [extra env assignments...] -> OUT, RC  (stub tessl on PATH)
+run() {
+  local dir="$1"; shift
+  OUT="$(env "PATH=$STUBBIN:$PATH" FRESHNESS_STATE_DIR="$dir" "$@" bash "$SCRIPT" </dev/null 2>/dev/null)"
+  RC=$?
+}
+
+# 1. outdated present -> notice
+d="$TMP/c1"
+run "$d" STUB_JSON="$OUTDATED"
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("coding-policy") and test("0.3.139")' >/dev/null 2>&1; then
+  pass; else fail "outdated present: expected notice, got RC=$RC OUT=$OUT"; fi
+
+# 2. nothing outdated -> silent
+d="$TMP/c2"
+run "$d" STUB_JSON="$EMPTY"
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "empty outdated: expected silence, got RC=$RC OUT=$OUT"; fi
+
+# 3. throttle -> second call within window is silent
+d="$TMP/c3"
+run "$d" STUB_JSON="$OUTDATED"   # first call fires + writes stamp
+[[ -n "$OUT" ]] || fail "throttle setup: first call should have fired"
+run "$d" STUB_JSON="$OUTDATED"   # second call within window
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle: second call should be silent, got OUT=$OUT"; fi
+
+# 4. tessl missing -> silent no-op (PATH without the stub, and without real tessl)
+d="$TMP/c4"
+OUT="$(env "PATH=/usr/bin:/bin" FRESHNESS_STATE_DIR="$d" bash "$SCRIPT" </dev/null 2>/dev/null)"; RC=$?
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "tessl missing: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+# 5. tessl errors -> silent no-op
+d="$TMP/c5"
+run "$d" STUB_JSON="$OUTDATED" STUB_EXIT=1
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "tessl error: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+echo "─────────────────────────────────────────────" >&2
+if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi
+echo "PASSED: all ${PASS} checks" >&2

--- a/scripts/run-diagnostics.sh
+++ b/scripts/run-diagnostics.sh
@@ -22,7 +22,7 @@
 # Output:
 #   stderr: each engine's native findings plus per-engine progress.
 # Usage: scripts/run-diagnostics.sh [base-dir]
-#   base-dir  Tree whose skills/, scripts/, .github/actions/, and
+#   base-dir  Tree whose skills/, scripts/, hooks/, .github/actions/, and
 #             .github/codex-review/ are scanned for shell scripts.
 #             Defaults to the repo root. The
 #             optional arg exists so the runner's own test can point it at
@@ -65,6 +65,9 @@ main() {
   local roots=()
   [[ -d "$base/skills" ]] && roots+=("$base/skills")
   [[ -d "$base/scripts" ]] && roots+=("$base/scripts")
+  # First-party hook scripts (hooks/*.sh + their tests) — gate them at the
+  # same zero-findings bar as every other shipped shell script.
+  [[ -d "$base/hooks" ]] && roots+=("$base/hooks")
   # Composite-action bodies extracted to real scripts per
   # rules/script-delegation.md (e.g. skill-review/review-skills.sh) — gate
   # them too so an action script is held to the same zero-findings bar.
@@ -76,7 +79,7 @@ main() {
   # "clean" (#199).
   [[ -d "$base/.github/codex-review" ]] && roots+=("$base/.github/codex-review")
   if [[ ${#roots[@]} -eq 0 ]]; then
-    echo "run-diagnostics: none of skills/, scripts/, .github/actions/, .github/codex-review/ found under $base" >&2
+    echo "run-diagnostics: none of skills/, scripts/, hooks/, .github/actions/, .github/codex-review/ found under $base" >&2
     return 2
   fi
 


### PR DESCRIPTION
The first *useful* hook, replacing the reverted resurface hook (#259) with one built on the right principle: **a hook DOES a deterministic thing at a lifecycle event — it doesn't re-state a rule the model already has.**

## What

`hooks/check-policy-freshness.sh`, wired as a Tessl `SessionStart` hook. Runs `tessl outdated --json`; if installed plugins are behind the registry, injects a one-line `tessl update` reminder via `additionalContext`.

- **Informative only** — always exits 0, never blocks (no exit 2), degrades to a silent no-op if `tessl`/`jq` are missing or the registry check fails.
- **Once per session, throttled to once/day** (`FRESHNESS_THROTTLE_HOURS`, default 24h) — so most session starts skip the network call. No per-turn tax (the resurface hook's real cost).

## Why (measured, not guessed)

Fleet repos silently drift onto stale policy with nothing flagging it. Verified live: `speaker-toolkit` was running `coding-policy@0.3.138` while `0.3.139` was published — `tessl outdated` flags it cleanly. Confirmed the hook emits the right notice against that real drift before shipping.

## Tests

- `hooks/tests/test_check_policy_freshness.sh` — 5 checks (outdated→notice, empty→silent, throttle, tessl-missing→no-op, tessl-error→no-op) with a stubbed `tessl`.
- Full suite 21/21, shellcheck + pyright clean, `tessl plugin lint` valid. Re-adds `hooks/` to the diagnostics gate.

Next in the plan: `SessionStart` sync-before-work fetch, and a `Stop` handoff-hygiene gate (diagnostics + merged-but-undeleted local branches + orphaned worktrees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GummAyubViVFrn5TVEUWEi