### PR TITLE
fix(actions): push the stamp commit when no bump will carry it

### DIFF
--- a/.github/actions/stamp-changelog/action.yml
+++ b/.github/actions/stamp-changelog/action.yml
@@ -1,8 +1,14 @@
 name: 'Stamp CHANGELOG with the published version'
 description: |
   Stamps the CHANGELOG's newest (un-headed) entries with the version the
-  publish step is about to assign, then commits the result with `[skip ci]`
-  (no push — the publish step's own commit carries it along).
+  publish step is about to assign, then commits the result with `[skip ci]`.
+
+  The commit is normally pushed by the publish step's own bump commit. On a
+  first publish (or when the manifest is already ahead of the registry) the
+  publish step assigns the manifest version verbatim and pushes nothing, so
+  this action pushes the stamp commit itself — otherwise the stamped heading
+  is stranded on the runner and the published artifact and `CHANGELOG.md` on
+  the branch disagree silently.
 
   Per `jbaruch/coding-policy: context-artifacts` "CHANGELOG Hygiene"
   (every merge publishes): PR authors add un-headed `### ` entry blocks at
@@ -46,8 +52,10 @@ inputs:
     default: ''
   commit:
     description: |
-      When 'true' (default), commit the stamped CHANGELOG with `[skip ci]`
-      and no push. Set 'false' to leave it staged for the caller to commit.
+      When 'true' (default), commit the stamped CHANGELOG with `[skip ci]`,
+      and push it when no downstream bump commit will carry it (first publish
+      / manifest ahead). Set 'false' to leave it staged for the caller to
+      commit.
     required: false
     default: 'true'
   commit-message:
@@ -89,6 +97,13 @@ runs:
         if [ -n "$LATEST" ]; then args+=(--latest "$LATEST"); fi
         if [ -n "$DATE" ]; then args+=(--date "$DATE"); fi
 
+        # The script writes 'true'/'false' here: must this step push the stamp
+        # commit itself because no downstream bump commit will carry it? The
+        # decision needs the computed publish version, which the script owns —
+        # recomputing it in bash would duplicate its registry logic.
+        decision_file="$(mktemp)"
+        args+=(--decision-file "$decision_file")
+
         python3 "$script" "${args[@]}"
 
         if [ "$DO_COMMIT" != "true" ]; then
@@ -109,3 +124,12 @@ runs:
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git add "$CHANGELOG"
         git diff --cached --quiet || git commit -m "$msg"
+
+        # Push only when the publish step will not carry the stamp commit for
+        # us. The `[skip ci]` on the commit stops it re-triggering the publish
+        # workflow (ci-safety Publish-Pipeline Loop-Prevention Carve-Out). A
+        # blocked/failed push must surface — no suppression (error-handling).
+        if [ "$(cat "$decision_file")" = "true" ]; then
+          echo "No downstream bump will carry the stamp — pushing it now."
+          git push origin "HEAD:${GITHUB_REF_NAME}"
+        fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Actions — stamp-changelog pushes its own commit on a first publish
+
+`stamp-changelog` committed the CHANGELOG heading with `[skip ci]` and no push, relying on `patch-version-publish`'s bump commit to carry it to `main`. That coupling breaks on a first publish (and any publish where the manifest is already ahead of the registry): `patch-version-publish` uses the manifest version verbatim, produces no bump commit, and pushes nothing — so the stamp commit was stranded on the runner, leaving the published version live while `CHANGELOG.md` on `main` still showed un-headed `### ` entries. Silent, and it fires exactly once per repo (observed on `jbaruch/tripit-api` 0.6.0). The action now pushes the stamp commit itself precisely when no downstream bump will carry it: `stamp-changelog.py` gained `needs_own_push()` (push iff a stamp was applied and the computed version equals the manifest version) and a `--decision-file`, and the action reads that to `git push` conditionally. The `[skip ci]` on the commit prevents a publish-workflow re-trigger (ci-safety Publish-Pipeline Loop-Prevention Carve-Out). Closes #270.
+
 ## 0.3.149 — 2026-08-09
 
 ### Release skill — request-copilot-review.sh verifies from the mutation, not REST

--- a/skills/release/stamp-changelog.py
+++ b/skills/release/stamp-changelog.py
@@ -20,10 +20,14 @@ to stamp), it is a no-op.
 Usage:
     stamp-changelog.py [--changelog CHANGELOG.md] [--manifest PATH]
                        [--latest X.Y.Z] [--date YYYY-MM-DD]
+                       [--decision-file PATH]
 
-    --latest  skip the registry query and use this as the latest published
-              version (for testing / manual runs). Omit in CI to query the
-              registry via `tessl plugin info`.
+    --latest         skip the registry query and use this as the latest
+                     published version (for testing / manual runs). Omit in CI
+                     to query the registry via `tessl plugin info`.
+    --decision-file  write `true` or `false` to PATH — whether the caller must
+                     push the stamp commit itself because no downstream version
+                     bump will carry it (first publish, or manifest ahead).
 """
 import argparse
 import json
@@ -57,6 +61,18 @@ def compute_version(local: str, latest: str | None) -> str:
     if local_num > latest_num:
         return local
     return f"{rp[0]}.{rp[1]}.{rp[2] + 1}"
+
+
+def needs_own_push(version: str, local: str, changed: bool) -> bool:
+    """True when this step must push the stamp commit itself.
+
+    The publish step pushes a commit only when it bumps the version away from
+    the manifest (computed != manifest). When they match — a first publish, or a
+    manifest already ahead of the registry — nothing downstream carries the
+    stamp, so the stamp commit is stranded on the runner unless this step pushes
+    it. No stamp applied (changed=False) means there is no commit to push.
+    """
+    return changed and version == local
 
 
 def stamp_changelog(text: str, version: str, date: str) -> tuple[str, bool]:
@@ -144,6 +160,9 @@ def main() -> None:
     ap.add_argument("--latest", default=None,
                     help="Latest published version (skip the registry query)")
     ap.add_argument("--date", default=None, help="Heading date (default: today, UTC)")
+    ap.add_argument("--decision-file", type=Path, default=None,
+                    help="Write 'true'/'false': must the caller push the stamp "
+                         "commit itself (no downstream bump will carry it)?")
     args = ap.parse_args()
 
     name, local = _read_manifest(args.manifest)
@@ -158,6 +177,10 @@ def main() -> None:
         print(f"Stamped {args.changelog} top entries as ## {version} — {date}")
     else:
         print(f"No un-headed entries to stamp in {args.changelog} (no-op)")
+
+    if args.decision_file is not None:
+        push = needs_own_push(version, local, changed)
+        args.decision_file.write_text("true" if push else "false")
 
 
 if __name__ == "__main__":

--- a/skills/release/tests/test_stamp_changelog.py
+++ b/skills/release/tests/test_stamp_changelog.py
@@ -54,6 +54,84 @@ class ComputeVersion(unittest.TestCase):
             stamp_changelog.compute_version("0.18.7", "vNext")
 
 
+class NeedsOwnPush(unittest.TestCase):
+    """The stamp commit must be pushed here only when no bump carries it."""
+
+    def test_first_publish_pushes(self):
+        # First publish: computed == manifest, publish step pushes nothing.
+        self.assertTrue(stamp_changelog.needs_own_push("0.1.0", "0.1.0", True))
+
+    def test_manifest_ahead_pushes(self):
+        # Manifest ahead of registry: published as-is, no bump commit.
+        self.assertTrue(stamp_changelog.needs_own_push("0.19.0", "0.19.0", True))
+
+    def test_normal_bump_does_not_push(self):
+        # Bump case: publish step's own commit carries the stamp.
+        self.assertFalse(stamp_changelog.needs_own_push("0.18.8", "0.18.7", True))
+
+    def test_noop_never_pushes(self):
+        # Nothing stamped — no commit exists to push.
+        self.assertFalse(stamp_changelog.needs_own_push("0.1.0", "0.1.0", False))
+
+
+class MainDecisionFile(unittest.TestCase):
+    """main() writes the push decision for the calling action to read."""
+
+    _BODY = "# Changelog\n\n### feat — x\n"
+
+    def _run(self, tmp, manifest_version, latest, body=None):
+        """Run main() with a temp changelog/manifest; return the decision text.
+
+        `latest=None` omits --latest and stubs the registry query to a 404
+        (first publish); a string passes --latest verbatim.
+        """
+        changelog = tmp / "CHANGELOG.md"
+        changelog.write_text(body if body is not None else self._BODY)
+        manifest = tmp / "plugin.json"
+        manifest.write_text('{"name": "ws/p", "version": "%s"}' % manifest_version)
+        decision = tmp / "decision"
+        argv = [
+            "stamp-changelog.py",
+            "--changelog", str(changelog),
+            "--manifest", str(manifest),
+            "--date", "2026-08-09",
+            "--decision-file", str(decision),
+        ]
+        if latest is not None:
+            argv += ["--latest", latest]
+        with mock.patch("sys.argv", argv):
+            if latest is None:
+                with mock.patch.object(stamp_changelog, "query_latest_version",
+                                       return_value=None):
+                    stamp_changelog.main()
+            else:
+                stamp_changelog.main()
+        return decision.read_text()
+
+    def test_first_publish_writes_true(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            # No registry version → computed == manifest → nothing carries it.
+            self.assertEqual(self._run(Path(d), "0.1.0", None), "true")
+
+    def test_manifest_ahead_writes_true(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(self._run(Path(d), "0.19.0", "0.18.7"), "true")
+
+    def test_normal_bump_writes_false(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(self._run(Path(d), "0.18.7", "0.18.7"), "false")
+
+    def test_noop_writes_false(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            # Top already headed → no stamp → no commit to push.
+            already = "# Changelog\n\n## 0.1.0 — 2026-08-09\n\n### feat — x\n"
+            self.assertEqual(self._run(Path(d), "0.1.0", None, body=already), "false")
+
+
 class QueryLatestVersion(unittest.TestCase):
     """query_latest_version degrades gracefully when the stamp step has no auth."""
 


### PR DESCRIPTION
Recreated from #274 (its PR number got stuck in the GitHub pull_request-dispatch outage). Same branch, same commit.

## What
`stamp-changelog` committed the CHANGELOG heading with `[skip ci]` and no push, relying on `patch-version-publish`'s bump commit to carry it. On a **first publish** (or manifest already ahead) that step assigns the manifest version verbatim, pushes nothing, and the stamp commit is stranded — published version live while `CHANGELOG.md` on `main` still shows un-headed entries. Silent; fires once per repo (seen on `jbaruch/tripit-api` 0.6.0).

## Fix
`stamp-changelog.py` gains `needs_own_push()` (push iff a stamp was applied and computed==manifest) + `--decision-file`; the action reads it and `git push`es the stamp commit only when no downstream bump will carry it. `[skip ci]` prevents a publish re-trigger. Tests cover first-publish / manifest-ahead / normal-bump / no-op. 25/25 suites, pyright + shellcheck clean.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)