### PR TITLE
feat(hooks): dual-wire stop-handoff-hygiene to Codex

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -72,6 +72,18 @@
           ]
         }
       ]
+    },
+    "codex": {
+      "Stop": [
+        {
+          "hooks": [
+            {
+              "type": "command",
+              "command": "bash \"${TESSL_PLUGIN_DIR}/hooks/stop-handoff-hygiene.sh\""
+            }
+          ]
+        }
+      ]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Hooks — stop-handoff-hygiene now runs on Codex too
+
+Dual-wire the `stop-handoff-hygiene` Stop hook to Codex via `nativeHooks.codex` in `.tessl-plugin/plugin.json` (#265). Codex's hooks system matches Claude Code's Stop contract — `decision:"block"` continues the turn with `reason` as the next prompt, guarded by a `stop_hook_active` stdin boolean — so the same script runs unchanged on both agents.
+
+The two `nativeHooks` entries differ in shape by necessity: Claude Code's native hook config takes `command` + an `args[]` array, but Codex's takes a single `command` string (its config has no `args` field and shell-parses the string itself). A `command:"bash"` + `args:[...]` entry would run bare `bash` on Codex, so `nativeHooks.codex` uses `bash "${TESSL_PLUGIN_DIR}/hooks/stop-handoff-hygiene.sh"` as one string. Verified by installing into scratch consumers with `--agent claude-code --agent codex` and inspecting the written `.claude/settings.json` and `.codex/config.toml` (Codex entry lands as `[[hooks.Stop]]`, `enabled = true`, trusted).
+
 ## 0.3.142 — 2026-08-09
 
 ### Hooks — stop-handoff-hygiene (Stop pre-handoff gate)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Coding policy plugin for Baruch's AI agents. Language-agnostic code quality rule
 
 ## What's New
 
-- `stop-handoff-hygiene` hook — a Claude Code `Stop` hook that blocks the handoff once (loop-safe via `stop_hook_active`) when it finds leftover local branches (merged, upstream deleted), orphaned worktrees, or diagnostics findings in the changed set; a dirty working tree is reported, not blocked
+- `stop-handoff-hygiene` hook — a `Stop` hook (Claude Code + Codex) that blocks the handoff once (loop-safe via `stop_hook_active`) when it finds leftover local branches (merged, upstream deleted), orphaned worktrees, or diagnostics findings in the changed set; a dirty working tree is reported, not blocked
 - `check-git-sync` hook — a Tessl `SessionStart` hook that fetches origin (throttled) and warns when the local default branch is behind `origin/<default>`, mechanizing `rules/sync-before-work.md`. Informative only, never blocks
 - `check-policy-freshness` hook — a Tessl `SessionStart` hook that runs `tessl outdated` and warns (throttled to once/day) when installed plugins are behind the registry, so repos don't silently drift onto stale policy. Informative only, never blocks
 - Policy review runs on the OpenAI Codex CLI authenticated by a ChatGPT subscription (no API key) via `.github/workflows/review-codex.yml`, reviewing every PR against the in-tree `rules/*.md`; Copilot stays as the complementary code-quality lane
@@ -69,7 +69,7 @@ tessl install jbaruch/coding-policy
 | ---- | ----- | ----------- |
 | [check-policy-freshness](hooks/check-policy-freshness.sh) | SessionStart | Warns (throttled once/day) when installed Tessl plugins are behind the registry — a `tessl update` reminder at session start. Informative only, never blocks. |
 | [check-git-sync](hooks/check-git-sync.sh) | SessionStart | Fetches origin (throttled once/hour per repo) and warns when the local default branch is behind `origin/<default>` — a `rules/sync-before-work.md` reminder at session start. Informative only, never blocks. |
-| [stop-handoff-hygiene](hooks/stop-handoff-hygiene.sh) | Stop (Claude Code) | Blocks the handoff once (loop-safe via `stop_hook_active`) on leftover local branches (merged, upstream gone), orphaned worktrees, or diagnostics findings in the changed set (uncommitted `.sh`/`.py`, linted with shellcheck/pyright). A dirty working tree is reported, not blocked. Fail-open. |
+| [stop-handoff-hygiene](hooks/stop-handoff-hygiene.sh) | Stop (Claude Code + Codex) | Blocks the handoff once (loop-safe via `stop_hook_active`) on leftover local branches (merged, upstream gone), orphaned worktrees, or diagnostics findings in the changed set (uncommitted `.sh`/`.py`, linted with shellcheck/pyright). A dirty working tree is reported, not blocked. Fail-open. |
 
 ## Philosophy
 

--- a/hooks/stop-handoff-hygiene.sh
+++ b/hooks/stop-handoff-hygiene.sh
@@ -11,10 +11,17 @@
 # (that auto-cleans REMOTE branches; this covers the LOCAL branches/worktrees it
 # never touches).
 #
-# Why nativeHooks.claude-code (not the portable `hooks` tier): blocking a stop is
-# an agent-specific contract with no portable consensus form — Tessl translates
-# `additionalContext` (informational), not a stop-block. This hook emits Claude
-# Code's native Stop decision, so it ships under nativeHooks.claude-code.
+# Why nativeHooks (not the portable `hooks` tier): blocking a stop is an
+# agent-specific contract with no portable consensus form — the `hooks` tier
+# wraps the script in `tessl hook run`, which translates `additionalContext`
+# (informational), not a stop-block. nativeHooks writes the entry raw to each
+# agent's native config, so the agent reads the script's `{"decision":"block"}`
+# directly. Claude Code and Codex share the same Stop contract (decision/reason/
+# stop_hook_active), so the SAME script is dual-wired. The two entries differ in
+# shape by necessity: Claude Code's config takes command + args[], Codex's takes
+# a single command string (its config has no args field), so nativeHooks.codex
+# uses `bash "<path>"` as one string. Verified by installing into scratch
+# consumers and inspecting .claude/settings.json and .codex/config.toml.
 #
 # Blocking findings (gate the stop, once):
 #   - Leftover local branches whose upstream is gone (merged then remote-deleted).


### PR DESCRIPTION
## What

Follow-up to #262/#264. Wires the `stop-handoff-hygiene` Stop hook to **Codex** as well as Claude Code, via a `nativeHooks.codex` entry in `.tessl-plugin/plugin.json`. No script change — the same `hooks/stop-handoff-hygiene.sh` runs on both.

## Why it works

Codex's hooks system matches Claude Code's Stop contract:
- `decision:"block"` continues the turn, turning `reason` into the next prompt.
- Loop guard: a `stop_hook_active` stdin boolean (the hook already reads it).
- The hook's checks are pure git + shellcheck/pyright — nothing agent-specific.

## Premise verification (per #265)

Verified empirically rather than from docs:
- **`codex` is a supported `nativeHooks` target** — `tessl install --agent` lists `codex`, and the tessl binary references `.codex/config.toml` / `.codex/hooks.json` write-targets plus the Codex Stop contract (`stop_hook_active`, `SubagentStop`, `last_assistant_message`).
- **Installed into scratch consumers** with `--agent claude-code --agent codex` and inspected the written native configs:
  - Codex → `.codex/config.toml` `[[hooks.Stop]]`, `enabled = true`, `trusted_hash` set (so it runs).
  - Claude Code → `.claude/settings.json` raw `command`+`args` (unchanged, still works).
- **Shape difference is required**: Codex's hook config takes a **single `command` string** (no `args` field — confirmed in `codex-rs/hooks/src/engine/`, which shell-parses the command itself). A `command:"bash"` + `args:[...]` passthrough would run bare `bash` on Codex, so `nativeHooks.codex` uses `bash "${TESSL_PLUGIN_DIR}/hooks/stop-handoff-hygiene.sh"` as one string. Tessl expands `${TESSL_PLUGIN_DIR}` inside the string (verified).
- The generic `hooks` tier was rejected: it wraps the script in `tessl hook run`, which translates `additionalContext` only — not a stop-block — and would also move the working Claude path off its raw entry.

## Validation

Diagnostics clean, full suite 23/23, `tessl plugin lint` valid, manifest re-verified via local install.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)