### PR TITLE
ci(publish): add node-version input to the reusable publish workflow

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -160,12 +160,12 @@ jobs:
       # publish command's output so the confirm gate can NAME an out-of-credits
       # failure from the logs, not merely infer it from the org's live credit
       # balance (rules/ci-safety.md "Credits Never Block Publishing"). Handles
-      # both modes: auto-bump (--bump patch from the registry + a `Bump … [skip
-      # ci]` manifest commit-back per the publish-pipeline loop-prevention
-      # carve-out, mirroring patch-version-publish) and as-is (manifest version
-      # verbatim, no bump, no commit-back — a missing human bump surfaces as a
-      # red `version already exists`). Sibling action referenced by full path
-      # @main (same-repo reusable-workflow carve-out).
+      # both modes: auto-bump (compute the registry-aware next version + a `Bump
+      # … [skip ci]` manifest commit-back per the publish-pipeline loop-
+      # prevention carve-out) and as-is (manifest version verbatim, no bump, no
+      # commit-back — a missing human bump surfaces as a red `version already
+      # exists`). Sibling action referenced by full path @main (same-repo
+      # reusable-workflow carve-out).
       #
       # continue-on-error: a post-publish out-of-credits exit lands the artifact
       # then exits non-zero. Do NOT let that red the job here — the confirm gate

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -14,6 +14,7 @@ name: Publish plugin (reusable)
 #       with:
 #         stamp-changelog: true          # optional
 #         python-version: '3.11'         # optional — only if the gate needs it
+#         node-version: '22'             # optional — only if a node gate needs it
 #         pre-publish-script: .github/pre-publish.sh   # optional repo-specific gate
 #         publish-mode: as-is            # optional — default auto-bump
 #
@@ -34,6 +35,10 @@ on:
         description: 'If set, sets up this Python before the pre-publish gate (for gates needing a pinned interpreter). Empty = no Python setup.'
         type: string
         default: ''
+      node-version:
+        description: 'If set, sets up this Node before the pre-publish gate (for node gates needing a pinned runtime). Empty = no Node setup.'
+        type: string
+        default: ''
       pre-publish-script:
         description: 'Path (in the caller repo) to a bash gate script run after checkout, before publish. Empty = no repo-specific gate.'
         type: string
@@ -51,7 +56,7 @@ on:
         type: boolean
         default: false
       publish-mode:
-        description: "'auto-bump' = tesslio/patch-version-publish (bump + commit + publish); 'as-is' = tessl plugin publish (manifest version verbatim, no bump)."
+        description: "Passed to the smart-publish action. 'auto-bump' = compute the registry-aware next version, publish it, commit the manifest bump back; 'as-is' = publish the manifest version verbatim, no bump, no commit-back (a human-bump model)."
         type: string
         default: 'auto-bump'
     secrets:
@@ -82,6 +87,12 @@ jobs:
         uses: actions/setup-python@v7
         with:
           python-version: ${{ inputs.python-version }}
+
+      - name: Set up Node
+        if: inputs.node-version != ''
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
 
       # Repo-specific gate (pyright, unit tests, custom lints, carve-out
       # checks). Deterministic gate logic lives in the caller's script per

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Actions — the reusable publish workflow can pin a Node runtime for the pre-publish gate
+
+The reusable `publish-plugin.yml` pinned only Python (`python-version`), so a node plugin's pre-publish gate (typecheck, tests) had nowhere to pin its runtime — it would have to run on the runner's unpinned system Node, a reproducibility regression `dependency-management` Pinning forbids. New optional `node-version` input sets up a pinned Node before the gate (mirrors `python-version`, `actions/setup-node@v7`, empty = no setup). This unblocks migrating node consumers (`tripit-api`) onto the canonical pipeline with their `node-version` pinned. Also corrects the stale `publish-mode` input description, which still named `tesslio/patch-version-publish` — both modes run through `smart-publish` since 0.3.158.
+
 ## 0.3.162 — 2026-08-17
 
 ### Fix — auto-bump computes the next version registry-aware, so a stale manifest cannot collide


### PR DESCRIPTION
## Scope: CI change (explicit)
This PR intentionally edits `.github/workflows/publish-plugin.yml` — a CI-config change, announced here per `rules/ci-safety.md` Hands Off CI Config.

## What
Adds an optional `node-version` input to the reusable publish workflow that sets up a pinned Node (`actions/setup-node@v7`) before the pre-publish gate — mirroring the existing `python-version` input. Empty (default) = no Node setup.

## Why
The reusable workflow pinned only Python, so a **node** consumer's pre-publish gate (typecheck, tests) had nowhere to pin its runtime. Running npm gates on the runner's unpinned system Node is a reproducibility regression `dependency-management` Pinning forbids. This unblocks migrating node consumers (`tripit-api`, pinned node 22) onto the canonical pipeline without that compromise.

## Also (boy-scout, same file)
Corrects the stale `publish-mode` input description — it still named `tesslio/patch-version-publish`, but both modes run through `smart-publish` since 0.3.158.

## Risk
Purely additive: the new step is gated `if: inputs.node-version != ''`, so every existing caller (all pass empty) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186da3iE7wGaQzsqXPHPymU