### PR TITLE
test(release): add reasoned SC2317 suppressions to copilot-review test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Tests — reasoned SC2317 suppressions on the indirect gh() overrides (#280)
+
+The three `main()` tests added in #277 each define a local `gh()` override invoked indirectly through the sourced `main()`. A stricter ShellCheck than CI's 0.11.0 flags each as SC2317 ("command appears unreachable") because it cannot trace the call through the sourced function. Each override now carries an adjacent, reasoned `# shellcheck disable=SC2317` naming the indirect-through-`main` invocation — matching the existing `SC2329` precedent in the same file, with no blanket file-wide suppression (`rules/language-diagnostics.md` "Findings Are Non-Dismissible Without Cause"). Closes #280.
+
 ## 0.3.152 — 2026-08-13
 
 ### CI — run Python test suites; guard the release baseline capture (#183)

--- a/skills/release/tests/test_request_copilot_review.sh
+++ b/skills/release/tests/test_request_copilot_review.sh
@@ -203,6 +203,7 @@ t_discover_returns_empty_when_no_copilot_review() {
 t_main_verifies_bot_only_reviewers() {
   local out rc
   out=$(
+    # shellcheck disable=SC2317  # gh() runs indirectly through the sourced main(); shellcheck cannot trace the call
     gh() { _main_gh_mock "$@"; }
     MUT_FIXTURE='{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"__typename":"Bot","login":"copilot-pull-request-reviewer"}}]}}}}}' \
       main owner repo 5 2>/dev/null
@@ -217,6 +218,7 @@ t_main_verifies_bot_only_reviewers() {
 t_main_fails_when_copilot_absent() {
   local err rc
   err=$(
+    # shellcheck disable=SC2317  # gh() runs indirectly through the sourced main(); shellcheck cannot trace the call
     gh() { _main_gh_mock "$@"; }
     MUT_FIXTURE='{"data":{"requestReviews":{"pullRequest":{"reviewRequests":{"nodes":[{"requestedReviewer":{"__typename":"Bot","login":"some-other-bot"}}]}}}}}' \
       main owner repo 5 2>&1 >/dev/null
@@ -233,6 +235,7 @@ t_main_falls_back_on_rejected_pinned_id() {
   local out rc flag
   flag=$(mktemp -u)
   out=$(
+    # shellcheck disable=SC2317  # gh() runs indirectly through the sourced main(); shellcheck cannot trace the call
     gh() { _main_gh_mock "$@"; }
     MUT_FAIL_ONCE=1 MUT_FAIL_FLAG="$flag" \
     DISCOVER_FIXTURE='{"data":{"repository":{"pullRequests":{"nodes":[{"reviews":{"nodes":[{"author":{"id":"BOT_discovered","login":"copilot-pull-request-reviewer"}}]}}]}}}}' \


### PR DESCRIPTION
## What

The three `main()` tests added in #277 each define a local `gh()` override invoked indirectly through the sourced `main()`. A stricter ShellCheck than CI's 0.11.0 flags each as **SC2317** ("command appears unreachable") because it cannot trace the call through the sourced function.

Each override now carries an adjacent, reasoned `# shellcheck disable=SC2317` naming the indirect-through-`main` invocation — matching the existing `SC2329` precedent in the same file, with no blanket file-wide suppression, per `rules/language-diagnostics.md` **"Findings Are Non-Dismissible Without Cause."**

## Scope

Exactly the three locations the issue names (`t_main_verifies_bot_only_reviewers`, `t_main_fails_when_copilot_absent`, `t_main_falls_back_on_rejected_pinned_id`) — matching the issue author's stricter-shellcheck evidence, so no possibly-unused directive is introduced.

## Verification

- `shellcheck` (0.11.0, same as CI) clean
- `scripts/run-diagnostics.sh` clean (shellcheck + pyright)
- `bash skills/release/tests/test_request_copilot_review.sh` — 9 passed, 0 failed

Closes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)