### PR TITLE
fix(actions): stamp-changelog always self-pushes its commit

### DIFF
--- a/.github/actions/stamp-changelog/action.yml
+++ b/.github/actions/stamp-changelog/action.yml
@@ -1,14 +1,18 @@
 name: 'Stamp CHANGELOG with the published version'
 description: |
   Stamps the CHANGELOG's newest (un-headed) entries with the version the
-  publish step is about to assign, then commits the result with `[skip ci]`.
+  publish step is about to assign, then commits the result with `[skip ci]`
+  and pushes that commit itself.
 
-  The commit is normally pushed by the publish step's own bump commit. On a
-  first publish (or when the manifest is already ahead of the registry) the
-  publish step assigns the manifest version verbatim and pushes nothing, so
-  this action pushes the stamp commit itself — otherwise the stamped heading
-  is stranded on the runner and the published artifact and `CHANGELOG.md` on
-  the branch disagree silently.
+  It always self-pushes the stamp commit rather than delegating to a downstream
+  bump commit. Delegating stranded the stamp whenever the publish step exited
+  non-zero AFTER publishing — e.g. a post-publish credit check aborts
+  `patch-version-publish` before its bump commit/push runs, so the artifact
+  ships while `CHANGELOG.md` on the branch keeps its un-headed `### ` entries
+  (`jbaruch/coding-policy#284`). Self-pushing decouples the stamp from the
+  publish step's exit status. The `[skip ci]` on the commit stops the push
+  re-triggering the publish workflow (ci-safety Publish-Pipeline
+  Loop-Prevention Carve-Out).
 
   Per `jbaruch/coding-policy: context-artifacts` "CHANGELOG Hygiene"
   (every merge publishes): PR authors add un-headed `### ` entry blocks at
@@ -52,9 +56,8 @@ inputs:
     default: ''
   commit:
     description: |
-      When 'true' (default), commit the stamped CHANGELOG with `[skip ci]`,
-      and push it when no downstream bump commit will carry it (first publish
-      / manifest ahead). Set 'false' to leave it staged for the caller to
+      When 'true' (default), commit the stamped CHANGELOG with `[skip ci]`
+      and push that commit. Set 'false' to leave it staged for the caller to
       commit.
     required: false
     default: 'true'
@@ -97,39 +100,15 @@ runs:
         if [ -n "$LATEST" ]; then args+=(--latest "$LATEST"); fi
         if [ -n "$DATE" ]; then args+=(--date "$DATE"); fi
 
-        # The script writes 'true'/'false' here: must this step push the stamp
-        # commit itself because no downstream bump commit will carry it? The
-        # decision needs the computed publish version, which the script owns —
-        # recomputing it in bash would duplicate its registry logic.
-        decision_file="$(mktemp)"
-        args+=(--decision-file "$decision_file")
-
         python3 "$script" "${args[@]}"
 
-        if [ "$DO_COMMIT" != "true" ]; then
-          echo "commit=false — leaving the stamped CHANGELOG uncommitted."
-          exit 0
+        # The deterministic git side effects (stage / commit with a guaranteed
+        # `[skip ci]` / self-push) live in a script so they are testable against
+        # a temporary remote — see skills/release/tests/test_commit_stamp.sh.
+        # Same three-levels-up resolution as the python script above.
+        commit_script="$GITHUB_ACTION_PATH/../../../skills/release/commit-stamp.sh"
+        if [ ! -f "$commit_script" ]; then
+          echo "::error::commit-stamp.sh not found at $commit_script — the coding-policy action repo did not check out fully."
+          exit 1
         fi
-
-        # Loop-prevention is non-negotiable: the stamp commit MUST carry
-        # `[skip ci]` or it re-triggers the publish workflow. Enforce it even
-        # when a caller overrode `commit-message` without it.
-        msg="$COMMIT_MESSAGE"
-        case "$msg" in
-          *"[skip ci]"*) ;;
-          *) msg="$msg [skip ci]" ;;
-        esac
-
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add "$CHANGELOG"
-        git diff --cached --quiet || git commit -m "$msg"
-
-        # Push only when the publish step will not carry the stamp commit for
-        # us. The `[skip ci]` on the commit stops it re-triggering the publish
-        # workflow (ci-safety Publish-Pipeline Loop-Prevention Carve-Out). A
-        # blocked/failed push must surface — no suppression (error-handling).
-        if [ "$(cat "$decision_file")" = "true" ]; then
-          echo "No downstream bump will carry the stamp — pushing it now."
-          git push origin "HEAD:${GITHUB_REF_NAME}"
-        fi
+        bash "$commit_script" "$CHANGELOG" "$DO_COMMIT" "$COMMIT_MESSAGE" "$GITHUB_REF_NAME" "$GITHUB_REF_TYPE"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,8 +58,8 @@ jobs:
 
       # Dogfoods the reusable action consumers call as
       # `uses: jbaruch/coding-policy/.github/actions/stamp-changelog@<ref>`.
-      # Commit only, no push — patch-version-publish's own commit/push
-      # carries it along; [skip ci] guards the re-trigger.
+      # The action self-pushes its stamp commit ([skip ci] guards the
+      # re-trigger), decoupled from patch-version-publish's exit status (#284).
       - name: Stamp CHANGELOG with the version being published
         uses: ./.github/actions/stamp-changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### Actions — stamp-changelog always self-pushes, decoupling from the publish exit (#284, #281)
+
+`stamp-changelog` delegated its push to `patch-version-publish`'s downstream bump commit whenever a bump would carry it (the `needs_own_push()` / `--decision-file` mechanism from #270). That coupling stranded the stamp whenever the publish step exited non-zero AFTER the artifact was already published: a post-publish credit check aborts `patch-version-publish` under `set -e` before its `git add`/commit/push, so the registry advanced and moderation passed while the manifest bump AND the CHANGELOG stamp never reached `main` (observed on `jbaruch/jbaruch-travel-policy` — four consecutive publishes, registry at 0.7.55 while the branch manifest sat at 0.7.51 under four un-headed `### ` blocks). The manifest lag self-heals on the next green publish (`patch-version-publish` bumps from the registry), but the CHANGELOG attribution does not — accumulated un-headed blocks collapse under a single later heading. The action now always pushes its own stamp commit, so per-version headings land run-by-run even mid-outage, independent of the publish step's exit status; `[skip ci]` still prevents a publish re-trigger (ci-safety Publish-Pipeline Loop-Prevention Carve-Out). The `needs_own_push()` function, the `--decision-file` plumbing, and the `mktemp` temp file it required are removed as dead code — which also resolves the never-cleaned-up tempfile flagged in #281. Also folds in #281: `commit=false` now `git add`s the stamped CHANGELOG so it is genuinely staged for the caller, matching the input's documented contract. The action's git stage/commit/self-push side effects are extracted into `skills/release/commit-stamp.sh`, covered by `test_commit_stamp.sh` against a temporary remote (self-push lands one `[skip ci]` commit, no-op when the top is already headed, staged-only under `commit=false`, `[skip ci]` enforcement, and refusing a non-branch ref so a tag-triggered run cannot create a branch named after the tag). Closes #284, #281.
+
+### Fix — drop a stray merge-conflict marker from the CHANGELOG
+
+A leftover diff3 base marker (`||||||| parent of …`) and a duplicated `## 0.3.133` heading slipped into `CHANGELOG.md` during #183's conflict resolution and shipped in the published 0.3.152–0.3.154 "what's new". Removed (boy-scout, in the same file this PR already edits).
+
 ## 0.3.154 — 2026-08-13
 
 ### CI safety — the watch gate is not always a PR check
@@ -116,8 +124,6 @@ Measurement contradicted the theory. Mining 33,768 assistant responses across 46
 
 So the hook fought a decay that does not occur on the models in use, at the cost of a per-turn `UserPromptSubmit` fork in every consumer. `skill-authoring.md`'s `hooks`/`nativeHooks` manifest-field documentation is kept — it is accurate reference for the manifest schema regardless of this plugin using it.
 
-## 0.3.133 — 2026-08-05
-||||||| parent of 6fc6441 (fix(ci): run Python test suites; guard registry baseline capture)
 ## 0.3.133 — 2026-08-05
 
 ### Hooks — resurface-response-clarity (closes #254)

--- a/skills/release/commit-stamp.sh
+++ b/skills/release/commit-stamp.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Stage the stamped CHANGELOG and, when committing, self-push it to the branch.
+# Extracted from the .github/actions/stamp-changelog run block so the git
+# stage/commit/push branches are testable against a temporary remote (issue
+# #284). The version stamping itself lives in stamp-changelog.py; this owns only
+# the deterministic git side effects (rules/script-delegation.md).
+#
+# Usage: commit-stamp.sh <changelog> <do-commit> <commit-message> <ref-name> <ref-type>
+#   do-commit   "true" commits + pushes; anything else stages only
+#   ref-name    GITHUB_REF_NAME — the branch to push HEAD to
+#   ref-type    GITHUB_REF_TYPE — must be "branch" to push (a tag ref would
+#               push HEAD:<tag> and create a branch named after the tag)
+# Out:  one JSON object on stdout describing the outcome —
+#         {"outcome":"pushed","ref":"<name>"} | {"outcome":"noop"} |
+#         {"outcome":"staged","changed":true|false}
+#       progress and diagnostics go to stderr.
+# Exit: 0 on pushed / noop / staged; non-zero on a non-branch ref, a bad
+#       argument count, or a git failure.
+set -euo pipefail
+
+main() {
+  if [ "$#" -ne 5 ]; then
+    echo "usage: $0 <changelog> <do-commit> <commit-message> <ref-name> <ref-type>" >&2
+    return 2
+  fi
+  local changelog="$1" do_commit="$2" commit_message="$3" ref_name="$4" ref_type="$5"
+
+  if [ "$do_commit" != "true" ]; then
+    # Stage only the changelog path so commit=false leaves the caller a staged
+    # change to commit (the input's contract), never sweeping in an unrelated
+    # dirty index. `changed` reports whether the stamp actually altered it.
+    git add -- "$changelog"
+    local changed=false
+    if ! git diff --cached --quiet -- "$changelog"; then changed=true; fi
+    echo "commit=false — staged $changelog for the caller (changed=$changed)." >&2
+    python3 -c 'import json,sys; print(json.dumps({"outcome":"staged","changed":sys.argv[1]=="true"}))' "$changed"
+    return 0
+  fi
+
+  # Refuse a non-branch ref before mutating anything: pushing HEAD:<ref-name> on
+  # a tag ref would create a branch named after the tag. The stamp only makes
+  # sense in a branch-triggered publish.
+  if [ "$ref_type" != "branch" ]; then
+    echo "error: stamp-changelog must push on a branch ref, got ref-type='${ref_type}' (ref '${ref_name}'). Run it in a branch-triggered workflow." >&2
+    return 1
+  fi
+
+  # Loop-prevention is non-negotiable: the stamp commit MUST carry the CI-skip
+  # marker or it re-triggers the publish workflow. Enforce it even when a caller
+  # overrode `commit-message` without it.
+  local msg="$commit_message"
+  case "$msg" in
+    *"[skip ci]"*) ;;
+    *) msg="$msg [skip ci]" ;;
+  esac
+
+  # No working-tree or staged change to the changelog => nothing to stamp.
+  # Capture to a variable so a `git status` failure aborts under set -e rather
+  # than reading as an empty (no-op) result inside the test.
+  local pending
+  pending="$(git status --porcelain -- "$changelog")"
+  if [ -z "$pending" ]; then
+    echo "Nothing to stamp (top section already headed) — no commit, no push." >&2
+    python3 -c 'import json; print(json.dumps({"outcome":"noop"}))'
+    return 0
+  fi
+
+  git config user.name "github-actions[bot]"
+  git config user.email "github-actions[bot]@users.noreply.github.com"
+  # Commit ONLY the changelog path (pathspec) so an unrelated staged file is
+  # never swept into the stamp commit and pushed.
+  git commit -m "$msg" -- "$changelog" >&2
+
+  # Always push the stamp commit ourselves rather than delegating to a
+  # downstream bump commit. Delegating stranded the stamp whenever the publish
+  # step exited non-zero AFTER publishing (issue #284) — the artifact shipped
+  # but the bump/stamp push never ran. A blocked/failed push must surface — no
+  # suppression (rules/error-handling.md).
+  git push origin "HEAD:${ref_name}" >&2
+  python3 -c 'import json,sys; print(json.dumps({"outcome":"pushed","ref":sys.argv[1]}))' "$ref_name"
+}
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && main "$@"

--- a/skills/release/stamp-changelog.py
+++ b/skills/release/stamp-changelog.py
@@ -20,14 +20,10 @@ to stamp), it is a no-op.
 Usage:
     stamp-changelog.py [--changelog CHANGELOG.md] [--manifest PATH]
                        [--latest X.Y.Z] [--date YYYY-MM-DD]
-                       [--decision-file PATH]
 
     --latest         skip the registry query and use this as the latest
                      published version (for testing / manual runs). Omit in CI
                      to query the registry via `tessl plugin info`.
-    --decision-file  write `true` or `false` to PATH — whether the caller must
-                     push the stamp commit itself because no downstream version
-                     bump will carry it (first publish, or manifest ahead).
 """
 import argparse
 import json
@@ -61,18 +57,6 @@ def compute_version(local: str, latest: str | None) -> str:
     if local_num > latest_num:
         return local
     return f"{rp[0]}.{rp[1]}.{rp[2] + 1}"
-
-
-def needs_own_push(version: str, local: str, changed: bool) -> bool:
-    """True when this step must push the stamp commit itself.
-
-    The publish step pushes a commit only when it bumps the version away from
-    the manifest (computed != manifest). When they match — a first publish, or a
-    manifest already ahead of the registry — nothing downstream carries the
-    stamp, so the stamp commit is stranded on the runner unless this step pushes
-    it. No stamp applied (changed=False) means there is no commit to push.
-    """
-    return changed and version == local
 
 
 def stamp_changelog(text: str, version: str, date: str) -> tuple[str, bool]:
@@ -160,9 +144,6 @@ def main() -> None:
     ap.add_argument("--latest", default=None,
                     help="Latest published version (skip the registry query)")
     ap.add_argument("--date", default=None, help="Heading date (default: today, UTC)")
-    ap.add_argument("--decision-file", type=Path, default=None,
-                    help="Write 'true'/'false': must the caller push the stamp "
-                         "commit itself (no downstream bump will carry it)?")
     args = ap.parse_args()
 
     name, local = _read_manifest(args.manifest)
@@ -177,10 +158,6 @@ def main() -> None:
         print(f"Stamped {args.changelog} top entries as ## {version} — {date}")
     else:
         print(f"No un-headed entries to stamp in {args.changelog} (no-op)")
-
-    if args.decision_file is not None:
-        push = needs_own_push(version, local, changed)
-        args.decision_file.write_text("true" if push else "false")
 
 
 if __name__ == "__main__":

--- a/skills/release/tests/test_commit_stamp.sh
+++ b/skills/release/tests/test_commit_stamp.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Outcome-based tests for commit-stamp.sh — the git stage/commit/self-push
+# behavior extracted from the stamp-changelog action (issue #284). Each test
+# runs the real script against an isolated temporary bare remote + work clone
+# and asserts on the emitted JSON outcome plus the remote's resulting state,
+# covering:
+#   - self-push: a stamped CHANGELOG lands on the branch as one [skip ci] commit
+#     and the script prints {"outcome":"pushed"};
+#   - no-op: an already-headed CHANGELOG prints {"outcome":"noop"}, no push;
+#   - commit=false: the CHANGELOG is staged, {"outcome":"staged"}, never pushed;
+#   - [skip ci] is appended when the caller's message lacks it;
+#   - a non-branch (tag) ref is refused — no commit, no tag-named branch;
+#   - an unrelated staged file is NOT swept into the stamp commit.
+#
+# Run: bash skills/release/tests/test_commit_stamp.sh
+# Exit 0 on all-pass; non-zero with a per-test diagnostic on failure.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/commit-stamp.sh"
+[[ -f "$SCRIPT" ]] || { echo "fatal: commit-stamp.sh not found at $SCRIPT" >&2; exit 2; }
+
+TESTTMP="$(mktemp -d)" || { echo "fatal: mktemp -d failed" >&2; exit 2; }
+# Named handler ending `return 0`, not a bare `trap 'rm -rf ...'`: the EXIT
+# trap's final command status can become the process's exit status, so a failed
+# cleanup would turn an all-green run non-zero and flake CI
+# (rules/error-handling.md Shell Error Handling).
+cleanup_tmp() {
+  if [[ -n "${TESTTMP:-}" ]]; then
+    if ! rm -rf "$TESTTMP"; then
+      echo "warning: could not remove temp dir ${TESTTMP} — remove it by hand" >&2
+    fi
+  fi
+  return 0
+}
+trap cleanup_tmp EXIT
+
+FAIL_COUNT=0
+PASS_COUNT=0
+
+run() {
+  local name="$1"; shift
+  if "$@"; then
+    PASS_COUNT=$((PASS_COUNT + 1))
+    echo "  pass: $name"
+  else
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    echo "  FAIL: $name" >&2
+  fi
+}
+
+# Create an isolated bare remote + work clone on branch `main` seeded with one
+# headed CHANGELOG commit. Echoes the sandbox root; work is $root/work, remote
+# is $root/remote.git.
+_sandbox() {
+  local root
+  root="$(mktemp -d "$TESTTMP/sbx.XXXXXX")" || { echo "fatal: sandbox mktemp -d failed" >&2; return 1; }
+  git init --bare -q -b main "$root/remote.git"
+  # init + remote add rather than clone: cloning the empty bare repo warns on
+  # stderr, and suppressing that warning would suppress real failures too.
+  git init -q -b main "$root/work"
+  git -C "$root/work" remote add origin "$root/remote.git"
+  git -C "$root/work" config user.name "seed"
+  git -C "$root/work" config user.email "seed@example.com"
+  printf '# Changelog\n\n## 0.1.0 — 2026-01-01\n\n### seed\n' > "$root/work/CHANGELOG.md"
+  git -C "$root/work" add CHANGELOG.md
+  git -C "$root/work" commit -q -m "seed"
+  git -C "$root/work" push -q -u origin main
+  echo "$root"
+}
+
+_remote_sha()   { git -C "$1/remote.git" rev-parse main; }
+_remote_msg()   { git -C "$1/remote.git" log -1 --format=%B main; }
+_remote_count() { git -C "$1/remote.git" rev-list --count main; }
+# Files changed by the remote's tip commit.
+_remote_tip_files() { git -C "$1/remote.git" show --name-only --format= main; }
+
+# Run the script in $work. The caller captures stdout (the JSON outcome) via
+# command substitution; stderr (progress prose, and any failure diagnostic)
+# flows through rather than being suppressed (rules/error-handling.md).
+_run_json() {
+  local root="$1"; shift
+  ( cd "$root/work" && bash "$SCRIPT" "$@" )
+}
+
+# --- test bodies ---
+
+t_self_push_lands_one_skip_ci_commit() {
+  local root; root="$(_sandbox)"
+  printf '\n### new entry\n' >> "$root/work/CHANGELOG.md"
+  local out; out="$(_run_json "$root" CHANGELOG.md true "Stamp the version [skip ci]" main branch)" \
+    || { echo "    FAIL: script exited non-zero" >&2; return 1; }
+  echo "$out" | jq -e '.outcome == "pushed"' >/dev/null \
+    || { echo "    FAIL: expected outcome=pushed, got: $out" >&2; return 1; }
+  [[ "$(_remote_count "$root")" == "2" ]] || { echo "    FAIL: expected 2 remote commits" >&2; return 1; }
+  [[ "$(_remote_msg "$root")" == *"[skip ci]"* ]] || { echo "    FAIL: remote commit missing [skip ci]" >&2; return 1; }
+  git -C "$root/remote.git" show main:CHANGELOG.md | grep -q "new entry" \
+    || { echo "    FAIL: remote CHANGELOG missing the stamped entry" >&2; return 1; }
+}
+
+t_noop_when_nothing_staged() {
+  local root; root="$(_sandbox)"
+  local before; before="$(_remote_sha "$root")"
+  local out; out="$(_run_json "$root" CHANGELOG.md true "Stamp [skip ci]" main branch)" \
+    || { echo "    FAIL: script exited non-zero on no-op" >&2; return 1; }
+  echo "$out" | jq -e '.outcome == "noop"' >/dev/null \
+    || { echo "    FAIL: expected outcome=noop, got: $out" >&2; return 1; }
+  [[ "$before" == "$(_remote_sha "$root")" ]] || { echo "    FAIL: remote advanced on a no-op" >&2; return 1; }
+}
+
+t_commit_false_stages_without_pushing() {
+  local root; root="$(_sandbox)"
+  printf '\n### staged entry\n' >> "$root/work/CHANGELOG.md"
+  local before; before="$(_remote_sha "$root")"
+  local out; out="$(_run_json "$root" CHANGELOG.md false "Stamp [skip ci]" main branch)" \
+    || { echo "    FAIL: script exited non-zero" >&2; return 1; }
+  echo "$out" | jq -e '.outcome == "staged" and .changed == true' >/dev/null \
+    || { echo "    FAIL: expected outcome=staged changed=true, got: $out" >&2; return 1; }
+  git -C "$root/work" diff --cached --name-only | grep -qx "CHANGELOG.md" \
+    || { echo "    FAIL: CHANGELOG not staged under commit=false" >&2; return 1; }
+  [[ "$(git -C "$root/work" rev-list --count HEAD)" == "1" ]] \
+    || { echo "    FAIL: a local commit was created under commit=false" >&2; return 1; }
+  [[ "$before" == "$(_remote_sha "$root")" ]] || { echo "    FAIL: remote advanced under commit=false" >&2; return 1; }
+}
+
+t_skip_ci_appended_when_absent() {
+  local root; root="$(_sandbox)"
+  printf '\n### entry\n' >> "$root/work/CHANGELOG.md"
+  _run_json "$root" CHANGELOG.md true "Stamp without a marker" main branch >/dev/null \
+    || { echo "    FAIL: script exited non-zero" >&2; return 1; }
+  [[ "$(_remote_msg "$root")" == *"[skip ci]"* ]] \
+    || { echo "    FAIL: [skip ci] not appended to a message lacking it" >&2; return 1; }
+}
+
+t_refuses_non_branch_ref() {
+  local root; root="$(_sandbox)"
+  printf '\n### entry\n' >> "$root/work/CHANGELOG.md"
+  local before; before="$(_remote_sha "$root")"
+  local err rc
+  err="$( ( cd "$root/work" && bash "$SCRIPT" CHANGELOG.md true "Stamp [skip ci]" v1.2.3 tag ) 2>&1 >/dev/null )"; rc=$?
+  [[ "$rc" -ne 0 ]] || { echo "    FAIL: expected non-zero exit on a tag ref" >&2; return 1; }
+  [[ "$err" == *"branch"* ]] || { echo "    FAIL: error message missing 'branch': $err" >&2; return 1; }
+  [[ "$before" == "$(_remote_sha "$root")" ]] || { echo "    FAIL: remote main advanced on a tag ref" >&2; return 1; }
+  if git -C "$root/remote.git" rev-parse --verify --quiet v1.2.3 >/dev/null; then
+    echo "    FAIL: a tag-named branch was created on the remote" >&2; return 1
+  fi
+  [[ "$(git -C "$root/work" rev-list --count HEAD)" == "1" ]] \
+    || { echo "    FAIL: a local commit was created before the ref-type refusal" >&2; return 1; }
+}
+
+t_does_not_sweep_unrelated_staged_file() {
+  local root; root="$(_sandbox)"
+  printf '\n### entry\n' >> "$root/work/CHANGELOG.md"
+  # A caller left an unrelated file staged before the stamp step ran.
+  printf 'unrelated\n' > "$root/work/unrelated.txt"
+  git -C "$root/work" add unrelated.txt
+  _run_json "$root" CHANGELOG.md true "Stamp [skip ci]" main branch >/dev/null \
+    || { echo "    FAIL: script exited non-zero" >&2; return 1; }
+  local files; files="$(_remote_tip_files "$root")"
+  echo "$files" | grep -qx "CHANGELOG.md" || { echo "    FAIL: stamp commit missing CHANGELOG.md" >&2; return 1; }
+  if echo "$files" | grep -qx "unrelated.txt"; then
+    echo "    FAIL: unrelated staged file was swept into the pushed commit" >&2; return 1
+  fi
+}
+
+# --- driver ---
+
+main() {
+  echo "== commit-stamp.sh tests =="
+  run "self-push lands one [skip ci] commit on the branch"   t_self_push_lands_one_skip_ci_commit
+  run "no commit or push when nothing is staged"             t_noop_when_nothing_staged
+  run "commit=false stages the CHANGELOG without pushing"    t_commit_false_stages_without_pushing
+  run "[skip ci] appended when the message lacks it"         t_skip_ci_appended_when_absent
+  run "a non-branch (tag) ref is refused"                    t_refuses_non_branch_ref
+  run "an unrelated staged file is not swept into the commit" t_does_not_sweep_unrelated_staged_file
+  echo "== summary: ${PASS_COUNT} passed, ${FAIL_COUNT} failed =="
+  [[ "$FAIL_COUNT" -eq 0 ]]
+}
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && main "$@"

--- a/skills/release/tests/test_stamp_changelog.py
+++ b/skills/release/tests/test_stamp_changelog.py
@@ -54,33 +54,13 @@ class ComputeVersion(unittest.TestCase):
             stamp_changelog.compute_version("0.18.7", "vNext")
 
 
-class NeedsOwnPush(unittest.TestCase):
-    """The stamp commit must be pushed here only when no bump carries it."""
-
-    def test_first_publish_pushes(self):
-        # First publish: computed == manifest, publish step pushes nothing.
-        self.assertTrue(stamp_changelog.needs_own_push("0.1.0", "0.1.0", True))
-
-    def test_manifest_ahead_pushes(self):
-        # Manifest ahead of registry: published as-is, no bump commit.
-        self.assertTrue(stamp_changelog.needs_own_push("0.19.0", "0.19.0", True))
-
-    def test_normal_bump_does_not_push(self):
-        # Bump case: publish step's own commit carries the stamp.
-        self.assertFalse(stamp_changelog.needs_own_push("0.18.8", "0.18.7", True))
-
-    def test_noop_never_pushes(self):
-        # Nothing stamped — no commit exists to push.
-        self.assertFalse(stamp_changelog.needs_own_push("0.1.0", "0.1.0", False))
-
-
-class MainDecisionFile(unittest.TestCase):
-    """main() writes the push decision for the calling action to read."""
+class Main(unittest.TestCase):
+    """main() stamps the changelog with the version the publish step will assign."""
 
     _BODY = "# Changelog\n\n### feat — x\n"
 
     def _run(self, tmp, manifest_version, latest, body=None):
-        """Run main() with a temp changelog/manifest; return the decision text.
+        """Run main() against a temp changelog/manifest; return the changelog text.
 
         `latest=None` omits --latest and stubs the registry query to a 404
         (first publish); a string passes --latest verbatim.
@@ -89,13 +69,11 @@ class MainDecisionFile(unittest.TestCase):
         changelog.write_text(body if body is not None else self._BODY)
         manifest = tmp / "plugin.json"
         manifest.write_text('{"name": "ws/p", "version": "%s"}' % manifest_version)
-        decision = tmp / "decision"
         argv = [
             "stamp-changelog.py",
             "--changelog", str(changelog),
             "--manifest", str(manifest),
             "--date", "2026-08-09",
-            "--decision-file", str(decision),
         ]
         if latest is not None:
             argv += ["--latest", latest]
@@ -106,30 +84,31 @@ class MainDecisionFile(unittest.TestCase):
                     stamp_changelog.main()
             else:
                 stamp_changelog.main()
-        return decision.read_text()
+        return changelog.read_text()
 
-    def test_first_publish_writes_true(self):
+    def test_first_publish_stamps_manifest_version(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d:
-            # No registry version → computed == manifest → nothing carries it.
-            self.assertEqual(self._run(Path(d), "0.1.0", None), "true")
+            # No registry version → stamp the manifest version verbatim.
+            self.assertIn("## 0.1.0 — 2026-08-09", self._run(Path(d), "0.1.0", None))
 
-    def test_manifest_ahead_writes_true(self):
+    def test_manifest_ahead_stamps_manifest_version(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d:
-            self.assertEqual(self._run(Path(d), "0.19.0", "0.18.7"), "true")
+            self.assertIn("## 0.19.0 — 2026-08-09", self._run(Path(d), "0.19.0", "0.18.7"))
 
-    def test_normal_bump_writes_false(self):
+    def test_normal_bump_stamps_bumped_version(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d:
-            self.assertEqual(self._run(Path(d), "0.18.7", "0.18.7"), "false")
+            # Manifest matches registry → stamp the bumped patch.
+            self.assertIn("## 0.18.8 — 2026-08-09", self._run(Path(d), "0.18.7", "0.18.7"))
 
-    def test_noop_writes_false(self):
+    def test_noop_leaves_headed_changelog_unchanged(self):
         import tempfile
         with tempfile.TemporaryDirectory() as d:
-            # Top already headed → no stamp → no commit to push.
+            # Top already headed → no stamp, changelog untouched.
             already = "# Changelog\n\n## 0.1.0 — 2026-08-09\n\n### feat — x\n"
-            self.assertEqual(self._run(Path(d), "0.1.0", None, body=already), "false")
+            self.assertEqual(self._run(Path(d), "0.1.0", None, body=already), already)
 
 
 class QueryLatestVersion(unittest.TestCase):


### PR DESCRIPTION
## Problem (#284)

`stamp-changelog` delegated its push to `patch-version-publish`'s downstream bump commit whenever a bump would carry it (the `needs_own_push()` / `--decision-file` mechanism from #270). That coupling strands the stamp whenever the publish step exits non-zero **after** the artifact is already published:

```
✔ Published …@0.7.55
✔ Uploaded 11 eval scenarios
##[error]Out of credits.        ← set -e aborts patch-version-publish here
# git add / commit / push never run
```

Registry advanced, moderation `pass`, artifact installable — but the manifest bump **and** the CHANGELOG stamp never reached `main`. Observed on `jbaruch/jbaruch-travel-policy`: four consecutive publishes, registry at 0.7.55 while the branch manifest sat at 0.7.51 under four un-headed `### ` blocks.

The manifest lag self-heals on the next green publish (`patch-version-publish` bumps from the registry). The **CHANGELOG attribution does not** — accumulated un-headed blocks collapse under a single later heading. That's the real data loss.

## Fix (option 1 — decouple stamp push)

The action **always** pushes its own stamp commit, so per-version headings land run-by-run even mid-outage, independent of the publish step's exit status. `[skip ci]` still prevents a publish re-trigger (ci-safety Publish-Pipeline Loop-Prevention Carve-Out).

Always-pushing makes the `needs_own_push()` / `--decision-file` decision dead — it's removed entirely from `action.yml`, `stamp-changelog.py`, and its tests. The `mktemp` temp file goes with it, which also **resolves #281's tempfile-cleanup point by deletion** (better than a `trap`).

## Folds in #281

- `commit=false` now `git add`s the stamped CHANGELOG so it is genuinely **staged** for the caller, matching the input's documented contract (was: modified but unstaged).
- The `mktemp` decision-file is gone (see above).

## Tests

`test_stamp_changelog.py` drops the `NeedsOwnPush` and decision-file coverage and gains a `main()` integration class asserting the stamped heading directly (first-publish, normal-bump, manifest-ahead, and no-op cases) — net orchestration coverage preserved.

## Verification

- `python3 skills/release/tests/test_stamp_changelog.py` — 18 passed
- `bash scripts/run-tests.sh` — 27/27 suites pass
- `scripts/run-diagnostics.sh` — shellcheck + pyright clean
- `action.yml` valid YAML
- No leftover `needs_own_push` / `--decision-file` references

Closes #284, #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)