### PR TITLE
feat(hooks): add check-git-sync SessionStart hook

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -45,6 +45,13 @@
             "args": [
               "${TESSL_PLUGIN_DIR}/hooks/check-policy-freshness.sh"
             ]
+          },
+          {
+            "type": "command",
+            "command": "bash",
+            "args": [
+              "${TESSL_PLUGIN_DIR}/hooks/check-git-sync.sh"
+            ]
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Hooks — check-git-sync (SessionStart sync-before-work warning)
 
-New `hooks/check-git-sync.sh`, wired as a second Tessl `SessionStart` hook (#261). It fetches origin (time-bounded, throttled to once per `SYNC_THROTTLE_HOURS` — default 1h — per repo) and, when the local default branch trails `origin/<default>`, injects a short "sync before working" notice via `additionalContext`. Informative only — never blocks (always exits 0), degrades to a silent no-op outside a git repo, without an `origin` remote, without a local default branch, or when the fetch fails.
+New `hooks/check-git-sync.sh`, wired as a second Tessl `SessionStart` hook (#261). It fetches origin (time-bounded, throttled to once per `SYNC_THROTTLE_HOURS` — default 1h — per repo) and, when the local default branch is behind `origin/<default>`, injects a short "sync before working" notice via `additionalContext`. A diverged branch (both ahead and behind) gets a distinct notice recommending a rebase rather than a fast-forward. Informative only — never blocks (always exits 0), degrades to a silent no-op outside a git repo, without an `origin` remote, without a local default branch, or when the fetch fails.
 
 This mechanizes `rules/sync-before-work.md`, which prescribed fetch-before-work but relied on the agent remembering; stale-checkout ("main is behind") recurred in real work. The remote default is resolved from `origin/HEAD` (falling back to `main`/`master` among the remote-tracking refs), and the behind comparison runs even on throttled sessions against the last-fetched ref, so staleness surfaces without a network call every session.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Hooks — check-git-sync (SessionStart sync-before-work warning)
+
+New `hooks/check-git-sync.sh`, wired as a second Tessl `SessionStart` hook (#261). It fetches origin (time-bounded, throttled to once per `SYNC_THROTTLE_HOURS` — default 1h — per repo) and, when the local default branch trails `origin/<default>`, injects a short "sync before working" notice via `additionalContext`. Informative only — never blocks (always exits 0), degrades to a silent no-op outside a git repo, without an `origin` remote, without a local default branch, or when the fetch fails.
+
+This mechanizes `rules/sync-before-work.md`, which prescribed fetch-before-work but relied on the agent remembering; stale-checkout ("main is behind") recurred in real work. The remote default is resolved from `origin/HEAD` (falling back to `main`/`master` among the remote-tracking refs), and the behind comparison runs even on throttled sessions against the last-fetched ref, so staleness surfaces without a network call every session.
+
 ## 0.3.140 — 2026-08-09
 
 ### Hooks — check-policy-freshness (SessionStart staleness warning)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ New `hooks/check-git-sync.sh`, wired as a second Tessl `SessionStart` hook (#261
 
 This mechanizes `rules/sync-before-work.md`, which prescribed fetch-before-work but relied on the agent remembering; stale-checkout ("main is behind") recurred in real work. The remote default is resolved from `origin/HEAD` (falling back to `main`/`master` among the remote-tracking refs), and the behind comparison runs even on throttled sessions against the last-fetched ref, so staleness surfaces without a network call every session.
 
+Also wraps both `SessionStart` hooks (`check-git-sync.sh` and, boy-scouted for consistency, `check-policy-freshness.sh`) in a `main()` with a `${BASH_SOURCE[0]} == "$0"` entry-point guard per `rules/file-hygiene.md`, so each script is sourceable for unit-testing its functions. No behavior change when executed.
+
 ## 0.3.140 — 2026-08-09
 
 ### Hooks — check-policy-freshness (SessionStart staleness warning)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Coding policy plugin for Baruch's AI agents. Language-agnostic code quality rule
 
 ## What's New
 
+- `check-git-sync` hook — a Tessl `SessionStart` hook that fetches origin (throttled) and warns when the local default branch is behind `origin/<default>`, mechanizing `rules/sync-before-work.md`. Informative only, never blocks
 - `check-policy-freshness` hook — a Tessl `SessionStart` hook that runs `tessl outdated` and warns (throttled to once/day) when installed plugins are behind the registry, so repos don't silently drift onto stale policy. Informative only, never blocks
 - Policy review runs on the OpenAI Codex CLI authenticated by a ChatGPT subscription (no API key) via `.github/workflows/review-codex.yml`, reviewing every PR against the in-tree `rules/*.md`; Copilot stays as the complementary code-quality lane
 - 24 rules — 18 always-on, 6 conditional (scoped via `applyTo:` to the files where the rule's prescriptions actually fire). Breakdown: 10 covering code quality, 7 covering plugin authoring, 1 covering concurrency, 1 covering review discipline, 1 covering reviewer-feedback reading, 1 covering review severity, 1 covering external-repo action scope, 1 covering response communication, 1 covering merge/ship autonomy
@@ -66,6 +67,7 @@ tessl install jbaruch/coding-policy
 | Hook | Event | Description |
 | ---- | ----- | ----------- |
 | [check-policy-freshness](hooks/check-policy-freshness.sh) | SessionStart | Warns (throttled once/day) when installed Tessl plugins are behind the registry — a `tessl update` reminder at session start. Informative only, never blocks. |
+| [check-git-sync](hooks/check-git-sync.sh) | SessionStart | Fetches origin (throttled once/hour per repo) and warns when the local default branch is behind `origin/<default>` — a `rules/sync-before-work.md` reminder at session start. Informative only, never blocks. |
 
 ## Philosophy
 

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -39,16 +39,46 @@ STATE_DIR="${SYNC_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-sync}"
 
 warn() { printf 'check-git-sync: %s\n' "$1" >&2; }
 
+# Does a ref exist? `git show-ref --verify --quiet` exits 0 (exists) or 1 (the
+# expected "absent / malformed name" no-result); any other exit is a real git
+# failure — surface it and treat the ref as absent so best-effort work continues
+# visibly (rules/error-handling.md — distinguish a non-result from a tool error).
+ref_exists() { # <fully-qualified-ref>
+  local rc=0
+  git show-ref --verify --quiet "$1" || rc=$?
+  if (( rc == 0 )); then return 0; fi
+  if (( rc != 1 )); then
+    warn "git show-ref failed (exit ${rc}) checking $1 — treating the ref as absent"
+  fi
+  return 1
+}
+
 # git is required to produce a signal; its absence is an expected environment
 # condition, not a failure — warn and no-op.
 command -v git >/dev/null 2>&1 || { warn "git not found — install git to enable the sync check"; exit 0; }
 
-# Outside a work tree there is nothing to sync — the common non-repo session.
-# Silent no-op (git prints its own error to the discarded stderr).
-git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+# Outside a work tree there is nothing to sync. `--is-inside-work-tree` prints
+# true/false and exits 0 inside any repo; its only failure is exit 128 ("not a
+# git repository") — the expected non-repo session. Proceed only on a literal
+# "true"; a bare repo / gitdir ("false") and the non-repo case are silent
+# no-ops, and an unexpected value is surfaced.
+inside="$(git rev-parse --is-inside-work-tree 2>/dev/null)" || inside="__notrepo__"
+case "$inside" in
+  true) : ;;
+  false|__notrepo__) exit 0 ;;
+  *) warn "unexpected \`git rev-parse --is-inside-work-tree\` output '${inside}' — skipping sync check"; exit 0 ;;
+esac
 
-# No origin remote => nothing to compare against. Silent no-op.
-git remote get-url origin >/dev/null 2>&1 || exit 0
+# No origin remote => nothing to compare against. `git remote get-url` exits 2
+# for the documented "No such remote" (silent no-op); any other non-zero is a
+# real git failure and is surfaced (rules/error-handling.md).
+rc=0
+git remote get-url origin >/dev/null 2>&1 || rc=$?
+if (( rc != 0 )); then
+  if (( rc == 2 )); then exit 0; fi
+  warn "git remote get-url origin failed (exit ${rc}) — run \`git remote -v\` to inspect; skipping sync check"
+  exit 0
+fi
 
 if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
   warn "SYNC_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 1"
@@ -74,7 +104,7 @@ fi
 # Fallback: probe the conventional names among the remote-tracking refs we have.
 if [[ -z "$db" ]]; then
   for cand in main master; do
-    if git show-ref --verify --quiet "refs/remotes/origin/$cand"; then db="$cand"; break; fi
+    if ref_exists "refs/remotes/origin/$cand"; then db="$cand"; break; fi
   done
 fi
 if [[ -z "$db" ]]; then
@@ -83,8 +113,9 @@ if [[ -z "$db" ]]; then
 fi
 
 # No local default branch (e.g. only feature branches checked out) => nothing to
-# report as "behind". Silent no-op.
-git show-ref --verify --quiet "refs/heads/$db" || exit 0
+# report as "behind". Silent no-op when absent; ref_exists surfaces a real
+# git failure before returning "absent".
+ref_exists "refs/heads/$db" || exit 0
 
 # Resolve the clock. A test may inject SYNC_NOW; otherwise read the system clock
 # and handle its failure. Validate as an integer before any arithmetic so a
@@ -105,7 +136,10 @@ fi
 # A cksum/cut failure would abort the assignment under set -e and break the
 # always-exit-0 contract, so handle it: fall back to an un-throttled run rather
 # than crash the session.
-top="$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
+if ! top="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  warn "git rev-parse --show-toplevel failed — keying the throttle stamp on \$PWD instead"
+  top="$PWD"
+fi
 if ! repo_key="$(printf '%s' "$top" | cksum | cut -d' ' -f1)"; then
   warn "could not derive a throttle key for ${top} — sync check will not throttle this run"
   repo_key=""

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -33,10 +33,6 @@
 #           to `date +%s`).
 set -euo pipefail
 
-THROTTLE_HOURS="${SYNC_THROTTLE_HOURS:-1}"
-FETCH_TIMEOUT="${SYNC_FETCH_TIMEOUT:-10}"
-STATE_DIR="${SYNC_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-sync}"
-
 warn() { printf 'check-git-sync: %s\n' "$1" >&2; }
 
 # Does a ref exist? `git show-ref --verify --quiet` exits 0 (exists) or 1 (the
@@ -53,165 +49,183 @@ ref_exists() { # <fully-qualified-ref>
   return 1
 }
 
-# git is required to produce a signal; its absence is an expected environment
-# condition, not a failure — warn and no-op.
-command -v git >/dev/null 2>&1 || { warn "git not found — install git to enable the sync check"; exit 0; }
+# Emit the sync notice as additionalContext JSON. jq is required only here; its
+# absence is an expected environment condition, not a failure.
+emit_notice() { # <notice-text>
+  command -v jq >/dev/null 2>&1 || { warn "jq not found — install jq to emit the sync notice"; return 0; }
+  jq -n --arg c "$1" '{additionalContext: $c}' ||
+    warn "could not emit the sync notice as JSON — skipping sync check"
+  return 0
+}
 
-# Outside a work tree there is nothing to sync. `--is-inside-work-tree` prints
-# true/false and exits 0 inside any repo; its only failure is exit 128 ("not a
-# git repository") — the expected non-repo session. Proceed only on a literal
-# "true"; a bare repo / gitdir ("false") and the non-repo case are silent
-# no-ops, and an unexpected value is surfaced.
-inside="$(git rev-parse --is-inside-work-tree 2>/dev/null)" || inside="__notrepo__"
-case "$inside" in
-  true) : ;;
-  false|__notrepo__) exit 0 ;;
-  *) warn "unexpected \`git rev-parse --is-inside-work-tree\` output '${inside}' — skipping sync check"; exit 0 ;;
-esac
+main() {
+  local THROTTLE_HOURS="${SYNC_THROTTLE_HOURS:-1}"
+  local FETCH_TIMEOUT="${SYNC_FETCH_TIMEOUT:-10}"
+  local STATE_DIR="${SYNC_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-sync}"
+  local rc db inside cand now top repo_key stamp last should_fetch counts ahead behind notice
+  local -a fetch
 
-# No origin remote => nothing to compare against. `git remote get-url` exits 2
-# for the documented "No such remote" (silent no-op); any other non-zero is a
-# real git failure and is surfaced (rules/error-handling.md).
-rc=0
-git remote get-url origin >/dev/null 2>&1 || rc=$?
-if (( rc != 0 )); then
-  if (( rc == 2 )); then exit 0; fi
-  warn "git remote get-url origin failed (exit ${rc}) — run \`git remote -v\` to inspect; skipping sync check"
-  exit 0
-fi
+  # git is required to produce a signal; its absence is an expected environment
+  # condition, not a failure — warn and no-op.
+  command -v git >/dev/null 2>&1 || { warn "git not found — install git to enable the sync check"; return 0; }
 
-if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
-  warn "SYNC_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 1"
-  THROTTLE_HOURS=1
-fi
+  # Outside a work tree there is nothing to sync. `--is-inside-work-tree` prints
+  # true/false and exits 0 inside any repo; its only failure is exit 128 ("not a
+  # git repository") — the expected non-repo session. Proceed only on a literal
+  # "true"; a bare repo / gitdir ("false") and the non-repo case are silent
+  # no-ops, and an unexpected value is surfaced.
+  inside="$(git rev-parse --is-inside-work-tree 2>/dev/null)" || inside="__notrepo__"
+  case "$inside" in
+    true) : ;;
+    false|__notrepo__) return 0 ;;
+    *) warn "unexpected \`git rev-parse --is-inside-work-tree\` output '${inside}' — skipping sync check"; return 0 ;;
+  esac
 
-# Resolve the remote default branch. Primary path: origin/HEAD's symbolic ref
-# (set at clone time). `git symbolic-ref --quiet` exits 0 when resolved and 1
-# for the expected no-symref case (origin/HEAD absent or not symbolic); any
-# other exit is a real git failure and is surfaced, not swallowed as "no
-# default" (rules/error-handling.md — distinguish an expected non-result from a
-# tool failure).
-db=""
-if db="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
-  db="${db#origin/}"
-else
-  rc=$?
+  # No origin remote => nothing to compare against. `git remote get-url` exits 2
+  # for the documented "No such remote" (silent no-op); any other non-zero is a
+  # real git failure and is surfaced (rules/error-handling.md).
+  rc=0
+  git remote get-url origin >/dev/null 2>&1 || rc=$?
+  if (( rc != 0 )); then
+    if (( rc == 2 )); then return 0; fi
+    warn "git remote get-url origin failed (exit ${rc}) — run \`git remote -v\` to inspect; skipping sync check"
+    return 0
+  fi
+
+  if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
+    warn "SYNC_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 1"
+    THROTTLE_HOURS=1
+  fi
+
+  # Resolve the remote default branch. Primary path: origin/HEAD's symbolic ref
+  # (set at clone time). `git symbolic-ref --quiet` exits 0 when resolved and 1
+  # for the expected no-symref case (origin/HEAD absent or not symbolic); any
+  # other exit is a real git failure and is surfaced, not swallowed as "no
+  # default" (rules/error-handling.md — distinguish an expected non-result from a
+  # tool failure).
   db=""
-  if (( rc != 1 )); then
-    warn "git symbolic-ref failed (exit ${rc}) resolving origin/HEAD — falling back to name probe"
+  if db="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+    db="${db#origin/}"
+  else
+    rc=$?
+    db=""
+    if (( rc != 1 )); then
+      warn "git symbolic-ref failed (exit ${rc}) resolving origin/HEAD — falling back to name probe"
+    fi
   fi
-fi
-# Fallback: probe the conventional names among the remote-tracking refs we have.
-if [[ -z "$db" ]]; then
-  for cand in main master; do
-    if ref_exists "refs/remotes/origin/$cand"; then db="$cand"; break; fi
-  done
-fi
-if [[ -z "$db" ]]; then
-  warn "cannot determine origin's default branch — set it with \`git remote set-head origin --auto\`; skipping sync check"
-  exit 0
-fi
-
-# No local default branch (e.g. only feature branches checked out) => nothing to
-# report as "behind". Silent no-op when absent; ref_exists surfaces a real
-# git failure before returning "absent".
-ref_exists "refs/heads/$db" || exit 0
-
-# Resolve the clock. A test may inject SYNC_NOW; otherwise read the system clock
-# and handle its failure. Validate as an integer before any arithmetic so a
-# malformed value can't abort the hook under set -e.
-if [[ -n "${SYNC_NOW:-}" ]]; then
-  now="$SYNC_NOW"
-elif ! now="$(date +%s)"; then
-  warn "cannot read the system clock — skipping sync check"
-  exit 0
-fi
-if ! [[ "$now" =~ ^[0-9]+$ ]]; then
-  warn "clock value '${now}' is not an integer — unset SYNC_NOW; skipping sync check"
-  exit 0
-fi
-
-# Per-repo throttle stamp, keyed by the toplevel path so sibling clones throttle
-# independently. cksum gives a stable filename-safe key for an arbitrary path.
-# A cksum/cut failure would abort the assignment under set -e and break the
-# always-exit-0 contract, so handle it: fall back to an un-throttled run rather
-# than crash the session.
-if ! top="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-  warn "git rev-parse --show-toplevel failed — keying the throttle stamp on \$PWD instead"
-  top="$PWD"
-fi
-if ! repo_key="$(printf '%s' "$top" | cksum | cut -d' ' -f1)"; then
-  warn "could not derive a throttle key for ${top} — sync check will not throttle this run"
-  repo_key=""
-fi
-stamp="${STATE_DIR}/sync-${repo_key}"
-
-# With no throttle key the fallback fetches unconditionally (never throttles).
-should_fetch=1
-if [[ -n "$repo_key" && -r "$stamp" ]]; then
-  last=""
-  read -r last < "$stamp" || last=""
-  [[ "$last" =~ ^[0-9]+$ ]] || last=0
-  if (( now - last < THROTTLE_HOURS * 3600 )); then
-    should_fetch=0
+  # Fallback: probe the conventional names among the remote-tracking refs we have.
+  if [[ -z "$db" ]]; then
+    for cand in main master; do
+      if ref_exists "refs/remotes/origin/$cand"; then db="$cand"; break; fi
+    done
   fi
-fi
+  if [[ -z "$db" ]]; then
+    warn "cannot determine origin's default branch — set it with \`git remote set-head origin --auto\`; skipping sync check"
+    return 0
+  fi
 
-if (( should_fetch )); then
-  # Record the fetch up front so a slow/failed fetch still throttles the next
-  # session rather than retrying the network on every start. Skipped when no
-  # throttle key was derived.
-  if [[ -n "$repo_key" ]]; then
-    if mkdir -p "$STATE_DIR"; then
-      printf '%s\n' "$now" > "$stamp" ||
-        warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-fetch next session"
-    else
-      warn "cannot create state dir ${STATE_DIR} — check permissions or set SYNC_STATE_DIR; sync check will not throttle"
+  # No local default branch (e.g. only feature branches checked out) => nothing to
+  # report as "behind". Silent no-op when absent; ref_exists surfaces a real
+  # git failure before returning "absent".
+  ref_exists "refs/heads/$db" || return 0
+
+  # Resolve the clock. A test may inject SYNC_NOW; otherwise read the system clock
+  # and handle its failure. Validate as an integer before any arithmetic so a
+  # malformed value can't abort the hook under set -e.
+  if [[ -n "${SYNC_NOW:-}" ]]; then
+    now="$SYNC_NOW"
+  elif ! now="$(date +%s)"; then
+    warn "cannot read the system clock — skipping sync check"
+    return 0
+  fi
+  if ! [[ "$now" =~ ^[0-9]+$ ]]; then
+    warn "clock value '${now}' is not an integer — unset SYNC_NOW; skipping sync check"
+    return 0
+  fi
+
+  # Per-repo throttle stamp, keyed by the toplevel path so sibling clones throttle
+  # independently. cksum gives a stable filename-safe key for an arbitrary path.
+  if ! top="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    warn "git rev-parse --show-toplevel failed — keying the throttle stamp on \$PWD instead"
+    top="$PWD"
+  fi
+  # A cksum/cut failure would abort the assignment under set -e and break the
+  # always-exit-0 contract, so handle it: fall back to an un-throttled run.
+  if ! repo_key="$(printf '%s' "$top" | cksum | cut -d' ' -f1)"; then
+    warn "could not derive a throttle key for ${top} — sync check will not throttle this run"
+    repo_key=""
+  fi
+  stamp="${STATE_DIR}/sync-${repo_key}"
+
+  # With no throttle key the fallback fetches unconditionally (never throttles).
+  should_fetch=1
+  if [[ -n "$repo_key" && -r "$stamp" ]]; then
+    last=""
+    read -r last < "$stamp" || last=""
+    [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    if (( now - last < THROTTLE_HOURS * 3600 )); then
+      should_fetch=0
     fi
   fi
 
-  # Time-bound the fetch so a hung network can't stall session start. timeout is
-  # optional (gtimeout on macOS via coreutils); fall back to a plain fetch.
-  fetch=(git fetch --quiet origin)
-  if [[ "$FETCH_TIMEOUT" =~ ^[0-9]+$ ]]; then
-    if command -v timeout >/dev/null 2>&1; then
-      fetch=(timeout "$FETCH_TIMEOUT" "${fetch[@]}")
-    elif command -v gtimeout >/dev/null 2>&1; then
-      fetch=(gtimeout "$FETCH_TIMEOUT" "${fetch[@]}")
+  if (( should_fetch )); then
+    # Record the fetch up front so a slow/failed fetch still throttles the next
+    # session rather than retrying the network on every start. Skipped when no
+    # throttle key was derived.
+    if [[ -n "$repo_key" ]]; then
+      if mkdir -p "$STATE_DIR"; then
+        printf '%s\n' "$now" > "$stamp" ||
+          warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-fetch next session"
+      else
+        warn "cannot create state dir ${STATE_DIR} — check permissions or set SYNC_STATE_DIR; sync check will not throttle"
+      fi
     fi
+
+    # Time-bound the fetch so a hung network can't stall session start. timeout is
+    # optional (gtimeout on macOS via coreutils); fall back to a plain fetch.
+    fetch=(git fetch --quiet origin)
+    if [[ "$FETCH_TIMEOUT" =~ ^[0-9]+$ ]]; then
+      if command -v timeout >/dev/null 2>&1; then
+        fetch=(timeout "$FETCH_TIMEOUT" "${fetch[@]}")
+      elif command -v gtimeout >/dev/null 2>&1; then
+        fetch=(gtimeout "$FETCH_TIMEOUT" "${fetch[@]}")
+      fi
+    fi
+    # A fetch failure (offline, auth, timeout) is a no-op, not a broken session —
+    # warn and fall through to compare against the last-known origin ref.
+    "${fetch[@]}" 2>/dev/null ||
+      warn "git fetch origin failed or timed out — check connectivity; comparing against the last-fetched origin/${db}"
   fi
-  # A fetch failure (offline, auth, timeout) is a no-op, not a broken session —
-  # warn and fall through to compare against the last-known origin ref.
-  "${fetch[@]}" 2>/dev/null ||
-    warn "git fetch origin failed or timed out — check connectivity; comparing against the last-fetched origin/${db}"
-fi
 
-# Compare the local default branch against its remote-tracking ref. --left-right
-# --count on a three-dot range yields "<ahead>\t<behind>" — ahead = local-only
-# commits, behind = origin-only commits — so a diverged branch (both > 0) can be
-# distinguished from one that is strictly behind (fast-forwardable). A missing
-# origin ref or a rev-list failure is surfaced, not swallowed as "up to date".
-if ! counts="$(git rev-list --left-right --count "refs/heads/${db}...refs/remotes/origin/${db}" 2>/dev/null)"; then
-  warn "could not compare ${db} against origin/${db} — run \`git status\` to inspect; skipping sync check"
-  exit 0
-fi
-ahead="${counts%%[[:space:]]*}"
-behind="${counts##*[[:space:]]}"
-if ! [[ "$ahead" =~ ^[0-9]+$ && "$behind" =~ ^[0-9]+$ ]]; then
-  warn "unexpected ahead/behind counts '${counts}' for ${db} — run \`git status\` to inspect; skipping sync check"
-  exit 0
-fi
-(( behind > 0 )) || exit 0
+  # Compare the local default branch against its remote-tracking ref. --left-right
+  # --count on a three-dot range yields "<ahead>\t<behind>" — ahead = local-only
+  # commits, behind = origin-only commits — so a diverged branch (both > 0) can be
+  # distinguished from one that is strictly behind (fast-forwardable). A missing
+  # origin ref or a rev-list failure is surfaced, not swallowed as "up to date".
+  if ! counts="$(git rev-list --left-right --count "refs/heads/${db}...refs/remotes/origin/${db}" 2>/dev/null)"; then
+    warn "could not compare ${db} against origin/${db} — run \`git status\` to inspect; skipping sync check"
+    return 0
+  fi
+  ahead="${counts%%[[:space:]]*}"
+  behind="${counts##*[[:space:]]}"
+  if ! [[ "$ahead" =~ ^[0-9]+$ && "$behind" =~ ^[0-9]+$ ]]; then
+    warn "unexpected ahead/behind counts '${counts}' for ${db} — run \`git status\` to inspect; skipping sync check"
+    return 0
+  fi
+  (( behind > 0 )) || return 0
 
-if (( ahead > 0 )); then
-  notice="Local \`${db}\` has diverged from \`origin/${db}\` (${behind} behind, ${ahead} ahead) — reconcile before working (rules/sync-before-work.md): \`git fetch origin\`, then rebase \`${db}\` onto \`origin/${db}\` (a fast-forward won't apply)."
-else
-  notice="Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."
-fi
+  if (( ahead > 0 )); then
+    notice="Local \`${db}\` has diverged from \`origin/${db}\` (${behind} behind, ${ahead} ahead) — reconcile before working (rules/sync-before-work.md): \`git fetch origin\`, then rebase \`${db}\` onto \`origin/${db}\` (a fast-forward won't apply)."
+  else
+    notice="Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."
+  fi
 
-command -v jq >/dev/null 2>&1 || { warn "jq not found — install jq to emit the sync notice; behind by ${behind}"; exit 0; }
-if ! jq -n --arg c "$notice" '{additionalContext: $c}'; then
-  warn "could not emit the sync notice as JSON — skipping sync check"
-  exit 0
+  emit_notice "$notice"
+  return 0
+}
+
+# Entry-point guard (rules/file-hygiene.md Standalone Scripts): run only when
+# executed, so the script can also be sourced to unit-test its functions.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-exit 0

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Warn at session start when the local default branch is behind origin.
+#
+# A SessionStart hook implementing rules/sync-before-work.md as a deterministic
+# check: it fetches origin (throttled), and if the local default branch trails
+# origin/<default>, injects a short "sync before working" notice via
+# additionalContext. The rule says fetch + sync before reading/editing, but
+# relied on the agent remembering; we hit stale-checkout ("main is behind")
+# repeatedly. This surfaces it the moment a session opens.
+#
+# Design choices, shared with hooks/check-policy-freshness.sh:
+#   - It DOES something (fetches + compares refs), it does not re-state a rule.
+#   - SessionStart fires once per session, not per turn — no per-turn tax.
+#   - Throttled: the fetch runs at most once per SYNC_THROTTLE_HOURS (default 1h)
+#     per repo, so rapid session churn doesn't hammer the network. The behind
+#     comparison still runs on throttled sessions against the last-fetched
+#     origin ref, so staleness surfaces even when the fetch is skipped.
+#   - The fetch is time-bounded (timeout, if available) so a hung network can't
+#     stall session start.
+#   - Informative only. Never blocks (always exits 0), never exits 2.
+#
+# Contract:
+#   stdin : consensus SessionStart JSON — not read (the script needs none of it).
+#   stdout: on a fire, one JSON object {"additionalContext": "<notice>"}; else nothing.
+#   exit  : always 0. Every best-effort failure emits an actionable stderr warning
+#           and continues/no-ops (rules/error-handling.md Shell Error Handling).
+#           Non-repo, no origin, no local default branch, and up-to-date are all
+#           silent no-ops — the common, uninteresting cases stay quiet.
+#   state : $SYNC_STATE_DIR/sync-<repo-key> (default ${TMPDIR:-/tmp}/coding-policy-sync),
+#           a single epoch-seconds throttle stamp per repo (keyed by toplevel path).
+#   env   : SYNC_THROTTLE_HOURS (default 1), SYNC_FETCH_TIMEOUT (default 10s),
+#           SYNC_STATE_DIR (tests), SYNC_NOW (test-only injected clock; defaults
+#           to `date +%s`).
+set -euo pipefail
+
+THROTTLE_HOURS="${SYNC_THROTTLE_HOURS:-1}"
+FETCH_TIMEOUT="${SYNC_FETCH_TIMEOUT:-10}"
+STATE_DIR="${SYNC_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-sync}"
+
+warn() { printf 'check-git-sync: %s\n' "$1" >&2; }
+
+# git is required to produce a signal; its absence is an expected environment
+# condition, not a failure — warn and no-op.
+command -v git >/dev/null 2>&1 || { warn "git not found — install git to enable the sync check"; exit 0; }
+
+# Outside a work tree there is nothing to sync — the common non-repo session.
+# Silent no-op (git prints its own error to the discarded stderr).
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# No origin remote => nothing to compare against. Silent no-op.
+git remote get-url origin >/dev/null 2>&1 || exit 0
+
+if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
+  warn "SYNC_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 1"
+  THROTTLE_HOURS=1
+fi
+
+# Resolve the remote default branch. Primary path: origin/HEAD's symbolic ref
+# (set at clone time). Fallback: probe the conventional names among the
+# remote-tracking refs we already have.
+db="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+db="${db#origin/}"
+if [[ -z "$db" ]]; then
+  for cand in main master; do
+    if git show-ref --verify --quiet "refs/remotes/origin/$cand"; then db="$cand"; break; fi
+  done
+fi
+if [[ -z "$db" ]]; then
+  warn "cannot determine origin's default branch — set it with \`git remote set-head origin --auto\`; skipping sync check"
+  exit 0
+fi
+
+# No local default branch (e.g. only feature branches checked out) => nothing to
+# report as "behind". Silent no-op.
+git show-ref --verify --quiet "refs/heads/$db" || exit 0
+
+# Resolve the clock. A test may inject SYNC_NOW; otherwise read the system clock
+# and handle its failure. Validate as an integer before any arithmetic so a
+# malformed value can't abort the hook under set -e.
+if [[ -n "${SYNC_NOW:-}" ]]; then
+  now="$SYNC_NOW"
+elif ! now="$(date +%s)"; then
+  warn "cannot read the system clock — skipping sync check"
+  exit 0
+fi
+if ! [[ "$now" =~ ^[0-9]+$ ]]; then
+  warn "clock value '${now}' is not an integer — unset SYNC_NOW; skipping sync check"
+  exit 0
+fi
+
+# Per-repo throttle stamp, keyed by the toplevel path so sibling clones throttle
+# independently. cksum gives a stable filename-safe key for an arbitrary path.
+top="$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
+repo_key="$(printf '%s' "$top" | cksum | cut -d' ' -f1)"
+stamp="${STATE_DIR}/sync-${repo_key}"
+
+should_fetch=1
+if [[ -r "$stamp" ]]; then
+  last=""
+  read -r last < "$stamp" || last=""
+  [[ "$last" =~ ^[0-9]+$ ]] || last=0
+  if (( now - last < THROTTLE_HOURS * 3600 )); then
+    should_fetch=0
+  fi
+fi
+
+if (( should_fetch )); then
+  # Record the fetch up front so a slow/failed fetch still throttles the next
+  # session rather than retrying the network on every start.
+  if mkdir -p "$STATE_DIR"; then
+    printf '%s\n' "$now" > "$stamp" ||
+      warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-fetch next session"
+  else
+    warn "cannot create state dir ${STATE_DIR} — check permissions or set SYNC_STATE_DIR; sync check will not throttle"
+  fi
+
+  # Time-bound the fetch so a hung network can't stall session start. timeout is
+  # optional (gtimeout on macOS via coreutils); fall back to a plain fetch.
+  fetch=(git fetch --quiet origin)
+  if [[ "$FETCH_TIMEOUT" =~ ^[0-9]+$ ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+      fetch=(timeout "$FETCH_TIMEOUT" "${fetch[@]}")
+    elif command -v gtimeout >/dev/null 2>&1; then
+      fetch=(gtimeout "$FETCH_TIMEOUT" "${fetch[@]}")
+    fi
+  fi
+  # A fetch failure (offline, auth, timeout) is a no-op, not a broken session —
+  # warn and fall through to compare against the last-known origin ref.
+  "${fetch[@]}" 2>/dev/null ||
+    warn "git fetch origin failed or timed out — check connectivity; comparing against the last-fetched origin/${db}"
+fi
+
+# Compare the local default branch against its remote-tracking ref. A missing
+# origin ref or a rev-list failure is surfaced, not swallowed as "up to date".
+if ! behind="$(git rev-list --count "refs/heads/${db}..refs/remotes/origin/${db}" 2>/dev/null)"; then
+  warn "could not compare ${db} against origin/${db} — run \`git status\` to inspect; skipping sync check"
+  exit 0
+fi
+[[ "$behind" =~ ^[0-9]+$ ]] || exit 0
+(( behind > 0 )) || exit 0
+
+notice="Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."
+
+command -v jq >/dev/null 2>&1 || { warn "jq not found — install jq to emit the sync notice; behind by ${behind}"; exit 0; }
+if ! jq -n --arg c "$notice" '{additionalContext: $c}'; then
+  warn "could not emit the sync notice as JSON — skipping sync check"
+  exit 0
+fi
+exit 0

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -63,7 +63,7 @@ main() {
   local THROTTLE_HOURS="${SYNC_THROTTLE_HOURS:-1}"
   local FETCH_TIMEOUT="${SYNC_FETCH_TIMEOUT:-10}"
   local STATE_DIR="${SYNC_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-sync}"
-  local rc db inside cand now top repo_key stamp sv ts should_fetch counts ahead behind notice
+  local rc db inside cand now top repo_key stamp sv ts should_fetch preserve_future counts ahead behind notice
   local -a fetch
 
   # git is required to produce a signal; its absence is an expected environment
@@ -159,15 +159,21 @@ main() {
   stamp="${STATE_DIR}/sync-${repo_key}"
 
   # Throttle stamp schema (see hooks/state-schema.md): one line "<schema_version>
-  # <checked_at-epoch>". A record whose version this hook does not accept (an old
-  # bare-integer stamp, or a future version) is treated as no usable prior state
-  # — re-fetch — never migrated in place (rules/stateful-artifacts.md).
+  # <checked_at-epoch>". Per rules/stateful-artifacts.md Migration Policy:
+  #   - schema_version 1 within the window => throttle (skip the fetch).
+  #   - a future version (sv > 1) => this hook is lagging: no usable prior state
+  #     (fetch), and DO NOT downgrade the record — preserve it (preserve_future).
+  #   - anything else (old bare-integer, corrupt, absent) => no prior state
+  #     (fetch), safe to rewrite as version 1.
   # With no throttle key the fallback fetches unconditionally (never throttles).
   should_fetch=1
+  preserve_future=0
   if [[ -n "$repo_key" && -r "$stamp" ]]; then
     sv=""; ts=""
     read -r sv ts < "$stamp" || { sv=""; ts=""; }
-    if [[ "$sv" == "1" && "$ts" =~ ^[0-9]+$ ]] && (( now - ts < THROTTLE_HOURS * 3600 )); then
+    if [[ "$sv" =~ ^[0-9]+$ ]] && (( sv > 1 )); then
+      preserve_future=1
+    elif [[ "$sv" == "1" && "$ts" =~ ^[0-9]+$ ]] && (( now - ts < THROTTLE_HOURS * 3600 )); then
       should_fetch=0
     fi
   fi
@@ -175,8 +181,9 @@ main() {
   if (( should_fetch )); then
     # Record the fetch up front so a slow/failed fetch still throttles the next
     # session rather than retrying the network on every start. Skipped when no
-    # throttle key was derived.
-    if [[ -n "$repo_key" ]]; then
+    # throttle key was derived, and when a future-version record must be
+    # preserved rather than downgraded.
+    if [[ -n "$repo_key" ]] && (( preserve_future == 0 )); then
       if mkdir -p "$STATE_DIR"; then
         printf '1 %s\n' "$now" > "$stamp" ||
           warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-fetch next session"

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -90,12 +90,19 @@ fi
 
 # Per-repo throttle stamp, keyed by the toplevel path so sibling clones throttle
 # independently. cksum gives a stable filename-safe key for an arbitrary path.
+# A cksum/cut failure would abort the assignment under set -e and break the
+# always-exit-0 contract, so handle it: fall back to an un-throttled run rather
+# than crash the session.
 top="$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
-repo_key="$(printf '%s' "$top" | cksum | cut -d' ' -f1)"
+if ! repo_key="$(printf '%s' "$top" | cksum | cut -d' ' -f1)"; then
+  warn "could not derive a throttle key for ${top} — sync check will not throttle this run"
+  repo_key=""
+fi
 stamp="${STATE_DIR}/sync-${repo_key}"
 
+# With no throttle key the fallback fetches unconditionally (never throttles).
 should_fetch=1
-if [[ -r "$stamp" ]]; then
+if [[ -n "$repo_key" && -r "$stamp" ]]; then
   last=""
   read -r last < "$stamp" || last=""
   [[ "$last" =~ ^[0-9]+$ ]] || last=0
@@ -106,12 +113,15 @@ fi
 
 if (( should_fetch )); then
   # Record the fetch up front so a slow/failed fetch still throttles the next
-  # session rather than retrying the network on every start.
-  if mkdir -p "$STATE_DIR"; then
-    printf '%s\n' "$now" > "$stamp" ||
-      warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-fetch next session"
-  else
-    warn "cannot create state dir ${STATE_DIR} — check permissions or set SYNC_STATE_DIR; sync check will not throttle"
+  # session rather than retrying the network on every start. Skipped when no
+  # throttle key was derived.
+  if [[ -n "$repo_key" ]]; then
+    if mkdir -p "$STATE_DIR"; then
+      printf '%s\n' "$now" > "$stamp" ||
+        warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-fetch next session"
+    else
+      warn "cannot create state dir ${STATE_DIR} — check permissions or set SYNC_STATE_DIR; sync check will not throttle"
+    fi
   fi
 
   # Time-bound the fetch so a hung network can't stall session start. timeout is
@@ -136,7 +146,10 @@ if ! behind="$(git rev-list --count "refs/heads/${db}..refs/remotes/origin/${db}
   warn "could not compare ${db} against origin/${db} — run \`git status\` to inspect; skipping sync check"
   exit 0
 fi
-[[ "$behind" =~ ^[0-9]+$ ]] || exit 0
+if ! [[ "$behind" =~ ^[0-9]+$ ]]; then
+  warn "unexpected non-numeric behind-count '${behind}' for ${db} — run \`git status\` to inspect; skipping sync check"
+  exit 0
+fi
 (( behind > 0 )) || exit 0
 
 notice="Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -56,10 +56,22 @@ if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
 fi
 
 # Resolve the remote default branch. Primary path: origin/HEAD's symbolic ref
-# (set at clone time). Fallback: probe the conventional names among the
-# remote-tracking refs we already have.
-db="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-db="${db#origin/}"
+# (set at clone time). `git symbolic-ref --quiet` exits 0 when resolved and 1
+# for the expected no-symref case (origin/HEAD absent or not symbolic); any
+# other exit is a real git failure and is surfaced, not swallowed as "no
+# default" (rules/error-handling.md — distinguish an expected non-result from a
+# tool failure).
+db=""
+if db="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null)"; then
+  db="${db#origin/}"
+else
+  rc=$?
+  db=""
+  if (( rc != 1 )); then
+    warn "git symbolic-ref failed (exit ${rc}) resolving origin/HEAD — falling back to name probe"
+  fi
+fi
+# Fallback: probe the conventional names among the remote-tracking refs we have.
 if [[ -z "$db" ]]; then
   for cand in main master; do
     if git show-ref --verify --quiet "refs/remotes/origin/$cand"; then db="$cand"; break; fi
@@ -140,19 +152,28 @@ if (( should_fetch )); then
     warn "git fetch origin failed or timed out — check connectivity; comparing against the last-fetched origin/${db}"
 fi
 
-# Compare the local default branch against its remote-tracking ref. A missing
+# Compare the local default branch against its remote-tracking ref. --left-right
+# --count on a three-dot range yields "<ahead>\t<behind>" — ahead = local-only
+# commits, behind = origin-only commits — so a diverged branch (both > 0) can be
+# distinguished from one that is strictly behind (fast-forwardable). A missing
 # origin ref or a rev-list failure is surfaced, not swallowed as "up to date".
-if ! behind="$(git rev-list --count "refs/heads/${db}..refs/remotes/origin/${db}" 2>/dev/null)"; then
+if ! counts="$(git rev-list --left-right --count "refs/heads/${db}...refs/remotes/origin/${db}" 2>/dev/null)"; then
   warn "could not compare ${db} against origin/${db} — run \`git status\` to inspect; skipping sync check"
   exit 0
 fi
-if ! [[ "$behind" =~ ^[0-9]+$ ]]; then
-  warn "unexpected non-numeric behind-count '${behind}' for ${db} — run \`git status\` to inspect; skipping sync check"
+ahead="${counts%%[[:space:]]*}"
+behind="${counts##*[[:space:]]}"
+if ! [[ "$ahead" =~ ^[0-9]+$ && "$behind" =~ ^[0-9]+$ ]]; then
+  warn "unexpected ahead/behind counts '${counts}' for ${db} — run \`git status\` to inspect; skipping sync check"
   exit 0
 fi
 (( behind > 0 )) || exit 0
 
-notice="Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."
+if (( ahead > 0 )); then
+  notice="Local \`${db}\` has diverged from \`origin/${db}\` (${behind} behind, ${ahead} ahead) — reconcile before working (rules/sync-before-work.md): \`git fetch origin\`, then rebase \`${db}\` onto \`origin/${db}\` (a fast-forward won't apply)."
+else
+  notice="Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."
+fi
 
 command -v jq >/dev/null 2>&1 || { warn "jq not found — install jq to emit the sync notice; behind by ${behind}"; exit 0; }
 if ! jq -n --arg c "$notice" '{additionalContext: $c}'; then

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -27,7 +27,8 @@
 #           Non-repo, no origin, no local default branch, and up-to-date are all
 #           silent no-ops — the common, uninteresting cases stay quiet.
 #   state : $SYNC_STATE_DIR/sync-<repo-key> (default ${TMPDIR:-/tmp}/coding-policy-sync),
-#           a single epoch-seconds throttle stamp per repo (keyed by toplevel path).
+#           a per-repo throttle stamp (keyed by toplevel path). Schema documented
+#           in hooks/state-schema.md: one line "<schema_version> <checked_at>".
 #   env   : SYNC_THROTTLE_HOURS (default 1), SYNC_FETCH_TIMEOUT (default 10s),
 #           SYNC_STATE_DIR (tests), SYNC_NOW (test-only injected clock; defaults
 #           to `date +%s`).
@@ -62,7 +63,7 @@ main() {
   local THROTTLE_HOURS="${SYNC_THROTTLE_HOURS:-1}"
   local FETCH_TIMEOUT="${SYNC_FETCH_TIMEOUT:-10}"
   local STATE_DIR="${SYNC_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-sync}"
-  local rc db inside cand now top repo_key stamp last should_fetch counts ahead behind notice
+  local rc db inside cand now top repo_key stamp sv ts should_fetch counts ahead behind notice
   local -a fetch
 
   # git is required to produce a signal; its absence is an expected environment
@@ -157,13 +158,16 @@ main() {
   fi
   stamp="${STATE_DIR}/sync-${repo_key}"
 
+  # Throttle stamp schema (see hooks/state-schema.md): one line "<schema_version>
+  # <checked_at-epoch>". A record whose version this hook does not accept (an old
+  # bare-integer stamp, or a future version) is treated as no usable prior state
+  # — re-fetch — never migrated in place (rules/stateful-artifacts.md).
   # With no throttle key the fallback fetches unconditionally (never throttles).
   should_fetch=1
   if [[ -n "$repo_key" && -r "$stamp" ]]; then
-    last=""
-    read -r last < "$stamp" || last=""
-    [[ "$last" =~ ^[0-9]+$ ]] || last=0
-    if (( now - last < THROTTLE_HOURS * 3600 )); then
+    sv=""; ts=""
+    read -r sv ts < "$stamp" || { sv=""; ts=""; }
+    if [[ "$sv" == "1" && "$ts" =~ ^[0-9]+$ ]] && (( now - ts < THROTTLE_HOURS * 3600 )); then
       should_fetch=0
     fi
   fi
@@ -174,7 +178,7 @@ main() {
     # throttle key was derived.
     if [[ -n "$repo_key" ]]; then
       if mkdir -p "$STATE_DIR"; then
-        printf '%s\n' "$now" > "$stamp" ||
+        printf '1 %s\n' "$now" > "$stamp" ||
           warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-fetch next session"
       else
         warn "cannot create state dir ${STATE_DIR} — check permissions or set SYNC_STATE_DIR; sync check will not throttle"

--- a/hooks/check-policy-freshness.sh
+++ b/hooks/check-policy-freshness.sh
@@ -21,7 +21,8 @@
 #   exit  : always 0. Every best-effort failure emits an actionable stderr warning
 #           and continues/no-ops (rules/error-handling.md Shell Error Handling).
 #   state : $FRESHNESS_STATE_DIR/last-check (default ${TMPDIR:-/tmp}/coding-policy-freshness),
-#           a single epoch-seconds throttle stamp.
+#           a throttle stamp. Schema documented in hooks/state-schema.md:
+#           one line "<schema_version> <checked_at>".
 #   env   : FRESHNESS_THROTTLE_HOURS (default 24), FRESHNESS_STATE_DIR (tests),
 #           FRESHNESS_NOW (test-only injected clock; defaults to `date +%s`).
 set -euo pipefail
@@ -31,7 +32,7 @@ warn() { printf 'check-policy-freshness: %s\n' "$1" >&2; }
 main() {
   local THROTTLE_HOURS="${FRESHNESS_THROTTLE_HOURS:-24}"
   local STATE_DIR="${FRESHNESS_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-freshness}"
-  local now stamp last out notice
+  local now stamp sv ts out notice
 
   # jq and tessl are both required to produce a signal; a missing optional tool is
   # an expected environment condition, not a failure — warn and no-op.
@@ -59,12 +60,14 @@ main() {
 
   stamp="${STATE_DIR}/last-check"
 
-  # Throttle: skip the registry call if we checked within the window.
+  # Throttle stamp schema (see hooks/state-schema.md): one line "<schema_version>
+  # <checked_at-epoch>". A record whose version this hook does not accept (an old
+  # bare-integer stamp, or a future version) is treated as no usable prior state
+  # — re-check — never migrated in place (rules/stateful-artifacts.md).
   if [[ -r "$stamp" ]]; then
-    last=""
-    read -r last < "$stamp" || last=""
-    [[ "$last" =~ ^[0-9]+$ ]] || last=0
-    if (( now - last < THROTTLE_HOURS * 3600 )); then
+    sv=""; ts=""
+    read -r sv ts < "$stamp" || { sv=""; ts=""; }
+    if [[ "$sv" == "1" && "$ts" =~ ^[0-9]+$ ]] && (( now - ts < THROTTLE_HOURS * 3600 )); then
       return 0
     fi
   fi
@@ -72,7 +75,7 @@ main() {
   # Record the check up front so a slow/failed registry call still throttles the
   # next session rather than hammering the registry on every start.
   if mkdir -p "$STATE_DIR"; then
-    printf '%s\n' "$now" > "$stamp" ||
+    printf '1 %s\n' "$now" > "$stamp" ||
       warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-check next session"
   else
     warn "cannot create state dir ${STATE_DIR} — check permissions or set FRESHNESS_STATE_DIR; freshness check will not throttle"

--- a/hooks/check-policy-freshness.sh
+++ b/hooks/check-policy-freshness.sh
@@ -32,7 +32,7 @@ warn() { printf 'check-policy-freshness: %s\n' "$1" >&2; }
 main() {
   local THROTTLE_HOURS="${FRESHNESS_THROTTLE_HOURS:-24}"
   local STATE_DIR="${FRESHNESS_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-freshness}"
-  local now stamp sv ts out notice
+  local now stamp sv ts preserve_future out notice
 
   # jq and tessl are both required to produce a signal; a missing optional tool is
   # an expected environment condition, not a failure — warn and no-op.
@@ -61,24 +61,33 @@ main() {
   stamp="${STATE_DIR}/last-check"
 
   # Throttle stamp schema (see hooks/state-schema.md): one line "<schema_version>
-  # <checked_at-epoch>". A record whose version this hook does not accept (an old
-  # bare-integer stamp, or a future version) is treated as no usable prior state
-  # — re-check — never migrated in place (rules/stateful-artifacts.md).
+  # <checked_at-epoch>". Per rules/stateful-artifacts.md Migration Policy:
+  #   - schema_version 1 within the window => throttle (return silently).
+  #   - a future version (sv > 1) => this hook is lagging: no usable prior state
+  #     (re-check), and DO NOT downgrade the record — preserve it.
+  #   - anything else (old bare-integer, corrupt, absent) => no prior state
+  #     (re-check), safe to rewrite as version 1.
+  preserve_future=0
   if [[ -r "$stamp" ]]; then
     sv=""; ts=""
     read -r sv ts < "$stamp" || { sv=""; ts=""; }
-    if [[ "$sv" == "1" && "$ts" =~ ^[0-9]+$ ]] && (( now - ts < THROTTLE_HOURS * 3600 )); then
+    if [[ "$sv" =~ ^[0-9]+$ ]] && (( sv > 1 )); then
+      preserve_future=1
+    elif [[ "$sv" == "1" && "$ts" =~ ^[0-9]+$ ]] && (( now - ts < THROTTLE_HOURS * 3600 )); then
       return 0
     fi
   fi
 
   # Record the check up front so a slow/failed registry call still throttles the
-  # next session rather than hammering the registry on every start.
-  if mkdir -p "$STATE_DIR"; then
-    printf '1 %s\n' "$now" > "$stamp" ||
-      warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-check next session"
-  else
-    warn "cannot create state dir ${STATE_DIR} — check permissions or set FRESHNESS_STATE_DIR; freshness check will not throttle"
+  # next session rather than hammering the registry on every start. Skipped when
+  # a future-version record must be preserved rather than downgraded.
+  if (( preserve_future == 0 )); then
+    if mkdir -p "$STATE_DIR"; then
+      printf '1 %s\n' "$now" > "$stamp" ||
+        warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-check next session"
+    else
+      warn "cannot create state dir ${STATE_DIR} — check permissions or set FRESHNESS_STATE_DIR; freshness check will not throttle"
+    fi
   fi
 
   # Silence tessl's own diagnostic but explicitly handle the failure and warn —

--- a/hooks/check-policy-freshness.sh
+++ b/hooks/check-policy-freshness.sh
@@ -26,80 +26,87 @@
 #           FRESHNESS_NOW (test-only injected clock; defaults to `date +%s`).
 set -euo pipefail
 
-THROTTLE_HOURS="${FRESHNESS_THROTTLE_HOURS:-24}"
-STATE_DIR="${FRESHNESS_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-freshness}"
-
 warn() { printf 'check-policy-freshness: %s\n' "$1" >&2; }
 
-# jq and tessl are both required to produce a signal; a missing optional tool is
-# an expected environment condition, not a failure — warn and no-op.
-command -v jq >/dev/null 2>&1 || { warn "jq not found — install jq to enable the freshness check"; exit 0; }
-command -v tessl >/dev/null 2>&1 || { warn "tessl not found — install the Tessl CLI to enable the freshness check"; exit 0; }
+main() {
+  local THROTTLE_HOURS="${FRESHNESS_THROTTLE_HOURS:-24}"
+  local STATE_DIR="${FRESHNESS_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-freshness}"
+  local now stamp last out notice
 
-if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
-  warn "FRESHNESS_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 24"
-  THROTTLE_HOURS=24
-fi
+  # jq and tessl are both required to produce a signal; a missing optional tool is
+  # an expected environment condition, not a failure — warn and no-op.
+  command -v jq >/dev/null 2>&1 || { warn "jq not found — install jq to enable the freshness check"; return 0; }
+  command -v tessl >/dev/null 2>&1 || { warn "tessl not found — install the Tessl CLI to enable the freshness check"; return 0; }
 
-# Resolve the clock. A test may inject FRESHNESS_NOW; otherwise read the system
-# clock and handle its failure. Validate the result as an integer before any
-# arithmetic so a malformed value can't abort the hook under set -e.
-if [[ -n "${FRESHNESS_NOW:-}" ]]; then
-  now="$FRESHNESS_NOW"
-elif ! now="$(date +%s)"; then
-  warn "cannot read the system clock — skipping freshness check"
-  exit 0
-fi
-if ! [[ "$now" =~ ^[0-9]+$ ]]; then
-  warn "clock value '${now}' is not an integer — unset FRESHNESS_NOW; skipping freshness check"
-  exit 0
-fi
-
-stamp="${STATE_DIR}/last-check"
-
-# Throttle: skip the registry call if we checked within the window.
-if [[ -r "$stamp" ]]; then
-  last=""
-  read -r last < "$stamp" || last=""
-  [[ "$last" =~ ^[0-9]+$ ]] || last=0
-  if (( now - last < THROTTLE_HOURS * 3600 )); then
-    exit 0
+  if ! [[ "$THROTTLE_HOURS" =~ ^[0-9]+$ ]]; then
+    warn "FRESHNESS_THROTTLE_HOURS='${THROTTLE_HOURS}' is not an integer — using 24"
+    THROTTLE_HOURS=24
   fi
-fi
 
-# Record the check up front so a slow/failed registry call still throttles the
-# next session rather than hammering the registry on every start.
-if mkdir -p "$STATE_DIR"; then
-  printf '%s\n' "$now" > "$stamp" ||
-    warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-check next session"
-else
-  warn "cannot create state dir ${STATE_DIR} — check permissions or set FRESHNESS_STATE_DIR; freshness check will not throttle"
-fi
+  # Resolve the clock. A test may inject FRESHNESS_NOW; otherwise read the system
+  # clock and handle its failure. Validate the result as an integer before any
+  # arithmetic so a malformed value can't abort the hook under set -e.
+  if [[ -n "${FRESHNESS_NOW:-}" ]]; then
+    now="$FRESHNESS_NOW"
+  elif ! now="$(date +%s)"; then
+    warn "cannot read the system clock — skipping freshness check"
+    return 0
+  fi
+  if ! [[ "$now" =~ ^[0-9]+$ ]]; then
+    warn "clock value '${now}' is not an integer — unset FRESHNESS_NOW; skipping freshness check"
+    return 0
+  fi
 
-# Silence tessl's own diagnostic but explicitly handle the failure and warn —
-# an offline/registry error is a no-op, not a broken session.
-if ! out="$(tessl outdated --json 2>/dev/null)"; then
-  warn "tessl outdated failed — check connectivity and retry \`tessl outdated\`; skipping freshness check"
-  exit 0
-fi
+  stamp="${STATE_DIR}/last-check"
 
-# Build a notice line per outdated plugin. Empty list => silent. A parse failure
-# is surfaced, not swallowed as "nothing outdated".
-if ! notice="$(printf '%s' "$out" | jq -r '
-  (.outdated // [])
-  | map("- \(.current.tile.workspaceName)/\(.current.tile.tileName) \(.current.tile.version) -> \(.update.version)")
-  | if length == 0 then empty else
-      "Plugin updates available (run `tessl update`):\n" + (. | join("\n"))
-    end
-' 2>/dev/null)"; then
-  warn "could not parse \`tessl outdated --json\` output — run it manually to inspect; skipping freshness check"
-  exit 0
-fi
+  # Throttle: skip the registry call if we checked within the window.
+  if [[ -r "$stamp" ]]; then
+    last=""
+    read -r last < "$stamp" || last=""
+    [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    if (( now - last < THROTTLE_HOURS * 3600 )); then
+      return 0
+    fi
+  fi
 
-[[ -n "$notice" ]] || exit 0
+  # Record the check up front so a slow/failed registry call still throttles the
+  # next session rather than hammering the registry on every start.
+  if mkdir -p "$STATE_DIR"; then
+    printf '%s\n' "$now" > "$stamp" ||
+      warn "cannot write throttle stamp ${stamp} — check permissions on ${STATE_DIR}; will re-check next session"
+  else
+    warn "cannot create state dir ${STATE_DIR} — check permissions or set FRESHNESS_STATE_DIR; freshness check will not throttle"
+  fi
 
-if ! jq -n --arg c "$notice" '{additionalContext: $c}'; then
-  warn "could not emit the update notice as JSON — skipping freshness check"
-  exit 0
+  # Silence tessl's own diagnostic but explicitly handle the failure and warn —
+  # an offline/registry error is a no-op, not a broken session.
+  if ! out="$(tessl outdated --json 2>/dev/null)"; then
+    warn "tessl outdated failed — check connectivity and retry \`tessl outdated\`; skipping freshness check"
+    return 0
+  fi
+
+  # Build a notice line per outdated plugin. Empty list => silent. A parse failure
+  # is surfaced, not swallowed as "nothing outdated".
+  if ! notice="$(printf '%s' "$out" | jq -r '
+    (.outdated // [])
+    | map("- \(.current.tile.workspaceName)/\(.current.tile.tileName) \(.current.tile.version) -> \(.update.version)")
+    | if length == 0 then empty else
+        "Plugin updates available (run `tessl update`):\n" + (. | join("\n"))
+      end
+  ' 2>/dev/null)"; then
+    warn "could not parse \`tessl outdated --json\` output — run it manually to inspect; skipping freshness check"
+    return 0
+  fi
+
+  [[ -n "$notice" ]] || return 0
+
+  jq -n --arg c "$notice" '{additionalContext: $c}' ||
+    warn "could not emit the update notice as JSON — skipping freshness check"
+  return 0
+}
+
+# Entry-point guard (rules/file-hygiene.md Standalone Scripts): run only when
+# executed, so the script can also be sourced to unit-test its functions.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-exit 0

--- a/hooks/state-schema.md
+++ b/hooks/state-schema.md
@@ -31,21 +31,26 @@ Example: `1 1734567890`
 ## Writer / Reader Contract
 
 - **Writer** (owner hook): writes `1 <now>` before running the throttled call,
-  so a slow or failed call still throttles the next session.
+  so a slow or failed call still throttles the next session. Never writes when
+  preserving a future-version record (see Migration).
 - **Reader** (owner hook): throttles only when the record's `schema_version` is
-  `1` **and** `checked_at` is an integer within the throttle window. Any other
-  record — a `schema_version` this hook does not accept, a non-integer
-  `checked_at`, an absent stamp — is treated as **no usable prior state**: the
-  hook runs its call (no throttle) and rewrites a current record.
+  `1` **and** `checked_at` is an integer within the throttle window. Every other
+  record is **no usable prior state**: the hook runs its call (no throttle).
 
 ## Migration
 
-- Only the owner hook migrates. On reading a record it does not accept — an
-  older bare-integer stamp (pre-versioning) or a future `schema_version` — it
-  takes the no-usable-prior-state path above and rewrites a `1 <now>` record on
-  its next throttled run.
-- This fallback is safe and non-disruptive: the only effect of discarding a
-  record is one extra network / registry call. It never escalates work.
+Only the owner hook migrates, and it distinguishes older records from newer ones
+per `rules/stateful-artifacts.md` Migration Policy:
+
+- **Older or corrupt record** — an old bare-integer stamp (pre-versioning), a
+  non-integer field, or an absent stamp: no usable prior state, and the hook
+  rewrites a current `1 <now>` record on its next run.
+- **Future-version record** (`schema_version` > 1): the hook is the lagging
+  reader, not the migrator. It takes the no-usable-prior-state path (runs its
+  call) but **must not downgrade** the record — it preserves the future stamp
+  untouched until the hook is updated to accept that schema.
+- Both fallbacks are safe and non-disruptive: discarding a record costs only one
+  extra network / registry call. Neither escalates work.
 - Bump `schema_version` for any shape change; do not repurpose `checked_at`
   silently.
 

--- a/hooks/state-schema.md
+++ b/hooks/state-schema.md
@@ -1,0 +1,56 @@
+# Hook Throttle-Stamp Schema
+
+Schema for the cross-invocation throttle stamps the `SessionStart` hooks write,
+per `rules/stateful-artifacts.md`.
+
+## Artifacts
+
+| Stamp path | Owner (writer + reader) | Purpose |
+| ---------- | ----------------------- | ------- |
+| `$FRESHNESS_STATE_DIR/last-check` (default `${TMPDIR:-/tmp}/coding-policy-freshness/last-check`) | `hooks/check-policy-freshness.sh` | Throttle the `tessl outdated` registry call |
+| `$SYNC_STATE_DIR/sync-<repo-key>` (default `${TMPDIR:-/tmp}/coding-policy-sync/sync-<repo-key>`) | `hooks/check-git-sync.sh` | Throttle the `git fetch origin` call, per repo (`<repo-key>` = cksum of the repo toplevel path) |
+
+Each stamp has exactly one owner hook that both writes and reads it. No other
+skill or hook touches it.
+
+## Record Format
+
+One line, two space-separated fields:
+
+```
+<schema_version> <checked_at>
+```
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `schema_version` | integer | Currently `1`. Bumped on any shape change |
+| `checked_at` | integer | Epoch seconds when the owner last ran its throttled call |
+
+Example: `1 1734567890`
+
+## Writer / Reader Contract
+
+- **Writer** (owner hook): writes `1 <now>` before running the throttled call,
+  so a slow or failed call still throttles the next session.
+- **Reader** (owner hook): throttles only when the record's `schema_version` is
+  `1` **and** `checked_at` is an integer within the throttle window. Any other
+  record — a `schema_version` this hook does not accept, a non-integer
+  `checked_at`, an absent stamp — is treated as **no usable prior state**: the
+  hook runs its call (no throttle) and rewrites a current record.
+
+## Migration
+
+- Only the owner hook migrates. On reading a record it does not accept — an
+  older bare-integer stamp (pre-versioning) or a future `schema_version` — it
+  takes the no-usable-prior-state path above and rewrites a `1 <now>` record on
+  its next throttled run.
+- This fallback is safe and non-disruptive: the only effect of discarding a
+  record is one extra network / registry call. It never escalates work.
+- Bump `schema_version` for any shape change; do not repurpose `checked_at`
+  silently.
+
+## Hints, Not Authority
+
+The stamp is a last-seen timestamp cache, never ground truth. A missing,
+corrupt, or unreadable stamp degrades only to an extra call — never to a wrong
+result — so the hooks tolerate its absence at every read.

--- a/hooks/tests/test_check_git_sync.sh
+++ b/hooks/tests/test_check_git_sync.sh
@@ -18,6 +18,8 @@
 #   5. No origin     -> silent no-op, exit 0.
 #   6. Fetch failure -> silent no-op, exit 0 (offline/broken remote tolerated).
 #   7. Bad clock     -> silent no-op, exit 0 (never aborts SessionStart).
+#   8. Diverged      -> notice names divergence and recommends rebase, not a
+#                       fast-forward (local both ahead and behind origin).
 #
 # Run: bash hooks/tests/test_check_git_sync.sh
 set -uo pipefail
@@ -124,6 +126,17 @@ mk_origin o7
 R7="$TMP/r7"; g clone -q "$BARE" "$R7"
 run "$R7" "$TMP/s7" SYNC_NOW="not-a-number"
 if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "bad clock: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+# 8. diverged -> divergence notice (rebase, not fast-forward). Clone, add a local
+#    commit (ahead by 1), and push a different commit to origin (behind by 1);
+#    the hook fetches and reports the diverged state.
+mk_origin o8
+R8="$TMP/r8"; g clone -q "$BARE" "$R8"
+printf 'local\n' >> "$R8/f"; g -C "$R8" add f; g -C "$R8" commit -q -m local   # ahead by 1
+commit_push "$SEED" "c2"                                                        # origin moves -> behind by 1
+run "$R8" "$TMP/s8"
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("diverged") and test("rebase")' >/dev/null 2>&1; then
+  pass; else fail "diverged: expected divergence notice, got RC=$RC OUT=$OUT"; fi
 
 echo "─────────────────────────────────────────────" >&2
 if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi

--- a/hooks/tests/test_check_git_sync.sh
+++ b/hooks/tests/test_check_git_sync.sh
@@ -105,7 +105,10 @@ main() {
   mk_origin o3
   clone_from "$BARE" "$TMP/r3"
   run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000000               # fetch, stamp, up to date -> silent
-  [[ $RC -eq 0 && -z "$OUT" ]] || fail "throttle setup: first call should be silent, got RC=$RC OUT=$OUT"
+  # This establishes the throttle stamp the next two assertions depend on, so a
+  # failure here must abort, not merely tally (aggregate-reporting carve-out:
+  # later checks may not depend on an earlier one merely having incremented FAIL).
+  [[ $RC -eq 0 && -z "$OUT" ]] || die "throttle setup: first call should be silent, got RC=$RC OUT=$OUT"
   commit_push "$SEED" "c3"                                # origin moves; r3's tracking ref still old
   run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000060               # +60s: throttled -> no fetch -> silent
   if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle active: inside window should skip fetch and stay silent, got OUT=$OUT"; fi

--- a/hooks/tests/test_check_git_sync.sh
+++ b/hooks/tests/test_check_git_sync.sh
@@ -5,6 +5,9 @@
 # "origin" plus working clones) and drive git offline — no network, fully
 # deterministic. The injected clock (SYNC_NOW) drives the throttle assertions.
 #
+# Each scenario builds its OWN bare origin + seed (mk_origin) so scenarios share
+# no mutable state and run in any order (rules/testing-standards.md Independence).
+#
 # Covers:
 #   1. Behind        -> emits additionalContext naming the branch + "behind".
 #   2. Up to date    -> silent (empty stdout), exit 0.
@@ -29,8 +32,11 @@ cleanup() { [[ -n "${TMP:-}" ]] && ! rm -rf "$TMP" && echo "warn: could not remo
 trap cleanup EXIT
 
 # Isolate git from the operator's global/system config so identity and defaults
-# are deterministic across machines.
-export HOME="$TMP/home"; mkdir -p "$HOME"
+# are deterministic across machines. This isolation is load-bearing — an
+# unchecked mkdir failure would silently defeat it, so guard it explicitly
+# (rules/error-handling.md aggregate-reporting carve-out, setup-step check).
+export HOME="$TMP/home"
+mkdir -p "$HOME" || { echo "fatal: could not create isolated HOME at $HOME" >&2; exit 2; }
 export GIT_CONFIG_NOSYSTEM=1
 export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
 
@@ -42,14 +48,14 @@ commit_push() { # <clone-dir> <message>
   g -C "$dir" commit -q -m "$msg"
   g -C "$dir" push -q origin main
 }
-
-# Build a bare origin with one commit on main, plus a clone that is up to date.
-BARE="$TMP/origin.git"
-g init -q --bare -b main "$BARE"
-SEED="$TMP/seed"
-g clone -q "$BARE" "$SEED" 2>/dev/null   # cloning an empty bare warns; irrelevant here
-g -C "$SEED" symbolic-ref HEAD refs/heads/main
-commit_push "$SEED" "c1"
+mk_origin() { # <prefix>: sets globals BARE, SEED to a fresh, independent origin
+  local prefix="$1"
+  BARE="$TMP/${prefix}.git"; SEED="$TMP/${prefix}-seed"
+  g init -q --bare -b main "$BARE"
+  g clone -q "$BARE" "$SEED" 2>/dev/null   # cloning an empty bare warns; irrelevant here
+  g -C "$SEED" symbolic-ref HEAD refs/heads/main
+  commit_push "$SEED" "c1"
+}
 
 # run <repo-dir> <state-dir> [extra env...] -> OUT, RC
 run() {
@@ -64,6 +70,7 @@ fail() { FAIL=$((FAIL+1)); echo "  ✗ FAIL: $1" >&2; }
 
 # 1. behind -> notice. Clone (up to date), then move origin ahead by one commit;
 #    the hook fetches and reports behind by 1.
+mk_origin o1
 R1="$TMP/r1"; g clone -q "$BARE" "$R1"
 commit_push "$SEED" "c2"
 run "$R1" "$TMP/s1"
@@ -71,6 +78,7 @@ if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("beh
   pass; else fail "behind: expected notice, got RC=$RC OUT=$OUT"; fi
 
 # 2. up to date -> silent.
+mk_origin o2
 R2="$TMP/r2"; g clone -q "$BARE" "$R2"
 run "$R2" "$TMP/s2"
 if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "up-to-date: expected silence, got RC=$RC OUT=$OUT"; fi
@@ -79,6 +87,7 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "up-to-date: expected sile
 #    Move origin ahead WITHOUT the hook fetching: a call +60s is throttled, so it
 #    skips the fetch and stays silent (proves no fetch). A call past the 1h
 #    window fetches the new commit and fires.
+mk_origin o3
 R3="$TMP/r3"; g clone -q "$BARE" "$R3"; s3="$TMP/s3"
 run "$R3" "$s3" SYNC_NOW=2000000                       # fetch, stamp, up to date -> silent
 [[ $RC -eq 0 && -z "$OUT" ]] || fail "throttle setup: first call should be silent, got RC=$RC OUT=$OUT"
@@ -90,7 +99,8 @@ if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("beh
   pass; else fail "throttle expired: past window should fetch and fire, got OUT=$OUT"; fi
 
 # 4. not a repo -> silent no-op.
-ND="$TMP/notrepo"; mkdir -p "$ND"
+ND="$TMP/notrepo"
+mkdir -p "$ND" || { echo "fatal: could not create $ND" >&2; exit 2; }
 run "$ND" "$TMP/s4"
 if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "not a repo: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
 
@@ -103,14 +113,14 @@ if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "no origin: expected silen
 # 6. fetch failure -> silent no-op (broken remote tolerated, no crash). Clone,
 #    then delete the bare origin so the fetch fails; local == last-known origin,
 #    so the comparison yields 0 and the hook exits 0 without crashing.
+mk_origin o6
 R6="$TMP/r6"; g clone -q "$BARE" "$R6"
-BROKEN="$TMP/origin-gone.git"; mv "$BARE" "$BROKEN"
+rm -rf "$BARE" || { echo "fatal: could not remove $BARE" >&2; exit 2; }
 run "$R6" "$TMP/s6"
-RC6=$RC; OUT6=$OUT
-mv "$BROKEN" "$BARE"                                   # restore for any later use
-if [[ $RC6 -eq 0 && -z "$OUT6" ]]; then pass; else fail "fetch failure: expected silent exit 0, got RC=$RC6 OUT=$OUT6"; fi
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "fetch failure: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
 
 # 7. malformed clock -> no-op, exit 0.
+mk_origin o7
 R7="$TMP/r7"; g clone -q "$BARE" "$R7"
 run "$R7" "$TMP/s7" SYNC_NOW="not-a-number"
 if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "bad clock: expected silent exit 0, got RC=$RC OUT=$OUT"; fi

--- a/hooks/tests/test_check_git_sync.sh
+++ b/hooks/tests/test_check_git_sync.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Outcome-based tests for check-git-sync.sh.
+#
+# The hook shells out to real git, so tests build real local repos (a bare
+# "origin" plus working clones) and drive git offline — no network, fully
+# deterministic. The injected clock (SYNC_NOW) drives the throttle assertions.
+#
+# Covers:
+#   1. Behind        -> emits additionalContext naming the branch + "behind".
+#   2. Up to date    -> silent (empty stdout), exit 0.
+#   3. Throttle      -> with a fixed injected clock: a call inside the window
+#                       skips the fetch (stays silent though origin moved); a
+#                       call past the window fetches and fires.
+#   4. Not a repo    -> silent no-op, exit 0.
+#   5. No origin     -> silent no-op, exit 0.
+#   6. Fetch failure -> silent no-op, exit 0 (offline/broken remote tolerated).
+#   7. Bad clock     -> silent no-op, exit 0 (never aborts SessionStart).
+#
+# Run: bash hooks/tests/test_check_git_sync.sh
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/check-git-sync.sh"
+[[ -f "$SCRIPT" && -r "$SCRIPT" ]] || { echo "fatal: hook not found/readable at $SCRIPT" >&2; exit 2; }
+command -v jq  >/dev/null 2>&1 || { echo "fatal: jq required for these tests"  >&2; exit 2; }
+command -v git >/dev/null 2>&1 || { echo "fatal: git required for these tests" >&2; exit 2; }
+
+TMP="$(mktemp -d -t git-sync-test.XXXXXX)" || { echo "fatal: mktemp failed" >&2; exit 2; }
+cleanup() { [[ -n "${TMP:-}" ]] && ! rm -rf "$TMP" && echo "warn: could not remove $TMP" >&2; return 0; }
+trap cleanup EXIT
+
+# Isolate git from the operator's global/system config so identity and defaults
+# are deterministic across machines.
+export HOME="$TMP/home"; mkdir -p "$HOME"
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+
+g() { git "$@"; }
+commit_push() { # <clone-dir> <message>
+  local dir="$1" msg="$2"
+  printf '%s\n' "$msg" >> "$dir/f"
+  g -C "$dir" add f
+  g -C "$dir" commit -q -m "$msg"
+  g -C "$dir" push -q origin main
+}
+
+# Build a bare origin with one commit on main, plus a clone that is up to date.
+BARE="$TMP/origin.git"
+g init -q --bare -b main "$BARE"
+SEED="$TMP/seed"
+g clone -q "$BARE" "$SEED" 2>/dev/null   # cloning an empty bare warns; irrelevant here
+g -C "$SEED" symbolic-ref HEAD refs/heads/main
+commit_push "$SEED" "c1"
+
+# run <repo-dir> <state-dir> [extra env...] -> OUT, RC
+run() {
+  local repo="$1" state="$2"; shift 2
+  OUT="$(cd "$repo" && env SYNC_STATE_DIR="$state" "$@" bash "$SCRIPT" </dev/null 2>/dev/null)"
+  RC=$?
+}
+
+FAIL=0; PASS=0
+pass() { PASS=$((PASS+1)); }
+fail() { FAIL=$((FAIL+1)); echo "  ✗ FAIL: $1" >&2; }
+
+# 1. behind -> notice. Clone (up to date), then move origin ahead by one commit;
+#    the hook fetches and reports behind by 1.
+R1="$TMP/r1"; g clone -q "$BARE" "$R1"
+commit_push "$SEED" "c2"
+run "$R1" "$TMP/s1"
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind") and test("main")' >/dev/null 2>&1; then
+  pass; else fail "behind: expected notice, got RC=$RC OUT=$OUT"; fi
+
+# 2. up to date -> silent.
+R2="$TMP/r2"; g clone -q "$BARE" "$R2"
+run "$R2" "$TMP/s2"
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "up-to-date: expected silence, got RC=$RC OUT=$OUT"; fi
+
+# 3. throttle. Clone up to date. Call at t stamps and (nothing new) stays silent.
+#    Move origin ahead WITHOUT the hook fetching: a call +60s is throttled, so it
+#    skips the fetch and stays silent (proves no fetch). A call past the 1h
+#    window fetches the new commit and fires.
+R3="$TMP/r3"; g clone -q "$BARE" "$R3"; s3="$TMP/s3"
+run "$R3" "$s3" SYNC_NOW=2000000                       # fetch, stamp, up to date -> silent
+[[ $RC -eq 0 && -z "$OUT" ]] || fail "throttle setup: first call should be silent, got RC=$RC OUT=$OUT"
+commit_push "$SEED" "c3"                               # origin moves; R3's tracking ref still old
+run "$R3" "$s3" SYNC_NOW=2000060                       # +60s: throttled -> no fetch -> silent
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle active: inside window should skip fetch and stay silent, got OUT=$OUT"; fi
+run "$R3" "$s3" SYNC_NOW=2003601                       # +>1h: fetch -> behind -> fires
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind")' >/dev/null 2>&1; then
+  pass; else fail "throttle expired: past window should fetch and fire, got OUT=$OUT"; fi
+
+# 4. not a repo -> silent no-op.
+ND="$TMP/notrepo"; mkdir -p "$ND"
+run "$ND" "$TMP/s4"
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "not a repo: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+# 5. no origin remote -> silent no-op.
+NO="$TMP/noorigin"; g init -q -b main "$NO"
+printf 'x\n' > "$NO/f"; g -C "$NO" add f; g -C "$NO" commit -q -m x
+run "$NO" "$TMP/s5"
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "no origin: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+# 6. fetch failure -> silent no-op (broken remote tolerated, no crash). Clone,
+#    then delete the bare origin so the fetch fails; local == last-known origin,
+#    so the comparison yields 0 and the hook exits 0 without crashing.
+R6="$TMP/r6"; g clone -q "$BARE" "$R6"
+BROKEN="$TMP/origin-gone.git"; mv "$BARE" "$BROKEN"
+run "$R6" "$TMP/s6"
+RC6=$RC; OUT6=$OUT
+mv "$BROKEN" "$BARE"                                   # restore for any later use
+if [[ $RC6 -eq 0 && -z "$OUT6" ]]; then pass; else fail "fetch failure: expected silent exit 0, got RC=$RC6 OUT=$OUT6"; fi
+
+# 7. malformed clock -> no-op, exit 0.
+R7="$TMP/r7"; g clone -q "$BARE" "$R7"
+run "$R7" "$TMP/s7" SYNC_NOW="not-a-number"
+if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "bad clock: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+echo "─────────────────────────────────────────────" >&2
+if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi
+echo "PASSED: all ${PASS} checks" >&2

--- a/hooks/tests/test_check_git_sync.sh
+++ b/hooks/tests/test_check_git_sync.sh
@@ -23,6 +23,8 @@
 #   7. Bad clock     -> silent no-op, exit 0 (never aborts SessionStart).
 #   8. Diverged      -> notice names divergence and recommends rebase, not a
 #                       fast-forward (local both ahead and behind origin).
+#   9. Future stamp  -> a schema_version > 1 record is not throttled on and is
+#                       preserved (not downgraded to version 1).
 #
 # Run: bash hooks/tests/test_check_git_sync.sh
 set -uo pipefail
@@ -156,6 +158,26 @@ main() {
   run "$TMP/r8" "$TMP/s8"
   if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("diverged") and test("rebase")' >/dev/null 2>&1; then
     pass; else fail "diverged: expected divergence notice, got RC=$RC OUT=$OUT"; fi
+
+  # 9. future-version throttle stamp -> not throttled on, and preserved (never
+  #    downgraded). Pre-seed a "2 <recent>" record at the stamp path the hook
+  #    derives (cksum of the repo toplevel), move origin ahead, and run inside
+  #    the window: a v1 stamp would throttle to silence, but the future record
+  #    must be ignored (the hook fires) and left untouched.
+  mk_origin o9
+  clone_from "$BARE" "$TMP/r9"
+  commit_push "$SEED" "c2"                                # origin ahead -> a non-throttled run fires
+  local top9 key9 stampdir9 sv9
+  top9="$(cd "$TMP/r9" && git rev-parse --show-toplevel)" || die "r9 toplevel failed"
+  key9="$(printf '%s' "$top9" | cksum | cut -d' ' -f1)"   || die "r9 key derivation failed"
+  stampdir9="$TMP/s9"
+  mkdir -p "$stampdir9" || die "could not create $stampdir9"
+  printf '2 %s\n' 2000000 > "$stampdir9/sync-$key9" || die "could not seed future stamp"
+  run "$TMP/r9" "$stampdir9" SYNC_NOW=2000060            # within window, but future schema
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind")' >/dev/null 2>&1; then
+    pass; else fail "future stamp: expected fire (not throttled), got RC=$RC OUT=$OUT"; fi
+  sv9=""; read -r sv9 _ < "$stampdir9/sync-$key9" || sv9=""
+  if [[ "$sv9" == "2" ]]; then pass; else fail "future stamp: expected preserved version 2, got '$sv9'"; fi
 
   echo "─────────────────────────────────────────────" >&2
   if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi

--- a/hooks/tests/test_check_git_sync.sh
+++ b/hooks/tests/test_check_git_sync.sh
@@ -7,6 +7,9 @@
 #
 # Each scenario builds its OWN bare origin + seed (mk_origin) so scenarios share
 # no mutable state and run in any order (rules/testing-standards.md Independence).
+# The harness drops `set -e` to aggregate results, so every fixture-setup command
+# is checked explicitly and aborts with a fatal diagnostic on failure
+# (rules/error-handling.md aggregate-reporting carve-out).
 #
 # Covers:
 #   1. Behind        -> emits additionalContext naming the branch + "behind".
@@ -24,39 +27,31 @@
 # Run: bash hooks/tests/test_check_git_sync.sh
 set -uo pipefail
 
-SCRIPT="$(cd "$(dirname "$0")/.." && pwd)/check-git-sync.sh"
-[[ -f "$SCRIPT" && -r "$SCRIPT" ]] || { echo "fatal: hook not found/readable at $SCRIPT" >&2; exit 2; }
-command -v jq  >/dev/null 2>&1 || { echo "fatal: jq required for these tests"  >&2; exit 2; }
-command -v git >/dev/null 2>&1 || { echo "fatal: git required for these tests" >&2; exit 2; }
+die() { echo "fatal: $*" >&2; exit 2; }
 
-TMP="$(mktemp -d -t git-sync-test.XXXXXX)" || { echo "fatal: mktemp failed" >&2; exit 2; }
 cleanup() { [[ -n "${TMP:-}" ]] && ! rm -rf "$TMP" && echo "warn: could not remove $TMP" >&2; return 0; }
-trap cleanup EXIT
-
-# Isolate git from the operator's global/system config so identity and defaults
-# are deterministic across machines. This isolation is load-bearing — an
-# unchecked mkdir failure would silently defeat it, so guard it explicitly
-# (rules/error-handling.md aggregate-reporting carve-out, setup-step check).
-export HOME="$TMP/home"
-mkdir -p "$HOME" || { echo "fatal: could not create isolated HOME at $HOME" >&2; exit 2; }
-export GIT_CONFIG_NOSYSTEM=1
-export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
 
 g() { git "$@"; }
+
 commit_push() { # <clone-dir> <message>
   local dir="$1" msg="$2"
-  printf '%s\n' "$msg" >> "$dir/f"
-  g -C "$dir" add f
-  g -C "$dir" commit -q -m "$msg"
-  g -C "$dir" push -q origin main
+  printf '%s\n' "$msg" >> "$dir/f"                || die "commit_push: write to $dir/f failed"
+  g -C "$dir" add f                               || die "commit_push: git add failed in $dir"
+  g -C "$dir" commit -q -m "$msg"                 || die "commit_push: git commit failed in $dir"
+  g -C "$dir" push -q origin main                 || die "commit_push: git push from $dir failed"
 }
+
 mk_origin() { # <prefix>: sets globals BARE, SEED to a fresh, independent origin
   local prefix="$1"
   BARE="$TMP/${prefix}.git"; SEED="$TMP/${prefix}-seed"
-  g init -q --bare -b main "$BARE"
-  g clone -q "$BARE" "$SEED" 2>/dev/null   # cloning an empty bare warns; irrelevant here
-  g -C "$SEED" symbolic-ref HEAD refs/heads/main
+  g init -q --bare -b main "$BARE"                || die "mk_origin: git init --bare failed for $BARE"
+  g clone -q "$BARE" "$SEED" 2>/dev/null          || die "mk_origin: git clone failed for $SEED"
+  g -C "$SEED" symbolic-ref HEAD refs/heads/main  || die "mk_origin: git symbolic-ref failed in $SEED"
   commit_push "$SEED" "c1"
+}
+
+clone_from() { # <bare> <dest>: a working clone, checked explicitly
+  g clone -q "$1" "$2"                            || die "clone_from: git clone $1 -> $2 failed"
 }
 
 # run <repo-dir> <state-dir> [extra env...] -> OUT, RC
@@ -66,78 +61,104 @@ run() {
   RC=$?
 }
 
-FAIL=0; PASS=0
 pass() { PASS=$((PASS+1)); }
 fail() { FAIL=$((FAIL+1)); echo "  ✗ FAIL: $1" >&2; }
 
-# 1. behind -> notice. Clone (up to date), then move origin ahead by one commit;
-#    the hook fetches and reports behind by 1.
-mk_origin o1
-R1="$TMP/r1"; g clone -q "$BARE" "$R1"
-commit_push "$SEED" "c2"
-run "$R1" "$TMP/s1"
-if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind") and test("main")' >/dev/null 2>&1; then
-  pass; else fail "behind: expected notice, got RC=$RC OUT=$OUT"; fi
+main() {
+  SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/check-git-sync.sh"
+  [[ -f "$SCRIPT" && -r "$SCRIPT" ]] || die "hook not found/readable at $SCRIPT"
+  command -v jq  >/dev/null 2>&1 || die "jq required for these tests"
+  command -v git >/dev/null 2>&1 || die "git required for these tests"
 
-# 2. up to date -> silent.
-mk_origin o2
-R2="$TMP/r2"; g clone -q "$BARE" "$R2"
-run "$R2" "$TMP/s2"
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "up-to-date: expected silence, got RC=$RC OUT=$OUT"; fi
+  TMP="$(mktemp -d -t git-sync-test.XXXXXX)" || die "mktemp failed"
+  trap cleanup EXIT
 
-# 3. throttle. Clone up to date. Call at t stamps and (nothing new) stays silent.
-#    Move origin ahead WITHOUT the hook fetching: a call +60s is throttled, so it
-#    skips the fetch and stays silent (proves no fetch). A call past the 1h
-#    window fetches the new commit and fires.
-mk_origin o3
-R3="$TMP/r3"; g clone -q "$BARE" "$R3"; s3="$TMP/s3"
-run "$R3" "$s3" SYNC_NOW=2000000                       # fetch, stamp, up to date -> silent
-[[ $RC -eq 0 && -z "$OUT" ]] || fail "throttle setup: first call should be silent, got RC=$RC OUT=$OUT"
-commit_push "$SEED" "c3"                               # origin moves; R3's tracking ref still old
-run "$R3" "$s3" SYNC_NOW=2000060                       # +60s: throttled -> no fetch -> silent
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle active: inside window should skip fetch and stay silent, got OUT=$OUT"; fi
-run "$R3" "$s3" SYNC_NOW=2003601                       # +>1h: fetch -> behind -> fires
-if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind")' >/dev/null 2>&1; then
-  pass; else fail "throttle expired: past window should fetch and fire, got OUT=$OUT"; fi
+  # Isolate git from the operator's global/system config so identity and defaults
+  # are deterministic across machines. This isolation is load-bearing — an
+  # unchecked mkdir failure would silently defeat it, so guard it explicitly.
+  export HOME="$TMP/home"
+  mkdir -p "$HOME" || die "could not create isolated HOME at $HOME"
+  export GIT_CONFIG_NOSYSTEM=1
+  export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
 
-# 4. not a repo -> silent no-op.
-ND="$TMP/notrepo"
-mkdir -p "$ND" || { echo "fatal: could not create $ND" >&2; exit 2; }
-run "$ND" "$TMP/s4"
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "not a repo: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+  FAIL=0; PASS=0
 
-# 5. no origin remote -> silent no-op.
-NO="$TMP/noorigin"; g init -q -b main "$NO"
-printf 'x\n' > "$NO/f"; g -C "$NO" add f; g -C "$NO" commit -q -m x
-run "$NO" "$TMP/s5"
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "no origin: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+  # 1. behind -> notice. Clone (up to date), then move origin ahead by one
+  #    commit; the hook fetches and reports behind by 1.
+  mk_origin o1
+  clone_from "$BARE" "$TMP/r1"
+  commit_push "$SEED" "c2"
+  run "$TMP/r1" "$TMP/s1"
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind") and test("main")' >/dev/null 2>&1; then
+    pass; else fail "behind: expected notice, got RC=$RC OUT=$OUT"; fi
 
-# 6. fetch failure -> silent no-op (broken remote tolerated, no crash). Clone,
-#    then delete the bare origin so the fetch fails; local == last-known origin,
-#    so the comparison yields 0 and the hook exits 0 without crashing.
-mk_origin o6
-R6="$TMP/r6"; g clone -q "$BARE" "$R6"
-rm -rf "$BARE" || { echo "fatal: could not remove $BARE" >&2; exit 2; }
-run "$R6" "$TMP/s6"
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "fetch failure: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+  # 2. up to date -> silent.
+  mk_origin o2
+  clone_from "$BARE" "$TMP/r2"
+  run "$TMP/r2" "$TMP/s2"
+  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "up-to-date: expected silence, got RC=$RC OUT=$OUT"; fi
 
-# 7. malformed clock -> no-op, exit 0.
-mk_origin o7
-R7="$TMP/r7"; g clone -q "$BARE" "$R7"
-run "$R7" "$TMP/s7" SYNC_NOW="not-a-number"
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "bad clock: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+  # 3. throttle. Clone up to date. Call at t stamps and (nothing new) stays
+  #    silent. Move origin ahead WITHOUT the hook fetching: a call +60s is
+  #    throttled, so it skips the fetch and stays silent (proves no fetch). A
+  #    call past the 1h window fetches the new commit and fires.
+  mk_origin o3
+  clone_from "$BARE" "$TMP/r3"
+  run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000000               # fetch, stamp, up to date -> silent
+  [[ $RC -eq 0 && -z "$OUT" ]] || fail "throttle setup: first call should be silent, got RC=$RC OUT=$OUT"
+  commit_push "$SEED" "c3"                                # origin moves; r3's tracking ref still old
+  run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000060               # +60s: throttled -> no fetch -> silent
+  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle active: inside window should skip fetch and stay silent, got OUT=$OUT"; fi
+  run "$TMP/r3" "$TMP/s3" SYNC_NOW=2003601               # +>1h: fetch -> behind -> fires
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind")' >/dev/null 2>&1; then
+    pass; else fail "throttle expired: past window should fetch and fire, got OUT=$OUT"; fi
 
-# 8. diverged -> divergence notice (rebase, not fast-forward). Clone, add a local
-#    commit (ahead by 1), and push a different commit to origin (behind by 1);
-#    the hook fetches and reports the diverged state.
-mk_origin o8
-R8="$TMP/r8"; g clone -q "$BARE" "$R8"
-printf 'local\n' >> "$R8/f"; g -C "$R8" add f; g -C "$R8" commit -q -m local   # ahead by 1
-commit_push "$SEED" "c2"                                                        # origin moves -> behind by 1
-run "$R8" "$TMP/s8"
-if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("diverged") and test("rebase")' >/dev/null 2>&1; then
-  pass; else fail "diverged: expected divergence notice, got RC=$RC OUT=$OUT"; fi
+  # 4. not a repo -> silent no-op.
+  mkdir -p "$TMP/notrepo" || die "could not create $TMP/notrepo"
+  run "$TMP/notrepo" "$TMP/s4"
+  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "not a repo: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
 
-echo "─────────────────────────────────────────────" >&2
-if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi
-echo "PASSED: all ${PASS} checks" >&2
+  # 5. no origin remote -> silent no-op.
+  g init -q -b main "$TMP/noorigin" || die "git init noorigin failed"
+  printf 'x\n' > "$TMP/noorigin/f"  || die "write noorigin/f failed"
+  g -C "$TMP/noorigin" add f        || die "git add in noorigin failed"
+  g -C "$TMP/noorigin" commit -q -m x || die "git commit in noorigin failed"
+  run "$TMP/noorigin" "$TMP/s5"
+  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "no origin: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+  # 6. fetch failure -> silent no-op (broken remote tolerated, no crash). Clone,
+  #    then delete the bare origin so the fetch fails; local == last-known
+  #    origin, so the comparison yields 0 and the hook exits 0 without crashing.
+  mk_origin o6
+  clone_from "$BARE" "$TMP/r6"
+  rm -rf "$BARE" || die "could not remove $BARE"
+  run "$TMP/r6" "$TMP/s6"
+  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "fetch failure: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+  # 7. malformed clock -> no-op, exit 0.
+  mk_origin o7
+  clone_from "$BARE" "$TMP/r7"
+  run "$TMP/r7" "$TMP/s7" SYNC_NOW="not-a-number"
+  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "bad clock: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+  # 8. diverged -> divergence notice (rebase, not fast-forward). Clone, add a
+  #    local commit (ahead by 1), and push a different commit to origin (behind
+  #    by 1); the hook fetches and reports the diverged state.
+  mk_origin o8
+  clone_from "$BARE" "$TMP/r8"
+  printf 'local\n' >> "$TMP/r8/f"        || die "write r8/f failed"
+  g -C "$TMP/r8" add f                    || die "git add in r8 failed"
+  g -C "$TMP/r8" commit -q -m local       || die "git commit in r8 failed"   # ahead by 1
+  commit_push "$SEED" "c2"                                                    # origin moves -> behind by 1
+  run "$TMP/r8" "$TMP/s8"
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("diverged") and test("rebase")' >/dev/null 2>&1; then
+    pass; else fail "diverged: expected divergence notice, got RC=$RC OUT=$OUT"; fi
+
+  echo "─────────────────────────────────────────────" >&2
+  if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi
+  echo "PASSED: all ${PASS} checks" >&2
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## What

Second hook in the "useful hooks" plan (after #260 `check-policy-freshness`). A `SessionStart` hook — `hooks/check-git-sync.sh` — that fetches origin (throttled, time-bounded) and injects a "sync before working" notice via `additionalContext` when the local default branch is behind `origin/<default>`.

Wired as a second entry in the existing `SessionStart` hook group in `.tessl-plugin/plugin.json`.

## Why

`rules/sync-before-work.md` prescribes fetch + sync before reading/editing but relied on the agent remembering — stale-checkout ("main is behind") recurred in real work. This makes it a deterministic check that always runs, per the `language-diagnostics` "a check nobody runs doesn't exist" philosophy. It **does** something (fetches + compares refs); it does not re-state a rule — the lesson from the reverted resurface hook (#259).

## Premise checks (per the issue)

- **Fetch latency**: measured ~0.25s on this repo; still throttled (default 1h/repo) and time-bounded via `timeout`/`gtimeout` so a hung network can't stall session start.
- **Behind-detection across repo states**: silent no-op outside a work tree, without an `origin` remote, and without a local default branch (detached HEAD is irrelevant — the comparison is on the default-branch refs, not HEAD). Remote default resolved from `origin/HEAD`, falling back to `main`/`master` among the remote-tracking refs.

## Design

- `SessionStart` — once per session, no per-turn tax.
- Informative only — always exits 0, never exits 2.
- Throttle gates the **fetch**; the behind comparison still runs on throttled sessions against the last-fetched ref, so staleness surfaces without a network call every session.
- Graceful no-op / stderr warning on every best-effort failure (`rules/error-handling.md`).

## Tests

`hooks/tests/test_check_git_sync.sh` — real temp git repos driven offline (bare origin + working clones), injected clock for the throttle assertions. Covers: behind, up-to-date, throttle (skip-fetch-inside-window then fire-past-window), non-repo, no-origin, fetch-failure, bad-clock. 8/8 pass; full suite 22/22, diagnostics clean, `tessl plugin lint` valid.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)