### PR TITLE
fix(ci-safety): credits never block publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### CI safety — credits never block publishing; a red publish run is the agent's to diagnose
+
+Agents repeatedly blame a red publish run on "tessl out of credits," reading it as proof the publish was blocked. The tessl publish step never consumes credits and never blocks on org credit state — the artifact lands regardless. Credits can still fail a review or eval step and turn the run red (the `context-artifacts` Credit-Outage Review Carve-Out governs the review step), but a red run — credit-caused or not — is never proof that publishing was blocked: whether the artifact published is answered by the registry advance plus moderation `pass`, independent of the run's color. Prompted by a live case: an agent asserted "your org is out of credits, every publish run went red" while the artifacts had actually landed (registry advanced, moderation `pass`) and the review step correctly skipped under the carve-out — the red gate came from a later eval step hard-failing, not from credits blocking the publish. New `ci-safety.md` section "Credits Never Block Publishing" makes the diagnosis the agent's to own.
+
 ## 0.3.155 — 2026-08-13
 
 ### Actions — stamp-changelog always self-pushes, decoupling from the publish exit (#284, #281)

--- a/rules/ci-safety.md
+++ b/rules/ci-safety.md
@@ -104,6 +104,18 @@ alwaysApply: true
 - If any conjunct fails, the publish is not confirmed — query the real moderation state, never invent one to hedge a failed publish
 - Naively re-running a failed publish can create an extra release when the workflow includes a version-bump step (e.g., `tesslio/patch-version-publish`) and the run got past it. Safer recovery: a follow-up commit fires a fresh publish on merge
 
+## Credits Never Block Publishing
+
+- The tessl publish step never consumes credits
+- The publish step never blocks on org credit state
+- The artifact lands regardless of the credit balance
+- Credits can still fail a review or eval step and turn the run red (see `rules/context-artifacts.md` Credit-Outage Review Carve-Out)
+- A red run (credit-caused or not) is never proof that publishing was blocked
+- Whether the artifact published is answered by the registry advance plus moderation `pass`, independent of the run's color
+- A red run whose artifact landed means a step other than the publish failed, not a blocked publish
+- Never blame a red publish run on credits without confirming the artifact landing and naming the failing step from the logs
+- A publish that did not land is the agent's own diagnosis, never a deflection to `tessl credits`
+
 ## Checks Not Starting
 
 - When pushed checks sit in `queued` and no `github-actions` run is created, check the PR's merge state before assuming an Actions outage


### PR DESCRIPTION
## Why

The most recurring agent misdiagnosis in releases: a red publish run gets blamed on **"tessl out of credits."** It's adjacency read as causation. A live example — an agent asserted *"your org is out of credits, every publish run went red,"* while the artifacts had **actually landed** (registry advanced, moderation `pass`), the review step correctly **skipped** under the credit-outage carve-out, and the red gate came from a **later eval step hard-failing** — not from credits blocking the publish.

## The principle

- **The tessl publish step never consumes credits and never blocks on org credit state** — the artifact lands regardless.
- Credits gate only the **review and eval** steps (the `context-artifacts` Credit-Outage Review Carve-Out governs the review step).
- So a red publish run is **never proof** credits blocked publishing — it has a specific failing step to name from the logs.
- Whether the artifact published is answered by the **registry advance + moderation `pass`**, independent of the run's color.
- A publish that did not land is the **agent's diagnosis to own**, never a deflection to "tessl credits."

## What

New `ci-safety.md` section **"Credits Never Block Publishing"** (9 atomic bullets), plus a CHANGELOG entry carrying the incident (rule body stays incident-free per `context-writing-style`).

## Consistency

- References, does not contradict, the Credit-Outage Review Carve-Out: credits *can* 403 the **review** step (that carve-out's domain); the **publish** step is never credit-gated.
- Complements the release contract's artifact-landing conjunction (registry + moderation) as the authority on publish success.
- Drift audit: the only credit-outage handling in the repo is the review-step skill-review action — correctly attributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)