### PR TITLE
fix(release): verify Copilot request from the mutation, not REST

### DIFF
--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jbaruch/coding-policy",
-  "version": "0.3.147",
+  "version": "0.3.148",
   "description": "General-purpose coding policy for Baruch's AI agents",
   "private": false,
   "skills": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Release skill — request-copilot-review.sh verifies from the mutation, not REST
+
+`request-copilot-review.sh` sent the Copilot review request over GraphQL (correct) but verified it over the REST `pulls` endpoint's `requested_reviewers` — the exact surface the script's own header says "silently drops bot reviewers." That field returns `[]` for a bot, so the check never matched and the script exited 1 on every successful request, unconditionally, for the only reviewer type it exists to request (observed on `jbaruch/tripit-api#36`; also hit in this repo requesting review on #273). Under a `set -euo pipefail` wrapper the non-zero exit aborts the release flow after the request already landed, and an agent trusting the exit code concludes Copilot was never requested — compounding the #267 fix that made the per-push re-request an explicit step. The mutation now returns its own `reviewRequests` and the script verifies from that authoritative response (dropping a REST round-trip); the `{pr_number, bot_id, requested_reviewers}` output shape is unchanged. Added `main()` coverage the earlier suite lacked — a bot-only reviewer list verifies clean, plus copilot-absent and stale-ID-fallback cases. Closes #276.
+
 ## 0.3.148 — 2026-08-09
 
 ### Release skill — Step 6 heading no longer contradicts its body

--- a/skills/release/request-copilot-review.sh
+++ b/skills/release/request-copilot-review.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # Request a Copilot review on a PR via GraphQL — REST silently drops bot
 # reviewers. Falls back to looking up the bot ID from recent reviews if the
-# pinned ID is stale, then verifies Copilot is in `requested_reviewers`.
+# pinned ID is stale, then verifies Copilot is in the mutation's OWN returned
+# review requests. The REST `requested_reviewers` field omits bot reviewers, so
+# it cannot verify a bot request (issue #276) — the mutation response is the
+# authoritative surface.
 #
 # Usage: request-copilot-review.sh <owner> <repo> <pr-number>
 # Env:   COPILOT_BOT_ID (override default BOT_kgDOCnlnWA)
@@ -46,12 +49,23 @@ fetch_pr_node_id() {
   echo "$pr_id"
 }
 
+# Run the requestReviews mutation and echo the resulting bot-reviewer logins as
+# a JSON array. The mutation's OWN response is the authoritative post-state and
+# the only surface that reports bot reviewers — the REST pulls endpoint's
+# `requested_reviewers` omits them (issue #276), so it cannot verify this. On a
+# GraphQL error (a stale/rejected bot ID) `gh api graphql` exits non-zero and
+# stdout is empty, so a caller can branch on the exit to fall back. stderr is
+# silenced because every caller emits its own actionable message on failure
+# (rules/error-handling.md — silencing a diagnostic while explicitly handling
+# the failure is not suppression).
 request_with_bot_id() {
   gh api graphql -f query="
     mutation { requestReviews(input: {
       pullRequestId: \"$1\", botIds: [\"$2\"]
-    }) { clientMutationId } }
-  " >/dev/null 2>&1
+    }) { pullRequest { reviewRequests(first: 20) { nodes {
+      requestedReviewer { __typename ... on Bot { login } }
+    } } } } }
+  " --jq '[.data.requestReviews.pullRequest.reviewRequests.nodes[]?.requestedReviewer.login // empty]' 2>/dev/null
 }
 
 discover_copilot_bot_id() {
@@ -86,7 +100,11 @@ main() {
   }
 
   local bot_id="${COPILOT_BOT_ID:-$COPILOT_BOT_ID_DEFAULT}"
-  if ! request_with_bot_id "$pr_node_id" "$bot_id"; then
+  local reviewers
+  # The mutation returns the post-request reviewer list; capture it as both the
+  # request AND the verification (issue #276). A non-zero exit means the pinned
+  # ID was rejected — discover the live one from review history and retry.
+  if ! reviewers=$(request_with_bot_id "$pr_node_id" "$bot_id"); then
     echo "warn: pinned bot ID $bot_id rejected; discovering from review history" >&2
     bot_id=$(discover_copilot_bot_id "$owner" "$repo") || {
       echo "error: failed to query review history" >&2; exit 1;
@@ -95,18 +113,13 @@ main() {
       echo "error: no Copilot bot ID found in recent reviews of ${owner}/${repo}" >&2
       exit 1
     fi
-    request_with_bot_id "$pr_node_id" "$bot_id" || {
+    reviewers=$(request_with_bot_id "$pr_node_id" "$bot_id") || {
       echo "error: request failed with discovered bot ID $bot_id" >&2; exit 1;
     }
   fi
 
-  local reviewers
-  reviewers=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}" \
-    --jq '[.requested_reviewers[]?.login // empty]') || {
-    echo "error: verification query failed" >&2; exit 1;
-  }
   if ! echo "$reviewers" | jq -e 'any(test("copilot"; "i"))' >/dev/null 2>&1; then
-    echo "error: Copilot not in requested_reviewers: $reviewers" >&2
+    echo "error: Copilot not in review requests after request: $reviewers" >&2
     exit 1
   fi
 

--- a/skills/release/tests/test_request_copilot_review.sh
+++ b/skills/release/tests/test_request_copilot_review.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-# Outcome-based tests for request-copilot-review.sh focused on the two
-# behaviours #42 + #43 fixed: fetch_pr_node_id refuses null PR IDs
-# upfront, and discover_copilot_bot_id matches Copilot's login with or
-# without the [bot] suffix (GraphQL Bot.login is inconsistent across
-# contexts).
+# Outcome-based tests for request-copilot-review.sh covering:
+#   - fetch_pr_node_id refuses null PR IDs upfront (#42);
+#   - discover_copilot_bot_id matches Copilot's login with or without the
+#     [bot] suffix — GraphQL Bot.login is inconsistent across contexts (#43);
+#   - main() verifies the request from the mutation's OWN returned review
+#     requests, not the REST `requested_reviewers` field that omits bot
+#     reviewers (#276) — a bot-only reviewer list must verify clean, the case
+#     the earlier suite never exercised, which let the REST-verify bug ship.
 #
 # Approach: source the script (its main() guard prevents auto-run when
 # sourced) and override `gh` with a shell function that returns
@@ -97,6 +100,47 @@ gh() {
   fi
 }
 
+# A content-aware graphql mock for driving main(): it distinguishes the
+# PR-id query, the requestReviews mutation, and the discover query by their
+# text, and applies the script's own --jq filter so the real filter logic is
+# exercised. Fixtures and behaviour come from env vars the caller sets:
+#   MUT_FIXTURE       requestReviews response JSON
+#   DISCOVER_FIXTURE  review-history response JSON (bot-id discovery)
+#   MUT_FAIL_ONCE + MUT_FAIL_FLAG  fail the FIRST mutation once (stale-ID path)
+# shellcheck disable=SC2329  # invoked indirectly via a per-test gh() override
+_main_gh_mock() {
+  [[ "$1" == api && "$2" == graphql ]] || { echo "mock gh: unsupported: $*" >&2; return 2; }
+  local query="" filter=""
+  shift 2
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f)   query="${2#query=}"; shift 2 ;;
+      --jq) filter="$2"; shift 2 ;;
+      *)    shift ;;
+    esac
+  done
+  local fixture
+  if [[ "$query" == *requestReviews* ]]; then
+    if [[ -n "${MUT_FAIL_ONCE:-}" && ! -f "${MUT_FAIL_FLAG:-/nonexistent}" ]]; then
+      : > "${MUT_FAIL_FLAG}"
+      echo "mock gh: requestReviews rejected the botId" >&2
+      return 1
+    fi
+    fixture="${MUT_FIXTURE:?MUT_FIXTURE unset}"
+  elif [[ "$query" == *"pullRequest(number"* ]]; then
+    fixture='{"data":{"repository":{"pullRequest":{"id":"PR_kwDOX"}}}}'
+  elif [[ "$query" == *"pullRequests(last"* ]]; then
+    fixture="${DISCOVER_FIXTURE:?DISCOVER_FIXTURE unset}"
+  else
+    echo "mock gh: unrecognized query: $query" >&2; return 2
+  fi
+  if [[ -n "$filter" ]]; then
+    echo "$fixture" | jq -r "$filter"
+  else
+    echo "$fixture"
+  fi
+}
+
 # --- test bodies ---
 
 t_fetch_pr_node_id_returns_empty_and_nonzero_on_null_pr() {
@@ -153,6 +197,55 @@ t_discover_returns_empty_when_no_copilot_review() {
   assert_eq "stdout" "" "$out"
 }
 
+# #276: a request that attaches only a bot reviewer must verify CLEAN. Under
+# the old REST verification this list came back `[]` and main() always exited
+# 1; verifying from the mutation response fixes it.
+t_main_verifies_bot_only_reviewers() {
+  local out rc
+  out=$(
+    gh() { _main_gh_mock "$@"; }
+    MUT_FIXTURE='{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]}}}}}' \
+      main owner repo 5 2>/dev/null
+  )
+  rc=$?
+  assert_eq "exit code" "0" "$rc" || return 1
+  echo "$out" | jq -e '.requested_reviewers | any(test("copilot"; "i"))' >/dev/null 2>&1 \
+    || { echo "    FAIL: output envelope missing copilot: $out" >&2; return 1; }
+}
+
+# A mutation whose returned reviewers do NOT include Copilot is a real failure.
+t_main_fails_when_copilot_absent() {
+  local err rc
+  err=$(
+    gh() { _main_gh_mock "$@"; }
+    MUT_FIXTURE='{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"__typename":"Bot","login":"some-other-bot"}}]}}}}}' \
+      main owner repo 5 2>&1 >/dev/null
+  )
+  rc=$?
+  assert_eq "exit code" "1" "$rc" || return 1
+  [[ "$err" == *"not in review requests"* ]] \
+    || { echo "    FAIL: stderr missing 'not in review requests': $err" >&2; return 1; }
+}
+
+# A rejected pinned bot ID falls back to discovery, then verifies from the
+# retried mutation's response.
+t_main_falls_back_on_rejected_pinned_id() {
+  local out rc flag
+  flag=$(mktemp -u)
+  out=$(
+    gh() { _main_gh_mock "$@"; }
+    MUT_FAIL_ONCE=1 MUT_FAIL_FLAG="$flag" \
+    DISCOVER_FIXTURE='{"data":{"repository":{"pullRequests":{"nodes":[{"reviews":{"nodes":[{"author":{"id":"BOT_discovered","login":"copilot-pull-request-reviewer"}}]}}]}}}}' \
+    MUT_FIXTURE='{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]}}}}}' \
+      main owner repo 5 2>/dev/null
+  )
+  rc=$?
+  rm -f "$flag"
+  assert_eq "exit code" "0" "$rc" || return 1
+  echo "$out" | jq -e '.bot_id == "BOT_discovered"' >/dev/null 2>&1 \
+    || { echo "    FAIL: expected the discovered bot id in the output: $out" >&2; return 1; }
+}
+
 # --- driver ---
 
 echo "== request-copilot-review.sh tests =="
@@ -162,6 +255,9 @@ run "fetch_pr_node_id returns ID for a real PR"                      t_fetch_pr_
 run "discover_copilot_bot_id matches Bot.login with [bot] suffix"    t_discover_matches_bot_suffix_login
 run "discover_copilot_bot_id matches Bot.login without suffix"       t_discover_matches_bare_login
 run "discover_copilot_bot_id returns empty when no Copilot review"   t_discover_returns_empty_when_no_copilot_review
+run "main verifies a bot-only reviewer list clean (#276)"           t_main_verifies_bot_only_reviewers
+run "main fails when Copilot is absent from the mutation response"   t_main_fails_when_copilot_absent
+run "main falls back to discovery on a rejected pinned bot ID"       t_main_falls_back_on_rejected_pinned_id
 
 echo "== summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed =="
 [[ "$FAIL_COUNT" -eq 0 ]]


### PR DESCRIPTION
## What

`request-copilot-review.sh` sends the review request over GraphQL (correct), then verifies it over REST (wrong).

## The bug

The script's own header says *"REST silently drops bot reviewers"* — then it verified against exactly that surface:

```bash
reviewers=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}" \
  --jq '[.requested_reviewers[]?.login // empty]')
```

`requested_reviewers` returns `[]` for a bot, so `any(test("copilot"))` never matched and the script exited **1 on a request that succeeded** — unconditionally, for the only reviewer type it exists to request. Observed on `jbaruch/tripit-api#36`, and hit in this repo requesting review on #273. Under `set -euo pipefail` the non-zero exit aborts the release flow after the request already landed — compounding #267, which just made the per-push re-request an explicit step.

## Fix

Verify from the **mutation's own response** — the authoritative surface that does report bot reviewers:

- `requestReviews` now selects `pullRequest.reviewRequests.nodes[].requestedReviewer.login`; `request_with_bot_id` echoes that list.
- `main()` captures it as both request and verification, keeping the case-insensitive `copilot` match and the `{pr_number, bot_id, requested_reviewers}` output shape. Drops one REST round-trip.

## Tests

Added `main()` coverage the earlier suite never had (which is why the bug shipped): a content-aware `gh` mock plus **bot-only-reviewer-verifies-clean** (#276's requested case), copilot-absent hard-fail, and stale-ID-fallback. 9/9 in this suite; full suite 25/25; pyright + shellcheck clean.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)