### PR TITLE
fix(actions): base skill review on the last successful publish

### DIFF
--- a/.github/actions/skill-review/action.yml
+++ b/.github/actions/skill-review/action.yml
@@ -8,9 +8,12 @@ description: |
   time and Tessl credits.
 
   Detection: `git diff $BASE..HEAD -- $skills-dir/`. BASE is the input
-  `base-ref` if provided, else `github.event.before` for push events.
-  On `workflow_dispatch` or initial push (no usable base), reviews
-  every skill (manual triggers expect a full re-review).
+  `base-ref` if provided; else the nearest ancestor marking the last
+  successful publish (the `Bump … to X.Y.Z [skip ci]` commit), so a
+  publish that failed after the review step does not drop its changed
+  skills from the next run's window; else `github.event.before`. On
+  `workflow_dispatch` or initial push (no usable base), reviews every
+  skill (manual triggers expect a full re-review).
 
   Requirements (consumer must arrange):
     - `tessl` CLI on PATH (typically via `tesslio/setup-tessl@v2`).
@@ -32,9 +35,11 @@ inputs:
     default: 'skills'
   base-ref:
     description: |
-      Override the base ref/SHA for the diff. When empty, the action falls
-      back to `github.event.before` (push events) or "review all"
-      (workflow_dispatch / initial push).
+      Override the base ref/SHA for the diff. When empty, the action uses
+      the last successful-publish marker commit, falling back to
+      `github.event.before` (push events) or "review all"
+      (workflow_dispatch / initial push). Set this to recover explicitly
+      from a failed publish by passing the last-published SHA.
     required: false
     default: ''
   workspace:

--- a/.github/actions/skill-review/review-skills.sh
+++ b/.github/actions/skill-review/review-skills.sh
@@ -16,6 +16,8 @@
 #   BASE_OVERRIDE   explicit diff base, or empty
 #   EVENT_NAME      github.event_name
 #   EVENT_BEFORE    github.event.before
+#   PUBLISH_MARKER_PATTERN  ERE for the publish-bump commit (optional; the
+#                   last-publish marker is preferred over EVENT_BEFORE — #271)
 #   CREDIT_OUTAGE   fail | skip                        (default fail)
 #   WORKSPACE       tessl workspace, or empty to derive it from the
 #                   consumer's plugin manifest name (<workspace>/<plugin>).
@@ -40,6 +42,14 @@ CREDIT_OUTAGE="${CREDIT_OUTAGE:-fail}"
 WORKSPACE="${WORKSPACE:-}"
 MANIFEST="${MANIFEST:-.tessl-plugin/plugin.json}"
 LEGACY_MANIFEST="${LEGACY_MANIFEST:-tile.json}"
+# The commit tesslio/patch-version-publish pushes after a green review+publish
+# ("Bump <name> to X.Y.Z [skip ci]"). identify_skills diffs from the nearest
+# such ancestor rather than github.event.before, so a publish that FAILED at or
+# after the review step does not drop its changed skills from the next run's
+# window (#271). An extended-regexp anchored to a message line (git log -E);
+# override for a publish flow with a different marker (a consumer can always
+# pass base-ref).
+PUBLISH_MARKER_PATTERN="${PUBLISH_MARKER_PATTERN:-^Bump .+ to [0-9]+\.[0-9]+\.[0-9]+.*\[skip ci\]}"
 
 # Skills skipped because the tessl org was out of credits. Populated by
 # run_reviews; read by main for the action output.
@@ -185,10 +195,33 @@ run_reviews() {
   return 0
 }
 
+# Echo the SHA of the nearest HEAD ancestor that marks a successful publish —
+# the commit tesslio/patch-version-publish pushes after a green review+publish
+# (PUBLISH_MARKER_PATTERN). That commit bounds every still-unpublished change,
+# so diffing from it re-reviews the skills a failed publish left behind, which
+# github.event.before would skip once a later push moves the window past them
+# (#271). Empty when no marker is in history — first publish ever, or a publish
+# flow that pushes no such commit — so the caller falls back to
+# github.event.before. A shallow clone that cannot see the marker is deepened
+# once (the calling workflow should set fetch-depth: 0); a deepen failure warns
+# and falls back rather than masking the miss.
+resolve_publish_marker() {
+  local sha=""
+  sha="$(git log -E --grep="$PUBLISH_MARKER_PATTERN" --max-count=1 --format='%H' HEAD 2>/dev/null)" \
+    || sha=""
+  if [ -z "$sha" ] && [ "$(git rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+    git fetch --unshallow origin 2>/dev/null \
+      || echo "::warning::could not deepen the clone to find the last-publish marker; falling back to github.event.before" >&2
+    sha="$(git log -E --grep="$PUBLISH_MARKER_PATTERN" --max-count=1 --format='%H' HEAD 2>/dev/null)" \
+      || sha=""
+  fi
+  printf '%s' "$sha"
+}
+
 # Resolve the diff base and echo the changed skill names (one per line).
-# BASE_OVERRIDE wins; else github.event.before for push; else "" meaning
-# review every skill (workflow_dispatch / initial push expect a full
-# re-review). An unreachable non-empty base hard-fails rather than
+# BASE_OVERRIDE wins; else "" (review every skill) for workflow_dispatch /
+# initial push; else the last successful-publish marker (#271); else
+# github.event.before. An unreachable non-empty base hard-fails rather than
 # silently collapsing to "no changes".
 identify_skills() {
   local base
@@ -199,7 +232,10 @@ identify_skills() {
        || [ "$EVENT_BEFORE" = "0000000000000000000000000000000000000000" ]; then
     base=""
   else
-    base="$EVENT_BEFORE"
+    base="$(resolve_publish_marker)"
+    if [ -z "$base" ]; then
+      base="$EVENT_BEFORE"
+    fi
   fi
 
   if [ -z "$base" ]; then

--- a/.github/actions/skill-review/tests/test_review_skills.sh
+++ b/.github/actions/skill-review/tests/test_review_skills.sh
@@ -426,6 +426,56 @@ rc=0
 capture_identify "$GITREPO" "skills" "" "push" "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" >/dev/null 2>&1 || rc=$?
 assert_eq "$rc" "2" "identify_skills: unreachable base hard-fails with exit 2"
 
+# --- #271: the last-publish marker is preferred over github.event.before, so a
+# publish that failed after the review step does not drop its skills. Fixture
+# reproduces the sequence: a bump-marker commit (last green publish), then a
+# skill change whose publish FAILED, then a later push whose event.before hides
+# the failed one.
+MARKERREPO="$FIXTURE/markerrepo"
+make_marker_fixture() {
+  rm -rf "$MARKERREPO"
+  mkdir -p "$MARKERREPO" || return 1
+  (
+    set -e
+    cd "$MARKERREPO"
+    git init -q
+    git config user.email t@e.test
+    git config user.name tester
+    mkdir -p skills/alpha; echo a > skills/alpha/SKILL.md
+    git add -A; git commit -q -m base
+    # Last successful publish — patch-version-publish's bump commit.
+    git commit -q --allow-empty -m "Bump acme/x to 1.0.0 [skip ci]"
+    # A push whose publish FAILED after review: gamma changed but never shipped.
+    mkdir -p skills/gamma; echo g > skills/gamma/SKILL.md
+    git add -A; git commit -q -m "add gamma skill"
+    # A later push (e.g. an action-pin bump) that re-triggers publish; its
+    # github.event.before is the gamma commit, hiding gamma from the diff.
+    mkdir -p skills/delta; echo d > skills/delta/SKILL.md
+    git add -A; git commit -q -m "add delta skill"
+  )
+}
+make_marker_fixture || { echo "fatal: could not build marker fixture" >&2; exit 2; }
+before_sha=$( cd "$MARKERREPO" && git rev-parse HEAD~1 )   # the gamma commit
+
+# event.before = gamma, but the marker base wins: BOTH gamma (the failed
+# publish) and delta are re-reviewed. event.before alone would yield delta only.
+got=$(capture_identify "$MARKERREPO" "skills" "" "push" "$before_sha")
+assert_eq "$got" "$(printf 'delta\ngamma')" "identify_skills: last-publish marker re-includes a failed publish's skills"
+
+# base-ref override still wins over the marker.
+got=$(capture_identify "$MARKERREPO" "skills" "$before_sha" "push" "$before_sha")
+assert_eq "$got" "delta" "identify_skills: explicit base-ref overrides the marker base"
+
+# The marker pattern is overridable for a different publish flow. Pointing it at
+# the gamma commit makes gamma the base, so only delta shows as changed after it.
+got=$( cd "$MARKERREPO" && SKILLS_DIR=skills BASE_OVERRIDE="" EVENT_NAME=push \
+         EVENT_BEFORE="$before_sha" PUBLISH_MARKER_PATTERN="^add gamma" identify_skills )
+assert_eq "$got" "delta" "identify_skills: PUBLISH_MARKER_PATTERN override selects a custom marker"
+
+# No marker in history → fall back to github.event.before (prior behaviour). The
+# GITREPO fixture above has no bump commit; its earlier assertion (base = HEAD~1
+# yields alpha+beta) already exercises this fallback through the new code path.
+
 # --- main: emits the unreviewed-skills output ---
 
 # Run main with the given context; its GITHUB_OUTPUT write is the artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Actions — skill-review diffs from the last successful publish, not event.before
+
+The changed-skills review loop diffed `github.event.before..HEAD`. When a publish failed at or after the review step, the skills it changed were consumed by that run's diff window; the next push's `event.before` pointed past them, so `Reviewing 0 skill(s)` — and the next green publish shipped them unreviewed, silently (observed on `jbaruch/tripit-api` 0.6.0 shipping `using-tripit` unreviewed after run 31297263155 failed on the `--workspace` bug). `review-skills.sh` now resolves the base to the nearest ancestor marking the last successful publish — the `Bump … to X.Y.Z [skip ci]` commit `tesslio/patch-version-publish` pushes — which bounds every still-unpublished change, so a failed publish's skills stay in the next run's window until a publish actually reviews and ships them. Falls back to `event.before` when no marker is in history (first publish, or a publish flow with a different marker); the `base-ref` input still overrides, now documented as the explicit failed-publish recovery. The marker regex is `PUBLISH_MARKER_PATTERN` (overridable). Closes #271.
+
 ## 0.3.148 — 2026-08-09
 
 ### Release skill — Step 6 heading no longer contradicts its body


### PR DESCRIPTION
## What

The changed-skills review loop diffed `github.event.before..HEAD`.

## The gap

When a publish **fails at or after** the review step, the skills it changed are consumed by that run's diff window. The next push's `event.before` points past them → `Reviewing 0 skill(s)` → the next green publish ships them **unreviewed**, silently. Observed on `jbaruch/tripit-api` 0.6.0, which shipped `using-tripit` unreviewed after run 31297263155 failed on the `--workspace` bug (#269). The gate is at-most-once per diff window, and a lost window is silent.

## Fix (issue option 1 — robust diff base)

`review-skills.sh` now resolves the base to the nearest ancestor marking the **last successful publish** — the `Bump … to X.Y.Z [skip ci]` commit `tesslio/patch-version-publish` pushes. That commit bounds every still-unpublished change, so a failed publish's skills stay in the next run's window until a publish actually reviews and ships them.

- New `resolve_publish_marker()`; base priority: `base-ref` → last-publish marker → `event.before` → review-all.
- Falls back to `event.before` when no marker is in history (first publish, or a different publish flow). Shallow clones are deepened once, else warn + fall back.
- `PUBLISH_MARKER_PATTERN` (ERE) is overridable. `base-ref` now documented as the explicit failed-publish recovery.

## Tests

New fixture reproduces the exact sequence (bump marker → failed-publish skill change → later push) and asserts the marker base re-includes the stranded skill; plus `base-ref`-overrides-marker and `PUBLISH_MARKER_PATTERN`-override cases. 58 assertions green; full suite 25/25; pyright + shellcheck clean.

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)