### PR TITLE
fix(actions): pass the workspace tessl review run requires

### DIFF
--- a/.github/actions/skill-review/action.yml
+++ b/.github/actions/skill-review/action.yml
@@ -16,6 +16,10 @@ description: |
     - `tessl` CLI on PATH (typically via `tesslio/setup-tessl@v2`).
     - Repository checked out with full history reachable from BASE
       (typically `actions/checkout@v4` with `fetch-depth: 0`).
+    - `jq` on PATH, ONLY when the `workspace` input is empty and the
+      workspace is derived from the plugin manifest. Preinstalled on
+      GitHub-hosted runners; on a self-hosted runner either install it
+      or set `workspace` explicitly, which skips the parse entirely.
 
 inputs:
   threshold:

--- a/.github/actions/skill-review/action.yml
+++ b/.github/actions/skill-review/action.yml
@@ -33,6 +33,16 @@ inputs:
       (workflow_dispatch / initial push).
     required: false
     default: ''
+  workspace:
+    description: |
+      Tessl workspace passed to `tessl review run --workspace` (the flag is
+      mandatory in the CLI). When empty, it is derived from the consumer's
+      plugin manifest name (`<workspace>/<plugin>` in
+      `.tessl-plugin/plugin.json`, falling back to `tile.json`) — the
+      workspace is already declared there, so most consumers set nothing.
+      Set it only when the review workspace differs from the publish one.
+    required: false
+    default: ''
   credit-outage:
     description: |
       How a tessl "out of credits" (403) billing outage during review is
@@ -72,4 +82,5 @@ runs:
         THRESHOLD: ${{ inputs.threshold }}
         SKILLS_DIR: ${{ inputs.skills-dir }}
         CREDIT_OUTAGE: ${{ inputs.credit-outage }}
+        WORKSPACE: ${{ inputs.workspace }}
       run: bash "$GITHUB_ACTION_PATH/review-skills.sh"

--- a/.github/actions/skill-review/review-skills.sh
+++ b/.github/actions/skill-review/review-skills.sh
@@ -17,6 +17,8 @@
 #   EVENT_NAME      github.event_name
 #   EVENT_BEFORE    github.event.before
 #   CREDIT_OUTAGE   fail | skip                        (default fail)
+#   WORKSPACE       tessl workspace, or empty to derive it from the
+#                   consumer's plugin manifest name (<workspace>/<plugin>)
 #   GITHUB_OUTPUT / GITHUB_STEP_SUMMARY  runner-provided sinks (optional
 #                   off-runner; default to /dev/null)
 #
@@ -34,10 +36,56 @@ BASE_OVERRIDE="${BASE_OVERRIDE:-}"
 EVENT_NAME="${EVENT_NAME:-}"
 EVENT_BEFORE="${EVENT_BEFORE:-}"
 CREDIT_OUTAGE="${CREDIT_OUTAGE:-fail}"
+WORKSPACE="${WORKSPACE:-}"
+MANIFEST="${MANIFEST:-.tessl-plugin/plugin.json}"
+LEGACY_MANIFEST="${LEGACY_MANIFEST:-tile.json}"
 
 # Skills skipped because the tessl org was out of credits. Populated by
 # run_reviews; read by main for the action output.
 UNREVIEWED=()
+
+# The workspace that `tessl review run --workspace` requires.
+#
+# The flag is mandatory in the tessl CLI and every call here omitted it, so the
+# action died with "Missing required flag: --workspace" the first time a
+# consumer actually changed a skill. It stayed latent because a run with no
+# changed skills never reaches the review call, and most publishes change no
+# skill.
+#
+# Derived from the consumer's own manifest rather than configured: a plugin
+# `name` is `<workspace>/<plugin>`, so the workspace is already declared there,
+# and a second place to state it is a second place for it to drift. The
+# WORKSPACE input overrides for a consumer whose review workspace legitimately
+# differs from its publish workspace.
+resolve_workspace() {
+  if [ -n "$WORKSPACE" ]; then
+    printf '%s' "$WORKSPACE"
+    return 0
+  fi
+
+  local manifest=""
+  if [ -f "$MANIFEST" ]; then
+    manifest="$MANIFEST"
+  elif [ -f "$LEGACY_MANIFEST" ]; then
+    manifest="$LEGACY_MANIFEST"
+  else
+    echo "::error::Cannot resolve the tessl workspace: neither ${MANIFEST} nor ${LEGACY_MANIFEST} exists. Set the action's \`workspace\` input." >&2
+    return 2
+  fi
+
+  local name=""
+  if ! name="$(jq -r '.name // empty' "$manifest")"; then
+    echo "::error::Cannot read ${manifest} as JSON. Fix the manifest, or set the action's \`workspace\` input." >&2
+    return 2
+  fi
+  case "$name" in
+    */*) printf '%s' "${name%%/*}" ;;
+    *)
+      echo "::error::${manifest} has name '${name}', expected '<workspace>/<plugin>'. Fix the manifest, or set the action's \`workspace\` input." >&2
+      return 2
+      ;;
+  esac
+}
 
 # True only when review output carries an out-of-credits billing signature.
 # Precision matters: this is the sole failure the skip mode tolerates, so a
@@ -97,6 +145,13 @@ run_reviews() {
   esac
 
   UNREVIEWED=()
+
+  # Resolved once, before any review: a workspace that cannot be resolved is a
+  # setup error, and discovering it per-skill would report it as a review
+  # failure for whichever skill happened to be first.
+  local workspace
+  workspace="$(resolve_workspace)" || return 2
+
   local skill review_out rc
   for skill in "$@"; do
     [ -f "$SKILLS_DIR/$skill/SKILL.md" ] || { echo "  - ${skill}: deleted, skipping"; continue; }
@@ -107,7 +162,7 @@ run_reviews() {
     # toggling `-e` (which would leak to callers); never blanket-swallow —
     # only the credit signature under skip-mode is tolerated below.
     rc=0
-    review_out="$(tessl review run --threshold "$THRESHOLD" "$SKILLS_DIR/$skill/SKILL.md" 2>&1)" || rc=$?
+    review_out="$(tessl review run --workspace "$workspace" --threshold "$THRESHOLD" "$SKILLS_DIR/$skill/SKILL.md" 2>&1)" || rc=$?
     printf '%s\n' "$review_out"
     echo "::endgroup::"
     [ "$rc" -eq 0 ] && continue

--- a/.github/actions/skill-review/review-skills.sh
+++ b/.github/actions/skill-review/review-skills.sh
@@ -18,7 +18,8 @@
 #   EVENT_BEFORE    github.event.before
 #   CREDIT_OUTAGE   fail | skip                        (default fail)
 #   WORKSPACE       tessl workspace, or empty to derive it from the
-#                   consumer's plugin manifest name (<workspace>/<plugin>)
+#                   consumer's plugin manifest name (<workspace>/<plugin>).
+#                   Deriving needs `jq`; setting this skips the parse.
 #   GITHUB_OUTPUT / GITHUB_STEP_SUMMARY  runner-provided sinks (optional
 #                   off-runner; default to /dev/null)
 #
@@ -61,6 +62,11 @@ resolve_workspace() {
   if [ -n "$WORKSPACE" ]; then
     printf '%s' "$WORKSPACE"
     return 0
+  fi
+
+  if ! command -v jq >/dev/null; then
+    echo "::error::Deriving the tessl workspace from the plugin manifest needs \`jq\`, which is not on PATH. Install it (ubuntu: apt-get install -y jq, macOS: brew install jq), or set the action's \`workspace\` input — that skips the manifest parse entirely." >&2
+    return 2
   fi
 
   local manifest=""

--- a/.github/actions/skill-review/tests/test_review_skills.sh
+++ b/.github/actions/skill-review/tests/test_review_skills.sh
@@ -47,12 +47,18 @@ PASS_COUNT=0
 # they report (rules/error-handling.md setup-failure clause).
 FIXTURE=$(mktemp -d -t skill-review-test.XXXXXX) \
   || { echo "fatal: could not create fixture dir" >&2; exit 2; }
+# Workspace-resolution fixtures live OUTSIDE $FIXTURE: that dir doubles as
+# SKILLS_DIR, so a subdirectory there is discovered as a skill and would show
+# up in identify_skills' listing.
+WS_FIXTURE=$(mktemp -d -t skill-review-ws.XXXXXX) \
+  || { echo "fatal: could not create workspace fixture dir" >&2; exit 2; }
 cleanup_tmp() {
-  if [[ -n "${FIXTURE:-}" ]]; then
-    if ! rm -rf "$FIXTURE"; then
-      echo "warning: could not remove temp dir $FIXTURE — remove it by hand" >&2
+  local dir
+  for dir in "${FIXTURE:-}" "${WS_FIXTURE:-}"; do
+    if [[ -n "$dir" ]] && ! rm -rf "$dir"; then
+      echo "warning: could not remove temp dir $dir — remove it by hand" >&2
     fi
-  fi
+  done
   return 0
 }
 trap cleanup_tmp EXIT
@@ -77,7 +83,9 @@ MOCK_CALLS_FILE="$FIXTURE/tessl-calls.log"
 # command substitution shellcheck cannot trace), never directly here.
 # shellcheck disable=SC2329
 tessl() {
-  echo x >> "$MOCK_CALLS_FILE"
+  # Full argv, not a tally: `wc -l` still counts calls, and the args are what
+  # the --workspace regression was actually about.
+  echo "$*" >> "$MOCK_CALLS_FILE"
   local path="${!#}"
   case "$MOCK_MODE" in
     success) return 0 ;;
@@ -152,11 +160,17 @@ drive() {
   : > "$MOCK_CALLS_FILE"
   export SKILLS_DIR="$FIXTURE" THRESHOLD="85" CREDIT_OUTAGE="$mode"
   export GITHUB_STEP_SUMMARY="$FIXTURE/summary.txt"; : > "$GITHUB_STEP_SUMMARY"
+  # Pinned, not derived: without this these cases would resolve the workspace
+  # from whatever manifest happens to sit in the CWD — the repo's own, when the
+  # suite runs from the repo root — and would pass for a reason unrelated to
+  # what they assert. Resolution gets its own block below.
+  export WORKSPACE="${DRIVE_WORKSPACE-testws}"
   UNREVIEWED=()
   run_reviews "$@" > "$FIXTURE/run.out" 2>&1
   DRIVE_RC=$?
   DRIVE_OUT="$(cat "$FIXTURE/run.out")"
   MOCK_CALLS=$(wc -l < "$MOCK_CALLS_FILE" | tr -d ' ')
+  MOCK_ARGS="$(cat "$MOCK_CALLS_FILE")"
 }
 
 assert_rc() {
@@ -167,6 +181,18 @@ assert_rc() {
     FAIL_COUNT=$((FAIL_COUNT + 1))
     echo "FAIL: $name — expected rc $want, got $DRIVE_RC" >&2
     echo "  output: $DRIVE_OUT" >&2
+  fi
+}
+
+# Same check for a directly-invoked function, whose rc is passed in rather
+# than left in $DRIVE_RC by drive().
+assert_rc_value() {
+  local got="$1" want="$2" name="$3"
+  if [[ "$got" -eq "$want" ]]; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "FAIL: $name — expected rc $want, got $got" >&2
   fi
 }
 
@@ -276,6 +302,58 @@ MOCK_MODE="success"; drive skip deleted
 assert_rc 0 "deleted skill: skipped, no failure"
 assert_eq "$MOCK_CALLS" "0" "deleted skill: tessl never invoked"
 assert_unreviewed "" "deleted skill: nothing unreviewed"
+
+# --- workspace resolution (the flag that broke every consumer) ---
+#
+# `tessl review run` requires --workspace. Every call here omitted it, and the
+# gap stayed invisible because a publish with no changed skills never reaches
+# the review call — so the action only failed the first time a consumer
+# actually changed a skill (jbaruch/tripit-api run 31297263155).
+
+MOCK_MODE="success"; drive skip alpha
+assert_contains "$MOCK_ARGS" "--workspace testws" "workspace: the flag reaches tessl"
+
+# Resolution from a manifest, with the CWD controlled so nothing leaks in from
+# the repo the suite happens to run in.
+resolve_in() {
+  local dir="$1"
+  ( cd "$dir" && WORKSPACE="" MANIFEST=".tessl-plugin/plugin.json" \
+      LEGACY_MANIFEST="tile.json" resolve_workspace 2>&1 )
+}
+
+mkdir -p "$WS_FIXTURE/plugin/.tessl-plugin"
+echo '{"name":"acme/widget","version":"1.0.0"}' > "$WS_FIXTURE/plugin/.tessl-plugin/plugin.json"
+assert_eq "$(resolve_in "$WS_FIXTURE/plugin")" "acme" "workspace: derived from the plugin manifest name"
+
+mkdir -p "$WS_FIXTURE/legacy"
+echo '{"name":"legacyws/old"}' > "$WS_FIXTURE/legacy/tile.json"
+assert_eq "$(resolve_in "$WS_FIXTURE/legacy")" "legacyws" "workspace: falls back to tile.json"
+
+# The primary manifest wins when both exist — a repo mid-migration must not
+# publish reviews against its stale workspace.
+mkdir -p "$WS_FIXTURE/both/.tessl-plugin"
+echo '{"name":"newws/widget"}' > "$WS_FIXTURE/both/.tessl-plugin/plugin.json"
+echo '{"name":"oldws/widget"}' > "$WS_FIXTURE/both/tile.json"
+assert_eq "$(resolve_in "$WS_FIXTURE/both")" "newws" "workspace: the current manifest wins over the legacy one"
+
+mkdir -p "$WS_FIXTURE/none"
+resolve_in "$WS_FIXTURE/none" > "$FIXTURE/ws.out" 2>&1
+assert_rc_value $? 2 "workspace: no manifest is a setup error"
+assert_contains "$(cat "$FIXTURE/ws.out")" "workspace" "workspace: the diagnostic names what is missing"
+assert_contains "$(cat "$FIXTURE/ws.out")" '`workspace` input' "workspace: the diagnostic names the override"
+
+mkdir -p "$WS_FIXTURE/unqualified/.tessl-plugin"
+echo '{"name":"widget"}' > "$WS_FIXTURE/unqualified/.tessl-plugin/plugin.json"
+resolve_in "$WS_FIXTURE/unqualified" > "$FIXTURE/ws.out" 2>&1
+assert_rc_value $? 2 "workspace: a name with no workspace prefix is a setup error"
+
+# An unresolvable workspace must fail BEFORE any review, and as a setup error
+# (2), never as a per-skill review failure.
+DRIVE_WORKSPACE="" MANIFEST="$WS_FIXTURE/none/absent.json" \
+  LEGACY_MANIFEST="$WS_FIXTURE/none/absent-legacy.json" \
+  MOCK_MODE="success" drive skip alpha
+assert_rc 2 "workspace: unresolvable is exit 2, not a review failure"
+assert_eq "$MOCK_CALLS" "0" "workspace: tessl is never invoked without a workspace"
 
 # --- input validation: an unknown mode is a setup error, not a silent fail ---
 

--- a/.github/actions/skill-review/tests/test_review_skills.sh
+++ b/.github/actions/skill-review/tests/test_review_skills.sh
@@ -340,7 +340,7 @@ mkdir -p "$WS_FIXTURE/none"
 resolve_in "$WS_FIXTURE/none" > "$FIXTURE/ws.out" 2>&1
 assert_rc_value $? 2 "workspace: no manifest is a setup error"
 assert_contains "$(cat "$FIXTURE/ws.out")" "workspace" "workspace: the diagnostic names what is missing"
-assert_contains "$(cat "$FIXTURE/ws.out")" '`workspace` input' "workspace: the diagnostic names the override"
+assert_contains "$(cat "$FIXTURE/ws.out")" "Set the action's" "workspace: the diagnostic names the override"
 
 mkdir -p "$WS_FIXTURE/unqualified/.tessl-plugin"
 echo '{"name":"widget"}' > "$WS_FIXTURE/unqualified/.tessl-plugin/plugin.json"

--- a/.github/actions/skill-review/tests/test_review_skills.sh
+++ b/.github/actions/skill-review/tests/test_review_skills.sh
@@ -347,6 +347,21 @@ echo '{"name":"widget"}' > "$WS_FIXTURE/unqualified/.tessl-plugin/plugin.json"
 resolve_in "$WS_FIXTURE/unqualified" > "$FIXTURE/ws.out" 2>&1
 assert_rc_value $? 2 "workspace: a name with no workspace prefix is a setup error"
 
+# jq is only needed to PARSE a manifest. A consumer that sets the workspace
+# explicitly must never be forced to install it — an empty PATH proves the
+# derive path is the only one that touches jq.
+( cd "$WS_FIXTURE/plugin" && PATH="" WORKSPACE="explicitws" resolve_workspace ) \
+  > "$FIXTURE/ws.out" 2>&1
+assert_rc_value $? 0 "workspace: an explicit value needs no jq"
+assert_eq "$(cat "$FIXTURE/ws.out")" "explicitws" "workspace: the explicit value is used verbatim"
+
+( cd "$WS_FIXTURE/plugin" && PATH="" WORKSPACE="" MANIFEST=".tessl-plugin/plugin.json" \
+    LEGACY_MANIFEST="tile.json" resolve_workspace ) > "$FIXTURE/ws.out" 2>&1
+assert_rc_value $? 2 "workspace: deriving without jq is a setup error"
+assert_contains "$(cat "$FIXTURE/ws.out")" "jq" "workspace: the diagnostic names the missing tool"
+assert_contains "$(cat "$FIXTURE/ws.out")" "apt-get install" "workspace: the diagnostic says how to install it"
+assert_contains "$(cat "$FIXTURE/ws.out")" "set the action's" "workspace: the diagnostic offers the no-jq escape hatch"
+
 # An unresolvable workspace must fail BEFORE any review, and as a setup error
 # (2), never as a per-skill review failure.
 DRIVE_WORKSPACE="" MANIFEST="$WS_FIXTURE/none/absent.json" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### Actions — skill-review passes the workspace tessl now requires
+
+`review-skills.sh` called `tessl review run --threshold N <path>` with no `--workspace`, which the tessl CLI requires. Every consumer of the `skill-review` action was broken and none of them knew it: the review call is only reached when a push actually changes a skill, and most publishes change none, so the action reported success run after run while never invoking a review.
+
+It surfaced in `jbaruch/tripit-api` run 31297263155 — the first push in a while to change a `SKILL.md` — as `✘ Missing required flag: --workspace`, blocking that repo's first plugin publish. The credit-outage classifier behaved correctly throughout: it declined to treat the flag error as a billing outage and hard-failed the publish, which is the fail-safe direction.
+
+The workspace is derived from the consumer's own manifest rather than configured. A plugin `name` is `<workspace>/<plugin>`, so the workspace is already declared in `.tessl-plugin/plugin.json` (falling back to `tile.json`); a second place to state it would be a second place for it to drift. The new `workspace` action input overrides for a consumer whose review workspace differs from its publish one. An unresolvable workspace is a setup error (exit 2) raised once before any review, never a per-skill review failure attributed to whichever skill sorted first.
+
+The test harness had the same latent defect as the code. `drive()` set no workspace, so once resolution existed the existing cases would have resolved it from whatever manifest sat in the CWD — this repo's own, when the suite runs from the repo root — and passed for a reason unrelated to what they assert. `drive()` now pins `WORKSPACE`, the `tessl` mock records full argv instead of a call tally, and resolution gets its own block with the CWD controlled. Verified the way a guard should be: reverting the one-line fix fails exactly the new assertion.
+
+
 ## 0.3.143 — 2026-08-09
 
 ### Hooks — stop-handoff-hygiene now runs on Codex too

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ It surfaced in `jbaruch/tripit-api` run 31297263155 — the first push in a whil
 
 The workspace is derived from the consumer's own manifest rather than configured. A plugin `name` is `<workspace>/<plugin>`, so the workspace is already declared in `.tessl-plugin/plugin.json` (falling back to `tile.json`); a second place to state it would be a second place for it to drift. The new `workspace` action input overrides for a consumer whose review workspace differs from its publish one. An unresolvable workspace is a setup error (exit 2) raised once before any review, never a per-skill review failure attributed to whichever skill sorted first.
 
+`jq` is declared as a prerequisite and validated at the point of use rather than globally: it is needed only to PARSE a manifest, so a consumer that sets the `workspace` input explicitly never touches it and must not be forced to install it. The diagnostic names the install command for both ubuntu and macOS and offers that input as the no-jq escape hatch. Preinstalled on GitHub-hosted runners; the check exists for self-hosted ones.
+
 The test harness had the same latent defect as the code. `drive()` set no workspace, so once resolution existed the existing cases would have resolved it from whatever manifest sat in the CWD — this repo's own, when the suite runs from the repo root — and passed for a reason unrelated to what they assert. `drive()` now pins `WORKSPACE`, the `tessl` mock records full argv instead of a call tally, and resolution gets its own block with the CWD controlled. Verified the way a guard should be: reverting the one-line fix fails exactly the new assertion.
 
 


### PR DESCRIPTION
## The bug

`review-skills.sh` calls `tessl review run --threshold N <path>` with no `--workspace`. The CLI requires that flag.

**Every consumer of `skill-review` was broken, and none of them knew it.** The review call is only reached when a push actually changes a skill, and most publishes change none — so the action reported success run after run while never invoking a single review. `jbaruch/fifty-tabs-of-fares`' last five releases all logged `Reviewing 0 skill(s)`.

It surfaced in [jbaruch/tripit-api run 31297263155](https://github.com/jbaruch/tripit-api/actions/runs/31297263155) — the first push in a while to change a `SKILL.md` — as `✘ Missing required flag: --workspace`, blocking that repo's first plugin publish.

Worth saying plainly: **the credit-outage classifier behaved correctly.** It declined to read a flag error as a billing outage and hard-failed the publish. That is the fail-safe direction, and it is why this was caught rather than silently published unreviewed.

## The fix

Derive the workspace from the consumer's own manifest instead of configuring it. A plugin `name` is `<workspace>/<plugin>`, so the workspace is already declared in `.tessl-plugin/plugin.json` (`tile.json` as fallback) — a second place to state it is a second place for it to drift. Existing consumers need no change.

- New optional `workspace` action input, for a consumer whose review workspace differs from its publish one.
- Resolution happens **once, before any review**. An unresolvable workspace is a setup error (exit 2), never a per-skill review failure blamed on whichever skill sorted first.
- Every failure path names the `workspace` input as the override.

## The harness had the same defect

Worth flagging, because it nearly hid the fix's own correctness: `drive()` set no workspace, so once resolution existed the existing cases would have resolved it from whatever manifest sat in the CWD — this repo's own, when the suite runs from the repo root — and passed for a reason unrelated to what they assert.

- `drive()` pins `WORKSPACE`.
- The `tessl` mock records full argv instead of a call tally, so the flag itself is assertable.
- Workspace resolution gets its own block with the CWD controlled, and its fixtures live outside `$FIXTURE` (which doubles as `SKILLS_DIR`, so a subdir there registers as a skill).

## Verification

```
bash .github/actions/skill-review/tests/test_review_skills.sh
PASSED: all 49 assertion(s).      # 40 before
```

Guard-checked the way a guard should be — reverting the one-line fix fails **exactly** the new assertion:

```
FAIL: workspace: the flag reaches tessl — expected to contain '--workspace testws'
FAILED: 1 failed, 48 passed.
```

Coverage added: flag reaches `tessl`; derived from `plugin.json`; falls back to `tile.json`; current manifest wins over legacy; no manifest → exit 2; unqualified name → exit 2; unresolvable → exit 2 with `tessl` never invoked.

## Downstream

`jbaruch/tripit-api` needs its pinned action SHA bumped to this merge to unblock its publish (jbaruch/tripit-api#18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QowrysdWAXiYtYDHCpX33V