### PR TITLE
feat(hooks): session-start status report with auto-update

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,3 +26,4 @@ This repo IS `jbaruch/coding-policy`. The rule files below are the source-of-tru
 @../rules/review-severity.md
 @../rules/response-clarity.md
 @../rules/ship-on-green.md
+@../rules/hook-action-reporting.md

--- a/.tessl-plugin/plugin.json
+++ b/.tessl-plugin/plugin.json
@@ -33,7 +33,8 @@
     "rules/reviewer-feedback-reading.md",
     "rules/review-severity.md",
     "rules/response-clarity.md",
-    "rules/ship-on-green.md"
+    "rules/ship-on-green.md",
+    "rules/hook-action-reporting.md"
   ],
   "hooks": {
     "SessionStart": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Hooks — session-start status report (version + update, git sync, policy freshness)
+
+The SessionStart hooks now surface an always-visible status block at session start, closing the recurring "did `tessl update` run? what coding-policy version am I on?" blind spot. `check-tessl-latest.sh` runs `tessl update --yes` each session and reports every `jbaruch/*` dependency's version transition — read from `.tessl/plugins/<ws>/<plugin>/tessl-package.json` before and after, leading with `jbaruch/coding-policy` (e.g. `jbaruch/coding-policy 0.3.147 → 0.3.156 (updated)` or `0.3.156 (latest)`). A missing CLI or a non-zero `tessl update` degrades to `update failed: <reason>` and never blocks the session (the update runs with stdin redirected from `/dev/null` so it can never hang on a prompt). `check-git-sync.sh` and `check-policy-freshness.sh` now emit a positive status on their success paths too. Each status payload begins with the `Session-start status — ` marker (its continuation lines — an update list, a pin `NOTE:` — are relayed with it); the pin check and freshness throttle are retained.
+
+A SessionStart hook's output reaches the model's context, not the user's transcript, so new rule `rules/hook-action-reporting.md` makes the agent relay the marker lines to the user as one concise block at session start (the sanctioned exception to `response-clarity` Lead With the Action) and act on any action they name. Wired into `plugin.json`, the README rules table, and the maintainer `.claude/CLAUDE.md`.
+
 ## 0.3.156 — 2026-08-13
 
 ### CI safety — credits never block publishing; a red publish run is the agent's to diagnose

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ tessl install jbaruch/coding-policy
 | Scope | [external-repo-contributions](rules/external-repo-contributions.md) | Default deny on issues, PRs, comments, reactions, and discussions in repos the operator does not own; explicit permission required per repo and action type |
 | Communication | [response-clarity](rules/response-clarity.md) | Shape responses action-first: lead with the command, number steps, show progress, plain errors, one concrete next step, no preamble or closers (exceptions for explanations, destructive actions, debug, ambiguity) |
 | Discipline | [ship-on-green](rules/ship-on-green.md) | Green gate is the approval — merge, never ask; asking in a costume (flag/confirm/"say go") is deciding not to ship; stakes raise care not permission; three objective exits only — Red / No undo / Murky |
+| Automation | [hook-action-reporting](rules/hook-action-reporting.md) | Relay any `Session-start status —` hook payloads to the user once at session start, then act on any action they name (a SessionStart hook's output reaches the model, not the transcript) |
 
 ### Skills
 

--- a/hooks/check-git-sync.sh
+++ b/hooks/check-git-sync.sh
@@ -12,20 +12,25 @@
 #   - It DOES something (fetches + compares refs), it does not re-state a rule.
 #   - SessionStart fires once per session, not per turn — no per-turn tax.
 #   - Throttled: the fetch runs at most once per SYNC_THROTTLE_HOURS (default 1h)
-#     per repo, so rapid session churn doesn't hammer the network. The behind
-#     comparison still runs on throttled sessions against the last-fetched
-#     origin ref, so staleness surfaces even when the fetch is skipped.
+#     per repo, so rapid session churn doesn't hammer the network. Without a
+#     fresh fetch this session the remote-tracking ref may be stale, so a
+#     throttled (or failed) fetch reports "sync not verified" rather than a
+#     definitive conclusion (rules/sync-before-work.md).
 #   - The fetch is time-bounded (timeout, if available) so a hung network can't
 #     stall session start.
 #   - Informative only. Never blocks (always exits 0), never exits 2.
 #
 # Contract:
 #   stdin : consensus SessionStart JSON — not read (the script needs none of it).
-#   stdout: on a fire, one JSON object {"additionalContext": "<notice>"}; else nothing.
+#   stdout: once the repo's default branch is resolved, one JSON object
+#           {"additionalContext": "<status>"} whose text begins with the
+#           "Session-start status — " marker (rules/hook-action-reporting.md) —
+#           reporting in-sync, ahead, behind, or diverged after a fresh fetch, or
+#           "sync not verified" when the fetch was throttled or failed.
 #   exit  : always 0. Every best-effort failure emits an actionable stderr warning
 #           and continues/no-ops (rules/error-handling.md Shell Error Handling).
-#           Non-repo, no origin, no local default branch, and up-to-date are all
-#           silent no-ops — the common, uninteresting cases stay quiet.
+#           Non-repo, no origin, and no local default branch are silent no-ops —
+#           the sync check does not apply, so those sessions stay quiet.
 #   state : $SYNC_STATE_DIR/sync-<repo-key> (default ${TMPDIR:-/tmp}/coding-policy-sync),
 #           a per-repo throttle stamp (keyed by toplevel path). Schema documented
 #           in hooks/state-schema.md: one line "<schema_version> <checked_at>".
@@ -63,7 +68,7 @@ main() {
   local THROTTLE_HOURS="${SYNC_THROTTLE_HOURS:-1}"
   local FETCH_TIMEOUT="${SYNC_FETCH_TIMEOUT:-10}"
   local STATE_DIR="${SYNC_STATE_DIR:-${TMPDIR:-/tmp}/coding-policy-sync}"
-  local rc db inside cand now top repo_key stamp sv ts should_fetch preserve_future counts ahead behind notice
+  local rc db inside cand now top repo_key stamp sv ts should_fetch preserve_future fetch_failed counts ahead behind notice
   local -a fetch
 
   # git is required to produce a signal; its absence is an expected environment
@@ -168,6 +173,7 @@ main() {
   # With no throttle key the fallback fetches unconditionally (never throttles).
   should_fetch=1
   preserve_future=0
+  fetch_failed=0
   if [[ -n "$repo_key" && -r "$stamp" ]]; then
     sv=""; ts=""
     read -r sv ts < "$stamp" || { sv=""; ts=""; }
@@ -204,8 +210,19 @@ main() {
     fi
     # A fetch failure (offline, auth, timeout) is a no-op, not a broken session —
     # warn and fall through to compare against the last-known origin ref.
-    "${fetch[@]}" 2>/dev/null ||
-      warn "git fetch origin failed or timed out — check connectivity; comparing against the last-fetched origin/${db}"
+    "${fetch[@]}" 2>/dev/null || {
+      warn "git fetch origin failed or timed out — check connectivity; cannot verify sync against a current origin/${db}"
+      fetch_failed=1
+    }
+  fi
+
+  # A definitive sync conclusion requires a fresh fetch this session. A throttled
+  # or failed fetch leaves the remote-tracking ref possibly stale, and stale
+  # state poisons conclusions (rules/sync-before-work.md). Report unverified
+  # rather than a false "in sync".
+  if (( should_fetch == 0 || fetch_failed )); then
+    emit_notice "Session-start status — git: \`${db}\` sync not verified against a current \`origin/${db}\` this session — run \`git fetch origin\`, then \`git status\` (rules/sync-before-work.md)."
+    return 0
   fi
 
   # Compare the local default branch against its remote-tracking ref. --left-right
@@ -223,12 +240,24 @@ main() {
     warn "unexpected ahead/behind counts '${counts}' for ${db} — run \`git status\` to inspect; skipping sync check"
     return 0
   fi
-  (( behind > 0 )) || return 0
 
+  # Success path: nothing to pull from origin. Distinguish truly in-sync from
+  # ahead-only — a branch ahead of origin (unpushed commits) is not "in sync".
+  if (( behind == 0 )); then
+    if (( ahead == 0 )); then
+      emit_notice "Session-start status — git: local \`${db}\` is in sync with \`origin/${db}\`"
+    else
+      emit_notice "Session-start status — git: local \`${db}\` is ${ahead} commit(s) ahead of \`origin/${db}\` (unpushed), none behind"
+    fi
+    return 0
+  fi
+
+  # Problem path: keep the existing actionable text, prefixed with the marker so
+  # the agent surfaces it too (rules/hook-action-reporting.md).
   if (( ahead > 0 )); then
-    notice="Local \`${db}\` has diverged from \`origin/${db}\` (${behind} behind, ${ahead} ahead) — reconcile before working (rules/sync-before-work.md): \`git fetch origin\`, then rebase \`${db}\` onto \`origin/${db}\` (a fast-forward won't apply)."
+    notice="Session-start status — Local \`${db}\` has diverged from \`origin/${db}\` (${behind} behind, ${ahead} ahead) — reconcile before working (rules/sync-before-work.md): \`git fetch origin\`, then rebase \`${db}\` onto \`origin/${db}\` (a fast-forward won't apply)."
   else
-    notice="Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."
+    notice="Session-start status — Local \`${db}\` is ${behind} commit(s) behind \`origin/${db}\` — sync before working (rules/sync-before-work.md): \`git fetch origin\`, then fast-forward \`${db}\` to \`origin/${db}\`."
   fi
 
   emit_notice "$notice"

--- a/hooks/check-policy-freshness.sh
+++ b/hooks/check-policy-freshness.sh
@@ -16,8 +16,11 @@
 #
 # Contract:
 #   stdin : consensus SessionStart JSON — not read (the script needs none of it).
-#   stdout: on a fire, one JSON object {"additionalContext": "<notice>"}; else nothing.
-#           The notice may span multiple lines (a header plus one line per plugin).
+#   stdout: when the registry check runs, one JSON object
+#           {"additionalContext": "<status>"} whose text begins with the
+#           "Session-start status — " marker (rules/hook-action-reporting.md) —
+#           "policy: fresh" (success) or the available updates (a header plus one
+#           line per plugin). Throttled and tool-missing sessions stay silent.
 #   exit  : always 0. Every best-effort failure emits an actionable stderr warning
 #           and continues/no-ops (rules/error-handling.md Shell Error Handling).
 #   state : $FRESHNESS_STATE_DIR/last-check (default ${TMPDIR:-/tmp}/coding-policy-freshness),
@@ -103,14 +106,21 @@ main() {
     (.outdated // [])
     | map("- \(.current.tile.workspaceName)/\(.current.tile.tileName) \(.current.tile.version) -> \(.update.version)")
     | if length == 0 then empty else
-        "Plugin updates available (run `tessl update`):\n" + (. | join("\n"))
+        "Session-start status — policy: plugin updates available (run `tessl update`):\n" + (. | join("\n"))
       end
   ' 2>/dev/null)"; then
     warn "could not parse \`tessl outdated --json\` output — run it manually to inspect; skipping freshness check"
     return 0
   fi
 
-  [[ -n "$notice" ]] || return 0
+  # Success path: nothing outdated. Emit a positive marker status so the agent
+  # surfaces it (rules/hook-action-reporting.md). The problem path's notice
+  # already carries the marker (set in the jq program above).
+  if [[ -z "$notice" ]]; then
+    jq -n --arg c "Session-start status — policy: fresh" '{additionalContext: $c}' ||
+      warn "could not emit the freshness status as JSON — skipping freshness check"
+    return 0
+  fi
 
   jq -n --arg c "$notice" '{additionalContext: $c}' ||
     warn "could not emit the update notice as JSON — skipping freshness check"

--- a/hooks/check-tessl-latest.sh
+++ b/hooks/check-tessl-latest.sh
@@ -1,63 +1,172 @@
 #!/usr/bin/env bash
-# Warn at session start when a tessl.json jbaruch/* dependency is not "latest".
+# Report jbaruch/* dependency versions at session start, after running an update.
 #
-# A SessionStart hook: it is the deterministic enforcement for the
-# Runtime-Managed Manifest Carve-Out (rules/dependency-management.md). tessl.json
+# A SessionStart hook. It is the deterministic enforcement for the
+# Runtime-Managed Manifest Carve-Out (rules/dependency-management.md): tessl.json
 # is a runtime-managed manifest — tessl rewrites the resolved state into the
 # gitignored .tessl/ — so jbaruch/*-owned deps use the floating "latest"
-# specifier. This hook reads tessl.json each session and surfaces any jbaruch/*
-# dep pinned to something other than "latest", so a disallowed specifier is
-# caught without a per-consumer deploy-time check. Third-party pins
-# (tessl-labs/*, tessl/npm-*) are out of scope — they pin normally.
+# specifier. Each session this hook runs `tessl update --yes` (best-effort) and
+# reports every jbaruch/* dependency's version transition, so a stale fleet repo
+# surfaces the moment a session opens and a disallowed pin is flagged without a
+# per-consumer deploy-time check. Third-party pins (tessl-labs/*, tessl/npm-*)
+# are out of scope — they pin normally.
 #
-# Design choices, shared with hooks/check-git-sync.sh:
-#   - It DOES something (reads the manifest), it does not re-state a rule.
+# The status text begins with the "Session-start status — " marker so the agent
+# surfaces it to the user (rules/hook-action-reporting.md).
+#
+# Design choices, shared with the other SessionStart hooks:
+#   - It DOES something (updates + reads resolved state), it does not re-state a rule.
 #   - SessionStart fires once per session, not per turn — no per-turn tax.
 #   - Informative only. Never blocks (always exits 0), never exits 2.
-#   - No state; the manifest is read live each session.
+#   - No throttle state: running `tessl update` is the point, so it runs every session.
 #
 # Contract:
 #   stdin : consensus SessionStart JSON — not read.
-#   stdout: on a fire, one JSON object {"additionalContext": "<notice>"}; else nothing.
-#   exit  : always 0. Best-effort failures warn to stderr and no-op
-#           (rules/error-handling.md Shell Error Handling).
-#   env   : TESSL_LATEST_MANIFEST (test-only; path to the manifest, default tessl.json).
+#   stdout: on a consumer repo, one JSON object {"additionalContext": "<status>"}
+#           whose text begins with "Session-start status — versions: ". A
+#           non-consumer (no manifest, or no jbaruch/* deps) emits nothing.
+#   exit  : always 0. Best-effort failures warn to stderr and still emit the
+#           status (rules/error-handling.md Shell Error Handling).
+#   env   : TESSL_LATEST_MANIFEST (manifest path, default tessl.json),
+#           TESSL_STATE_DIR (resolved-state dir, default .tessl).
 set -euo pipefail
 
 warn() { printf 'check-tessl-latest: %s\n' "$1" >&2; }
 
+# Print a jbaruch/* dependency's installed version from its resolved-state
+# tessl-package.json, or nothing when it cannot be determined. An absent file is
+# an expected non-result (the dep is not yet resolved into .tessl/ — reported as
+# install-pending). An existing but unreadable or unparseable file is a tool
+# failure: warn, never swallow it as an absent-file non-result
+# (rules/error-handling.md — distinguish a non-result from a tool failure).
+installed_version() { # <state-dir> <dep-name>
+  local pkg="$1/plugins/$2/tessl-package.json" v
+  [[ -e "$pkg" ]] || return 0
+  if [[ ! -r "$pkg" ]]; then
+    warn "resolved-state file ${pkg} is unreadable — check permissions on the .tessl/ tree"
+    return 0
+  fi
+  if ! v="$(jq -r '.version // empty' "$pkg" 2>/dev/null)"; then
+    warn "could not parse ${pkg} — check it is valid JSON"
+    return 0
+  fi
+  printf '%s' "$v"
+}
+
 main() {
   local manifest="${TESSL_LATEST_MANIFEST:-tessl.json}"
+  local state_dir="${TESSL_STATE_DIR:-.tessl}"
 
-  # No tessl.json => not a tessl consumer; nothing to check. Silent no-op.
+  # No tessl.json => not a tessl consumer; nothing to report. Silent no-op.
   [[ -f "$manifest" ]] || return 0
 
-  # This hook IS the carve-out's enforcement, so an unavailable checker must be
-  # surfaced (not a silent no-op) — emit the gap via additionalContext without
-  # jq (a literal, no interpolation, so no escaping is needed).
+  # jq builds the JSON and reads the resolved state. Its absence is an expected
+  # environment condition — surface the gap as a marker status without jq (a
+  # literal, no interpolation, so no escaping is needed).
   if ! command -v jq >/dev/null 2>&1; then
-    warn "jq not found — cannot verify tessl.json specifiers"
-    printf '%s\n' '{"additionalContext":"check-tessl-latest could not verify tessl.json — jq is not installed. Install jq so the Runtime-Managed Manifest Carve-Out enforcement (jbaruch/* deps must be \"latest\") can run."}'
+    warn "jq not found — cannot read tessl.json or the resolved state"
+    printf '%s\n' '{"additionalContext":"Session-start status — versions: unavailable — jq is not installed, cannot read tessl.json or the resolved state. Install jq (and the Tessl CLI) so the Runtime-Managed Manifest Carve-Out enforcement (jbaruch/* deps must be \"latest\") can run."}'
     return 0
   fi
 
-  # Collect jbaruch/* deps whose version is not "latest". A parse failure is
-  # surfaced, not swallowed as "all latest".
-  local pinned
-  if ! pinned="$(jq -r '
-      [.dependencies // {} | to_entries[]
-       | select((.key | startswith("jbaruch/")) and .value.version != "latest")
-       | "\(.key)@\(.value.version)"] | join(", ")' "$manifest" 2>/dev/null)"; then
-    warn "could not parse ${manifest} — check it is valid JSON; skipping the tessl-latest check"
+  # Collect jbaruch/* deps as "<name>\t<specifier>" lines, sorted by name for a
+  # deterministic status (jbaruch/coding-policy is pinned first below). A parse
+  # failure is surfaced, not swallowed as "no deps".
+  local deps_raw
+  if ! deps_raw="$(jq -r '
+      (.dependencies // {} | to_entries | sort_by(.key)[])
+      | select(.key | startswith("jbaruch/"))
+      | "\(.key)\t\(.value.version // "")"' "$manifest" 2>/dev/null)"; then
+    warn "could not parse ${manifest} — check it is valid JSON; skipping the versions status"
     return 0
   fi
 
-  [[ -n "$pinned" ]] || return 0
+  local -a names=() specs=()
+  local name spec
+  while IFS=$'\t' read -r name spec; do
+    [[ -n "$name" ]] || continue
+    names+=("$name"); specs+=("$spec")
+  done <<< "$deps_raw"
 
-  local notice="tessl.json pins jbaruch/* dependencies that should float to \`latest\` (Runtime-Managed Manifest Carve-Out, rules/dependency-management.md): ${pinned}. Set them to \`\"version\": \"latest\"\` — the resolved state lives in the gitignored \`.tessl/\`, so a pin only re-introduces the auto-update churn."
+  # No jbaruch/* deps => nothing first-party to report. Silent no-op.
+  (( ${#names[@]} > 0 )) || return 0
 
-  jq -n --arg c "$notice" '{additionalContext: $c}' \
-    || warn "could not emit the tessl-latest notice as JSON — skipping"
+  # Installed versions BEFORE the update.
+  local -a before=() after=()
+  local i
+  for (( i = 0; i < ${#names[@]}; i++ )); do
+    before[i]="$(installed_version "$state_dir" "${names[i]}")"
+  done
+
+  # Run `tessl update --yes` best-effort. A missing CLI or a non-zero exit never
+  # aborts the hook — it degrades the status to "update failed".
+  local update_failed=0 update_reason="" out=""
+  if ! command -v tessl >/dev/null 2>&1; then
+    update_failed=1
+    update_reason="tessl not installed — install the Tessl CLI to enable auto-update"
+  elif ! out="$(tessl update --yes </dev/null 2>&1)"; then
+    update_failed=1
+    update_reason="${out%%$'\n'*}"
+    update_reason="${update_reason:0:200}"
+    [[ -n "$update_reason" ]] || update_reason="tessl update exited non-zero"
+  fi
+
+  # Installed versions AFTER the update.
+  for (( i = 0; i < ${#names[@]}; i++ )); do
+    after[i]="$(installed_version "$state_dir" "${names[i]}")"
+  done
+
+  # Report order: jbaruch/coding-policy first, then the rest in manifest order.
+  local -a order=()
+  for (( i = 0; i < ${#names[@]}; i++ )); do
+    if [[ "${names[i]}" == "jbaruch/coding-policy" ]]; then order+=("$i"); fi
+  done
+  for (( i = 0; i < ${#names[@]}; i++ )); do
+    if [[ "${names[i]}" != "jbaruch/coding-policy" ]]; then order+=("$i"); fi
+  done
+
+  # One segment per dep; collect any pins for the trailing NOTE.
+  local -a segments=() pinned=()
+  local idx b a seg
+  for idx in "${order[@]}"; do
+    b="${before[idx]}"; a="${after[idx]}"
+    if [[ -z "$a" ]]; then
+      seg="${names[idx]} (install pending)"
+    elif [[ "$b" == "$a" ]]; then
+      # A failed update never verified freshness — do not claim "latest".
+      if (( update_failed )); then
+        seg="${names[idx]} ${a} (installed)"
+      else
+        seg="${names[idx]} ${a} (latest)"
+      fi
+    elif [[ -z "$b" ]]; then
+      seg="${names[idx]} unknown → ${a} (updated)"
+    else
+      seg="${names[idx]} ${b} → ${a} (updated)"
+    fi
+    segments+=("$seg")
+    if [[ "${specs[idx]}" != "latest" ]]; then pinned+=("${names[idx]}@${specs[idx]}"); fi
+  done
+
+  # Assemble the status line, marker first.
+  local status="Session-start status — versions: "
+  local first=1
+  for seg in "${segments[@]}"; do
+    if (( first )); then status+="$seg"; first=0; else status+=", ${seg}"; fi
+  done
+
+  if (( update_failed )); then status+="; update failed: ${update_reason}"; fi
+
+  if (( ${#pinned[@]} > 0 )); then
+    local pins="" firstp=1 p
+    for p in "${pinned[@]}"; do
+      if (( firstp )); then pins+="$p"; firstp=0; else pins+=", ${p}"; fi
+    done
+    status+=$'\n'"NOTE: tessl.json pins jbaruch/* dependencies that should float to \`latest\` (Runtime-Managed Manifest Carve-Out, rules/dependency-management.md): ${pins}. Set them to \`\"version\": \"latest\"\` — the resolved state lives in the gitignored \`.tessl/\`, so a pin only re-introduces the auto-update churn."
+  fi
+
+  jq -n --arg c "$status" '{additionalContext: $c}' \
+    || warn "could not emit the versions status as JSON — skipping"
   return 0
 }
 

--- a/hooks/tests/test_check_git_sync.sh
+++ b/hooks/tests/test_check_git_sync.sh
@@ -12,17 +12,19 @@
 # (rules/error-handling.md aggregate-reporting carve-out).
 #
 # Covers:
-#   1. Behind        -> emits additionalContext naming the branch + "behind".
-#   2. Up to date    -> silent (empty stdout), exit 0.
+#   1. Behind        -> emits marker additionalContext naming the branch + "behind".
+#   2. Up to date    -> emits a marker "in sync" status, exit 0.
 #   3. Throttle      -> with a fixed injected clock: a call inside the window
-#                       skips the fetch (stays silent though origin moved); a
-#                       call past the window fetches and fires.
+#                       skips the fetch and reports "not verified" (never a
+#                       definitive "in sync"/"behind" against the stale ref); a
+#                       call past the window fetches and fires "behind".
 #   4. Not a repo    -> silent no-op, exit 0.
 #   5. No origin     -> silent no-op, exit 0.
-#   6. Fetch failure -> silent no-op, exit 0 (offline/broken remote tolerated).
+#   6. Fetch failure -> marker "not verified" (never a false "in sync" against a
+#                       stale ref), exit 0 (offline/broken remote tolerated).
 #   7. Bad clock     -> silent no-op, exit 0 (never aborts SessionStart).
-#   8. Diverged      -> notice names divergence and recommends rebase, not a
-#                       fast-forward (local both ahead and behind origin).
+#   8. Diverged      -> marker notice names divergence and recommends rebase, not
+#                       a fast-forward (local both ahead and behind origin).
 #   9. Future stamp  -> a schema_version > 1 record is not throttled on and is
 #                       preserved (not downgraded to version 1).
 #
@@ -91,29 +93,42 @@ main() {
   clone_from "$BARE" "$TMP/r1"
   commit_push "$SEED" "c2"
   run "$TMP/r1" "$TMP/s1"
-  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind") and test("main")' >/dev/null 2>&1; then
-    pass; else fail "behind: expected notice, got RC=$RC OUT=$OUT"; fi
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("behind") and test("main")' >/dev/null 2>&1; then
+    pass; else fail "behind: expected marker notice, got RC=$RC OUT=$OUT"; fi
 
-  # 2. up to date -> silent.
+  # 2. up to date -> marker "in sync" status.
   mk_origin o2
   clone_from "$BARE" "$TMP/r2"
   run "$TMP/r2" "$TMP/s2"
-  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "up-to-date: expected silence, got RC=$RC OUT=$OUT"; fi
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("in sync")' >/dev/null 2>&1; then
+    pass; else fail "up-to-date: expected in-sync status, got RC=$RC OUT=$OUT"; fi
 
-  # 3. throttle. Clone up to date. Call at t stamps and (nothing new) stays
-  #    silent. Move origin ahead WITHOUT the hook fetching: a call +60s is
-  #    throttled, so it skips the fetch and stays silent (proves no fetch). A
-  #    call past the 1h window fetches the new commit and fires.
+  # 2b. ahead only -> "ahead ... unpushed", never "in sync" (ahead>0, behind==0).
+  #     Clone up to date, add a local commit without pushing; origin unchanged.
+  mk_origin o2b
+  clone_from "$BARE" "$TMP/r2b"
+  g -C "$TMP/r2b" commit -q --allow-empty -m "local ahead"  || die "git commit in r2b failed"
+  run "$TMP/r2b" "$TMP/s2b"
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("ahead") and (test("in sync") | not)' >/dev/null 2>&1; then
+    pass; else fail "ahead-only: expected \"ahead\" (not \"in sync\"), got RC=$RC OUT=$OUT"; fi
+
+  # 3. throttle. Clone up to date. First call fetches, stamps, and reports a
+  #    definitive "in sync". Move origin ahead WITHOUT the hook fetching: a call
+  #    +60s is throttled, so it does not fetch and reports "not verified" (never
+  #    a definitive "in sync"/"behind" against a stale ref). A call past the 1h
+  #    window fetches the new commit and fires "behind".
   mk_origin o3
   clone_from "$BARE" "$TMP/r3"
-  run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000000               # fetch, stamp, up to date -> silent
+  run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000000               # fetch, stamp, up to date -> in sync
   # This establishes the throttle stamp the next two assertions depend on, so a
   # failure here must abort, not merely tally (aggregate-reporting carve-out:
   # later checks may not depend on an earlier one merely having incremented FAIL).
-  [[ $RC -eq 0 && -z "$OUT" ]] || die "throttle setup: first call should be silent, got RC=$RC OUT=$OUT"
+  { [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("in sync")' >/dev/null 2>&1; } \
+    || die "throttle setup: first call should report in sync, got RC=$RC OUT=$OUT"
   commit_push "$SEED" "c3"                                # origin moves; r3's tracking ref still old
-  run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000060               # +60s: throttled -> no fetch -> silent
-  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "throttle active: inside window should skip fetch and stay silent, got OUT=$OUT"; fi
+  run "$TMP/r3" "$TMP/s3" SYNC_NOW=2000060               # +60s: throttled -> no fetch -> not verified
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("not verified") and (test("in sync") | not) and (test("behind") | not)' >/dev/null 2>&1; then
+    pass; else fail "throttle active: inside window should report 'not verified' (not 'in sync'/'behind'), got OUT=$OUT"; fi
   run "$TMP/r3" "$TMP/s3" SYNC_NOW=2003601               # +>1h: fetch -> behind -> fires
   if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("behind")' >/dev/null 2>&1; then
     pass; else fail "throttle expired: past window should fetch and fire, got OUT=$OUT"; fi
@@ -131,14 +146,16 @@ main() {
   run "$TMP/noorigin" "$TMP/s5"
   if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "no origin: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
 
-  # 6. fetch failure -> silent no-op (broken remote tolerated, no crash). Clone,
-  #    then delete the bare origin so the fetch fails; local == last-known
-  #    origin, so the comparison yields 0 and the hook exits 0 without crashing.
+  # 6. fetch failure -> "not verified" (broken remote tolerated, no crash, and
+  #    never a false "in sync" against a stale ref — sync-before-work). Clone,
+  #    then delete the bare origin so the fetch fails; the hook reports
+  #    not-verified and exits 0 without crashing.
   mk_origin o6
   clone_from "$BARE" "$TMP/r6"
   rm -rf "$BARE" || die "could not remove $BARE"
   run "$TMP/r6" "$TMP/s6"
-  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "fetch failure: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("not verified") and (test("in sync") | not)' >/dev/null 2>&1; then
+    pass; else fail "fetch failure: expected 'not verified' (not 'in sync') exit 0, got RC=$RC OUT=$OUT"; fi
 
   # 7. malformed clock -> no-op, exit 0.
   mk_origin o7
@@ -156,8 +173,8 @@ main() {
   g -C "$TMP/r8" commit -q -m local       || die "git commit in r8 failed"   # ahead by 1
   commit_push "$SEED" "c2"                                                    # origin moves -> behind by 1
   run "$TMP/r8" "$TMP/s8"
-  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("diverged") and test("rebase")' >/dev/null 2>&1; then
-    pass; else fail "diverged: expected divergence notice, got RC=$RC OUT=$OUT"; fi
+  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("diverged") and test("rebase")' >/dev/null 2>&1; then
+    pass; else fail "diverged: expected marker divergence notice, got RC=$RC OUT=$OUT"; fi
 
   # 9. future-version throttle stamp -> not throttled on, and preserved (never
   #    downgraded). Pre-seed a "2 <recent>" record at the stamp path the hook

--- a/hooks/tests/test_check_policy_freshness.sh
+++ b/hooks/tests/test_check_policy_freshness.sh
@@ -5,10 +5,11 @@
 # PATH (real jq/bash/date stay resolvable) and drive it via STUB_JSON / STUB_EXIT.
 #
 # Covers:
-#   1. Outdated present  -> emits additionalContext naming the plugin + new version.
-#   2. Nothing outdated  -> silent (empty stdout), exit 0.
+#   1. Outdated present  -> emits marker additionalContext naming the plugin + new version.
+#   2. Nothing outdated  -> emits a marker "policy: fresh" status, exit 0.
 #   3. Throttle          -> with an injected fixed clock (FRESHNESS_NOW): a call
-#                           inside the window is silent, a call past it fires again.
+#                           inside the window is silent (throttle skips the check
+#                           before any emit), a call past it fires again.
 #   4. tessl missing     -> silent no-op, exit 0 (no crash).
 #   5. tessl errors      -> silent no-op, exit 0 (network/registry failure tolerated).
 #
@@ -48,16 +49,17 @@ run() {
   RC=$?
 }
 
-# 1. outdated present -> notice
+# 1. outdated present -> marker notice
 d="$TMP/c1"
 run "$d" STUB_JSON="$OUTDATED"
-if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("coding-policy") and test("0.3.139")' >/dev/null 2>&1; then
-  pass; else fail "outdated present: expected notice, got RC=$RC OUT=$OUT"; fi
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("coding-policy") and test("0.3.139")' >/dev/null 2>&1; then
+  pass; else fail "outdated present: expected marker notice, got RC=$RC OUT=$OUT"; fi
 
-# 2. nothing outdated -> silent
+# 2. nothing outdated -> marker "policy: fresh" status
 d="$TMP/c2"
 run "$d" STUB_JSON="$EMPTY"
-if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "empty outdated: expected silence, got RC=$RC OUT=$OUT"; fi
+if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("Session-start status") and test("fresh")' >/dev/null 2>&1; then
+  pass; else fail "empty outdated: expected fresh status, got RC=$RC OUT=$OUT"; fi
 
 # 3. throttle -> deterministic via an injected clock (FRESHNESS_NOW), not the
 #    real wall clock. First call stamps t; a call 1h later is throttled; a call

--- a/hooks/tests/test_check_tessl_latest.sh
+++ b/hooks/tests/test_check_tessl_latest.sh
@@ -1,59 +1,174 @@
 #!/usr/bin/env bash
-# Outcome-based tests for check-tessl-latest.sh. Drives the hook against fixture
-# manifests via TESSL_LATEST_MANIFEST — no git repo needed, deterministic.
+# Outcome-based tests for check-tessl-latest.sh.
+#
+# The hook runs `tessl update --yes` and reads each jbaruch/* dep's installed
+# version from the resolved state before and after, so tests put a FAKE `tessl`
+# on PATH and drive it via env: STUB_BUMP_FILE/STUB_BUMP_TO rewrite a fixture
+# tessl-package.json to simulate an update, STUB_UPDATE_EXIT makes the update
+# fail. Manifest and resolved state are fixture-driven via TESSL_LATEST_MANIFEST
+# and TESSL_STATE_DIR — no real tessl, no network, deterministic.
 #
 # Covers:
-#   1. jbaruch/* pinned      -> warns, naming the pinned dep.
-#   2. all jbaruch/* latest  -> silent.
-#   3. only third-party pins  -> silent (jbaruch/* deps are latest).
-#   4. no manifest            -> silent no-op.
-#   5. malformed JSON         -> silent no-op, exit 0.
+#   1. updated         -> "X → Y (updated)" segment, marker present, exit 0.
+#   2. already latest  -> "Y (latest)" segment, marker present, exit 0.
+#   3. update failed    -> status still emits with "update failed: <reason>", exit 0.
+#   4. tessl missing   -> status emits with "update failed" (unavailable), exit 0.
+#   5. install pending  -> no resolved-state file -> "(install pending)", exit 0.
+#   6. pinned dep      -> "NOTE:" pin warning present, marker present, exit 0.
+#   7. no manifest     -> silent no-op, exit 0.
+#   8. third-party only -> silent (no jbaruch/* deps), exit 0.
+#   9. malformed JSON   -> silent no-op, exit 0 (never aborts SessionStart).
+#  10. unreadable state -> warns to stderr (existing-but-unreadable is a tool
+#                          failure, not an absent-file non-result), exit 0.
+#
+# The harness drops `set -e` to aggregate results, so every fixture-setup command
+# is checked explicitly and aborts with a fatal diagnostic on failure
+# (rules/error-handling.md aggregate-reporting carve-out).
 #
 # Run: bash hooks/tests/test_check_tessl_latest.sh
 set -uo pipefail
 
-SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/check-tessl-latest.sh"
+die() { echo "fatal: $*" >&2; exit 2; }
 
 cleanup() { [[ -n "${TMP:-}" ]] && ! rm -rf "$TMP" && echo "warn: could not remove $TMP" >&2; return 0; }
+
 pass() { PASS=$((PASS+1)); }
 fail() { FAIL=$((FAIL+1)); echo "  ✗ FAIL: $1" >&2; }
-run()  { OUT="$(TESSL_LATEST_MANIFEST="$1" bash "$SCRIPT" </dev/null 2>/dev/null)"; RC=$?; }
+
+# Write a resolved-state tessl-package.json fixture for <dep> at <version>.
+seed_pkg() { # <state-dir> <dep> <version>
+  local d="$1/plugins/$2"
+  mkdir -p "$d" || die "seed_pkg: mkdir $d failed"
+  printf '{"name":"%s","version":"%s"}\n' "$2" "$3" > "$d/tessl-package.json" \
+    || die "seed_pkg: write $d/tessl-package.json failed"
+}
+
+# run <manifest> <state-dir> [extra env...] -> OUT, RC  (fake tessl on PATH)
+run() {
+  local manifest="$1" state="$2"; shift 2
+  OUT="$(env "PATH=$STUBBIN:$PATH" TESSL_LATEST_MANIFEST="$manifest" TESSL_STATE_DIR="$state" "$@" bash "$SCRIPT" </dev/null 2>/dev/null)"
+  RC=$?
+}
+
+# has <regex>: true when the emitted additionalContext matches <regex>.
+has() { printf '%s' "$OUT" | jq -e ".additionalContext | test(\"$1\")" >/dev/null 2>&1; }
 
 main() {
-  [[ -f "$SCRIPT" && -r "$SCRIPT" ]] || { echo "fatal: hook not found at $SCRIPT" >&2; exit 2; }
-  command -v jq >/dev/null 2>&1 || { echo "fatal: jq required" >&2; exit 2; }
+  SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/check-tessl-latest.sh"
+  [[ -f "$SCRIPT" && -r "$SCRIPT" ]] || die "hook not found/readable at $SCRIPT"
+  command -v jq >/dev/null 2>&1 || die "jq required for these tests"
 
-  TMP="$(mktemp -d)" || { echo "fatal: mktemp" >&2; exit 2; }
+  TMP="$(mktemp -d -t tessl-latest-test.XXXXXX)" || die "mktemp failed"
   trap cleanup EXIT
+
+  # A FAKE `tessl`: on `update`, optionally rewrite a fixture tessl-package.json
+  # to a new version (simulating a resolved-state bump), then exit
+  # STUB_UPDATE_EXIT (default 0). Any other subcommand is a no-op success.
+  STUBBIN="$TMP/bin"; mkdir -p "$STUBBIN" || die "could not create $STUBBIN"
+  cat > "$STUBBIN/tessl" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "update" ]]; then
+  if [[ -n "${STUB_BUMP_FILE:-}" && -n "${STUB_BUMP_TO:-}" ]]; then
+    printf '{"name":"jbaruch/coding-policy","version":"%s"}\n' "$STUB_BUMP_TO" > "$STUB_BUMP_FILE"
+  fi
+  if [[ -n "${STUB_UPDATE_EXIT:-}" ]]; then
+    printf 'stub tessl: simulated update failure\n' >&2
+    exit "$STUB_UPDATE_EXIT"
+  fi
+fi
+exit 0
+STUB
+  chmod +x "$STUBBIN/tessl" || die "chmod stub tessl failed"
+
   FAIL=0; PASS=0
 
-  # 1. jbaruch/* pinned -> warns.
-  local f="$TMP/1.json"
-  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"0.3.99"},"tessl/npm-react":{"version":"19.2.0"}}}\n' > "$f"
-  run "$f"
-  if [[ $RC -eq 0 ]] && printf '%s' "$OUT" | jq -e '.additionalContext | test("jbaruch/coding-policy")' >/dev/null 2>&1; then
-    pass; else fail "pinned: expected warn, got RC=$RC OUT=$OUT"; fi
+  # 1. updated: coding-policy at latest, resolved state 0.3.147, update bumps to
+  #    0.3.153 -> "0.3.147 → 0.3.153 (updated)".
+  local m1="$TMP/m1.json" s1="$TMP/s1"
+  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"}}}\n' > "$m1" || die "write m1 failed"
+  seed_pkg "$s1" "jbaruch/coding-policy" "0.3.147"
+  run "$m1" "$s1" STUB_BUMP_FILE="$s1/plugins/jbaruch/coding-policy/tessl-package.json" STUB_BUMP_TO="0.3.153"
+  if [[ $RC -eq 0 ]] && has "Session-start status" && has "versions:" && has "0.3.147" && has "0.3.153" && has "updated"; then
+    pass; else fail "updated: expected transition status, got RC=$RC OUT=$OUT"; fi
 
-  # 2. all jbaruch/* latest -> silent.
-  f="$TMP/2.json"
-  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"}}}\n' > "$f"
-  run "$f"
-  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "all latest: expected silence, got RC=$RC OUT=$OUT"; fi
+  # 2. already latest: resolved state 0.3.153, update leaves it unchanged ->
+  #    "0.3.153 (latest)".
+  local m2="$TMP/m2.json" s2="$TMP/s2"
+  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"}}}\n' > "$m2" || die "write m2 failed"
+  seed_pkg "$s2" "jbaruch/coding-policy" "0.3.153"
+  run "$m2" "$s2"
+  if [[ $RC -eq 0 ]] && has "Session-start status" && has "0.3.153" && has "latest"; then
+    pass; else fail "already-latest: expected (latest) status, got RC=$RC OUT=$OUT"; fi
 
-  # 3. only third-party pins -> silent (jbaruch/* are latest).
-  f="$TMP/3.json"
-  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"},"tessl/npm-react":{"version":"19.2.0"}}}\n' > "$f"
-  run "$f"
+  # 3. update failed: fake tessl exits non-zero. Status still emits, hook exits 0.
+  local m3="$TMP/m3.json" s3="$TMP/s3"
+  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"}}}\n' > "$m3" || die "write m3 failed"
+  seed_pkg "$s3" "jbaruch/coding-policy" "0.3.147"
+  run "$m3" "$s3" STUB_UPDATE_EXIT=1
+  # A failed update must NOT claim "latest" for the unchanged version — it is
+  # labeled "(installed)" since freshness was never verified.
+  if [[ $RC -eq 0 ]] && has "Session-start status" && has "update failed" && has "installed" && ! has "latest"; then
+    pass; else fail "update-failed: expected 'update failed' + 'installed' (not 'latest'), got RC=$RC OUT=$OUT"; fi
+
+  # 4. tessl missing: PATH lacks tessl (jq + bash only). Update marked
+  #    unavailable, status still emits, hook exits 0.
+  local minbin="$TMP/minbin"; mkdir -p "$minbin" || die "could not create $minbin"
+  ln -s "$(command -v bash)" "$minbin/bash" || die "symlink bash failed"
+  ln -s "$(command -v jq)"   "$minbin/jq"   || die "symlink jq failed"
+  local m4="$TMP/m4.json" s4="$TMP/s4"
+  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"}}}\n' > "$m4" || die "write m4 failed"
+  seed_pkg "$s4" "jbaruch/coding-policy" "0.3.147"
+  OUT="$(env "PATH=$minbin" TESSL_LATEST_MANIFEST="$m4" TESSL_STATE_DIR="$s4" bash "$SCRIPT" </dev/null 2>/dev/null)"; RC=$?
+  if [[ $RC -eq 0 ]] && has "Session-start status" && has "update failed"; then
+    pass; else fail "tessl-missing: expected status with 'update failed', got RC=$RC OUT=$OUT"; fi
+
+  # 5. install pending: manifest lists coding-policy but no resolved-state file
+  #    exists (and the update does not create one) -> "(install pending)".
+  local m5="$TMP/m5.json" s5="$TMP/s5"
+  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"}}}\n' > "$m5" || die "write m5 failed"
+  run "$m5" "$s5"
+  if [[ $RC -eq 0 ]] && has "Session-start status" && has "install pending"; then
+    pass; else fail "install-pending: expected '(install pending)', got RC=$RC OUT=$OUT"; fi
+
+  # 6. pinned dep: coding-policy pinned to 0.3.99 -> the "NOTE:" pin warning is
+  #    appended and the marker status is present.
+  local m6="$TMP/m6.json" s6="$TMP/s6"
+  printf '{"dependencies":{"jbaruch/coding-policy":{"version":"0.3.99"}}}\n' > "$m6" || die "write m6 failed"
+  seed_pkg "$s6" "jbaruch/coding-policy" "0.3.99"
+  run "$m6" "$s6"
+  if [[ $RC -eq 0 ]] && has "Session-start status" && has "NOTE:" && has "0.3.99"; then
+    pass; else fail "pinned: expected NOTE pin warning, got RC=$RC OUT=$OUT"; fi
+
+  # 7. no manifest -> silent no-op.
+  run "$TMP/does-not-exist.json" "$TMP/s7"
+  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "no-manifest: expected silence, got RC=$RC OUT=$OUT"; fi
+
+  # 8. third-party only (no jbaruch/* deps) -> silent.
+  local m8="$TMP/m8.json" s8="$TMP/s8"
+  printf '{"dependencies":{"tessl/npm-react":{"version":"19.2.0"}}}\n' > "$m8" || die "write m8 failed"
+  run "$m8" "$s8"
   if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "third-party only: expected silence, got RC=$RC OUT=$OUT"; fi
 
-  # 4. no manifest -> silent no-op.
-  run "$TMP/does-not-exist.json"
-  if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "no manifest: expected silence, got RC=$RC OUT=$OUT"; fi
-
-  # 5. malformed JSON -> silent no-op, exit 0.
-  f="$TMP/5.json"; printf 'not json\n' > "$f"
-  run "$f"
+  # 9. malformed JSON -> silent no-op, exit 0.
+  local m9="$TMP/m9.json" s9="$TMP/s9"
+  printf 'not json\n' > "$m9" || die "write m9 failed"
+  run "$m9" "$s9"
   if [[ $RC -eq 0 && -z "$OUT" ]]; then pass; else fail "malformed: expected silent exit 0, got RC=$RC OUT=$OUT"; fi
+
+  # 10. unreadable resolved-state file: an existing but unreadable tessl-package
+  #     .json is a tool failure, not an absent-file non-result — the hook warns
+  #     to stderr and still exits 0 (distinguished from case 5's absent file,
+  #     which is silent). Skipped as root: chmod 000 does not bind root.
+  if [[ "$(id -u)" -ne 0 ]]; then
+    local m10="$TMP/m10.json" s10="$TMP/s10" errU pkg10
+    printf '{"dependencies":{"jbaruch/coding-policy":{"version":"latest"}}}\n' > "$m10" || die "write m10 failed"
+    seed_pkg "$s10" "jbaruch/coding-policy" "0.3.147"
+    pkg10="$s10/plugins/jbaruch/coding-policy/tessl-package.json"
+    chmod 000 "$pkg10" || die "chmod 000 $pkg10 failed"
+    errU="$(env "PATH=$STUBBIN:$PATH" TESSL_LATEST_MANIFEST="$m10" TESSL_STATE_DIR="$s10" bash "$SCRIPT" </dev/null 2>&1 >/dev/null)"; RC=$?
+    if [[ $RC -eq 0 ]] && printf '%s' "$errU" | grep -q "unreadable"; then
+      pass; else fail "unreadable state file: expected 'unreadable' warning + exit 0, got RC=$RC err=$errU"; fi
+  fi
 
   echo "─────────────────────────────────────────────" >&2
   if [[ $FAIL -gt 0 ]]; then echo "FAILED: ${FAIL} failed, ${PASS} passed" >&2; exit 1; fi

--- a/rules/hook-action-reporting.md
+++ b/rules/hook-action-reporting.md
@@ -1,0 +1,29 @@
+---
+alwaysApply: true
+---
+
+# Hook Action Reporting
+
+## Surface the Status
+
+- A SessionStart hook emits an `additionalContext` payload beginning with `Session-start status — ` only when it has a status to report
+- Many outcomes emit nothing (non-repo, throttled freshness check, no matching dependency)
+- At session start, collect every such payload the context carries (there may be none) and relay each in full as one block, before the first substantive action
+- A payload may span several lines, a marker line plus continuation lines such as an update list or a `NOTE:`
+- Relay the whole payload, never only its marker line
+- Report the block once per session, at the start, never repeating it every turn
+- Relay the payloads verbatim, without padding or restating them as your own analysis
+
+## Act on What It Names
+
+- A payload may name an action: a branch to sync, a pinned dependency to fix, an update that failed
+- After relaying the block, act on any such action per its governing rule
+- An all-green status needs only the report, no further action
+
+## Reconciliation With `response-clarity`
+
+- Narrow exception for the session-start status block to `rules/response-clarity.md` Lead With the Action
+- Preconditions (all required):
+  1. The block appears once per session, at the start, before the first substantive action
+  2. It carries only the `Session-start status — ` payloads, nothing else
+- Every other turn opens with the action, no status block


### PR DESCRIPTION
## Why

Consumers had no visibility into whether the SessionStart hooks ran or what they did — "did `tessl update` work? what coding-policy version am I on?" A SessionStart hook can't show the user anything directly (its output reaches the *model's* context, not the transcript), so the fix is two-part: the hooks emit a marker-tagged status, and a rule makes the agent relay it.

## What

**Hooks** (`hooks/`):
- **`check-tessl-latest.sh`** (rewrite) — runs `tessl update --yes` each session and reports every `jbaruch/*` version transition, read from the resolved `.tessl/plugins/<ws>/<plugin>/tessl-package.json` before/after, leading with `jbaruch/coding-policy`:
  - `jbaruch/coding-policy 0.3.147 → 0.3.156 (updated)` / `0.3.156 (latest)` / `(install pending)`
  - missing CLI or non-zero update → `update failed: <reason>`, never blocks (exit 0); update runs with `</dev/null` so it can't hang on a prompt
  - keeps the pin check (jbaruch/* must be `latest`) as a trailing `NOTE:`
- **`check-git-sync.sh`** / **`check-policy-freshness.sh`** — emit a positive status on their success paths (were silent); problem paths keep their text, now marker-prefixed.
- Every status line begins with the `Session-start status — ` marker. All hooks still `exit 0` on every path.

**Rule** (`rules/hook-action-reporting.md`, new) — at session start the agent relays every `Session-start status — ` line as one concise block, before its first substantive action, then acts on any action they name. Reconciled with `response-clarity` (the one sanctioned session-start preamble). Surface-synced into `plugin.json`, README rules table, and the maintainer `.claude/CLAUDE.md`.

## Design notes

- **Update cadence**: runs every session (per the request). No throttle on the update; the freshness check keeps its existing throttle.
- **Tests**: hook suites rewritten/updated (tessl-latest 9 cases, git-sync 11, freshness 7) with a fake `tessl` on `PATH` — no network. Covers updated / already-latest / update-failed / tessl-missing / install-pending / pinned / no-manifest / malformed.

## Verification

- `bash scripts/run-tests.sh` — 28/28 suites pass
- `bash scripts/run-diagnostics.sh` — shellcheck (56 scripts) + pyright clean
- No banned connectives in the new rule; `plugin.json` valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)