### PR TITLE
fix(release): retry transient tessl api failure in moderation wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fix — the moderation wait retries a transient `tessl api` blip instead of aborting
+
+`verify-moderation-cleared.sh` treated any non-zero `tessl api` exit as a terminal tool failure (exit 2) with no retry. During the 0.3.165 release the local tessl CLI — a version behind the registry's latest — intermittently exited non-zero on its version-check path, so the first moderation poll aborted the whole wait even though the release had published cleanly; an immediate re-run cleared on attempt 1. The script now retries a failed fetch inside its existing backoff loop up to `FETCH_RETRY_MAX` (default 3) consecutive times, resets the counter on any successful fetch, and escalates to exit 2 only on a persistent failure or budget exhaustion — a genuine tool/auth/network fault, distinguished from a momentary blip. The pending-poll and transient-retry paths now share one `advance_backoff` schedule rather than duplicating the sleep/backoff. New `VERIFY_MODERATION_FETCH_RETRY_MAX` override; five new tests (retry-to-cap, transient-then-success, cap override, budget-during-failure, env validation). Closes #304.
+
 ## 0.3.165 — 2026-08-18
 
 ### Fix — CHANGELOG entry length lives in one rule, and it is not a cap

--- a/skills/release/tests/test_verify_moderation_cleared.sh
+++ b/skills/release/tests/test_verify_moderation_cleared.sh
@@ -15,7 +15,13 @@
 #      budget diagnostic and bounded total sleep.
 #   7. Arg-count + empty-arg validation — exit 2 with usage/diagnostic.
 #   8. Env-var validation — non-positive / inverted bounds exit 2.
-#   9. tessl failure — non-zero `tessl api` exits 2 with a diagnostic.
+#   9. Persistent tessl failure — non-zero `tessl api` is retried up to
+#      FETCH_RETRY_MAX consecutive times, then exits 2 (issue #304).
+#   9b. Transient then success — a fetch failure below the cap retries in the
+#       loop and clears on a later call, exit 0.
+#   9c. Retry cap is FETCH_RETRY_MAX — overriding it bounds the retries.
+#   9d. Persistent failure to budget — a high cap lets the budget stop the
+#       retries; still exit 2 (tool failure), never rc 1.
 #  10. Unparseable body — no moderation fields exits 2.
 #
 # Approach mirrors test_resolve_publish_run.sh: source the script (the
@@ -233,12 +239,56 @@ if [[ $rc -eq 2 ]]; then pass "base delay 0: exit 2"; else fail "base delay 0 (r
 if [[ $rc -eq 2 ]]; then pass "base > max: exit 2"; else fail "base > max (rc=$rc)"; fi
 ( BASE_DELAY_SEC=100 MAX_DELAY_SEC=100 BUDGET_SEC=10 main acme widget 1.2.3 ) >/dev/null 2>&1; rc=$?
 if [[ $rc -eq 2 ]]; then pass "base > budget: exit 2"; else fail "base > budget (rc=$rc)"; fi
+( FETCH_RETRY_MAX=0 main acme widget 1.2.3 ) >/dev/null 2>&1; rc=$?
+if [[ $rc -eq 2 ]]; then pass "fetch-retry-max 0: exit 2"; else fail "fetch-retry-max 0 (rc=$rc)"; fi
 
-# --- 9. tessl failure ---
+# --- 9. Persistent tessl failure: retried FETCH_RETRY_MAX times, then exit 2 ---
+# A single fixture is sticky-last, so every call fails. Default
+# FETCH_RETRY_MAX=3 => 3 consecutive failures before the hard exit 2.
 reset_mocks
 queue 1 "$(printf '__FAIL__\n500 Internal Server Error')"
 out=$(main acme widget 1.2.3 2>/dev/null); rc=$?
-if [[ $rc -eq 2 ]]; then pass "tessl api failure: exit 2"; else fail "tessl failure (rc=$rc out=$out)"; fi
+if [[ $rc -eq 2 ]] && [[ "$(count_calls)" == "3" ]]; then
+  pass "persistent tessl failure: retried to FETCH_RETRY_MAX then exit 2"
+else
+  fail "persistent tessl failure (rc=$rc calls=$(count_calls) out=$out)"
+fi
+
+# --- 9b. Transient failure then success: retry inside the loop, exit 0 ---
+# First call fails (below FETCH_RETRY_MAX), the next clears (issue #304).
+reset_mocks
+queue 1 "$(printf '__FAIL__\n502 Bad Gateway')"
+queue 2 "$(body_json pass true '')"
+out=$(main acme widget 1.2.3 2>/dev/null); rc=$?
+if [[ $rc -eq 0 ]] && echo "$out" | jq -e '.ok == true' >/dev/null 2>&1 && [[ "$(count_calls)" == "2" ]] && [[ "$(count_sleeps)" -ge 1 ]]; then
+  pass "transient failure then pass: retried and cleared, exit 0"
+else
+  fail "transient then pass (rc=$rc out=$out calls=$(count_calls) sleeps=$(count_sleeps))"
+fi
+
+# --- 9c. Retry cap is FETCH_RETRY_MAX ---
+# Command-scope the global (same pattern as the env-var tests): 2 consecutive
+# failures now exit 2, proving the cap is the constant, not hardcoded.
+reset_mocks
+queue 1 "$(printf '__FAIL__\n500 err')"
+out=$( FETCH_RETRY_MAX=2 main acme widget 1.2.3 2>/dev/null ); rc=$?
+if [[ $rc -eq 2 ]] && [[ "$(count_calls)" == "2" ]]; then
+  pass "FETCH_RETRY_MAX=2: exit 2 after exactly 2 failures"
+else
+  fail "retry cap override (rc=$rc calls=$(count_calls))"
+fi
+
+# --- 9d. Persistent failure hits the budget before a high retry cap ---
+# With a high FETCH_RETRY_MAX the budget bound stops the retries; it exits 2
+# (tool failure), never rc 1 (rc 1 is a moderation verdict, not a tool fault).
+reset_mocks
+queue 1 "$(printf '__FAIL__\n503 err')"
+err=$( { FETCH_RETRY_MAX=100 main acme widget 1.2.3 >/dev/null; } 2>&1 ); rc=$?
+if [[ $rc -eq 2 ]] && [[ "$err" == *"budget is exhausted"* ]]; then
+  pass "persistent failure to budget: exit 2 with budget diagnostic"
+else
+  fail "transient-to-budget (rc=$rc err=$err)"
+fi
 
 # --- 10. Unparseable body ---
 reset_mocks

--- a/skills/release/verify-moderation-cleared.sh
+++ b/skills/release/verify-moderation-cleared.sh
@@ -17,6 +17,11 @@
 # would exceed BUDGET_SEC. Constants below; override via the matching
 # env vars (used by the test harness to keep runs fast).
 #
+# Transient fetch retry: a non-zero `tessl api` exit is retried inside the
+# backoff loop up to FETCH_RETRY_MAX consecutive times before exiting 2, so
+# a momentary CLI/network blip does not abort a wait for a release that
+# published fine (issue #304). A successful fetch resets the counter.
+#
 # Fail-loud-at-budget: a still-pending OR blocked state when the budget is
 # exhausted exits 1 — an unconfirmed release is never reported as success.
 #
@@ -32,8 +37,8 @@
 #            same fields and "ok": false). Wrappers MUST parse stdout only
 #            when exit code is 0 or 1.
 # Exit:  0 moderation cleared; 1 blocked or still-pending at budget
-#        exhaustion (fail loud); 2 argument-validation or external-tool
-#        failure (tessl unreachable, jq missing, bad env var).
+#        exhaustion (fail loud); 2 argument-validation, jq-missing, or a
+#        persistent `tessl api` failure (retried FETCH_RETRY_MAX times first).
 
 set -euo pipefail
 
@@ -42,6 +47,12 @@ set -euo pipefail
 BASE_DELAY_SEC="${VERIFY_MODERATION_BASE_DELAY_SEC:-5}"
 MAX_DELAY_SEC="${VERIFY_MODERATION_MAX_DELAY_SEC:-120}"
 BUDGET_SEC="${VERIFY_MODERATION_BUDGET_SEC:-600}"
+# Consecutive `tessl api` fetch failures tolerated before declaring a
+# persistent tool failure (issue #304). A single transient non-zero exit —
+# an outdated CLI's version-check blip, a momentary network drop — is retried
+# inside the backoff loop rather than aborting the whole moderation wait; a
+# genuinely persistent failure still exits 2 fast.
+FETCH_RETRY_MAX="${VERIFY_MODERATION_FETCH_RETRY_MAX:-3}"
 
 # Terminal "blocked" moderation states — fast-fail without waiting out the
 # budget. Anything not in here and not "pass" is treated as still-pending
@@ -105,6 +116,19 @@ is_block_state() {
   return 1
 }
 
+# Sleep one backoff interval and advance the schedule. Reads and WRITES the
+# caller's `delay` and `elapsed` locals via bash dynamic scope (same idiom as
+# the script-global `err_file`), so both the pending-poll path and the
+# transient-fetch-retry path share one backoff schedule rather than
+# duplicating it. Declares no `delay`/`elapsed` local of its own — that would
+# shadow the caller's and silently stall the schedule.
+advance_backoff() {
+  sleep "$delay"
+  elapsed=$(( elapsed + delay ))
+  delay=$(( delay * 2 ))
+  (( delay > MAX_DELAY_SEC )) && delay="$MAX_DELAY_SEC"
+}
+
 main() {
   if [[ $# -ne 3 ]]; then
     echo "usage: $0 <workspace> <plugin> <version>" >&2
@@ -119,6 +143,7 @@ main() {
   validate_positive_int "VERIFY_MODERATION_BASE_DELAY_SEC" "$BASE_DELAY_SEC"
   validate_positive_int "VERIFY_MODERATION_MAX_DELAY_SEC" "$MAX_DELAY_SEC"
   validate_positive_int "VERIFY_MODERATION_BUDGET_SEC" "$BUDGET_SEC"
+  validate_positive_int "VERIFY_MODERATION_FETCH_RETRY_MAX" "$FETCH_RETRY_MAX"
   if (( BASE_DELAY_SEC > MAX_DELAY_SEC )); then
     echo "error: VERIFY_MODERATION_BASE_DELAY_SEC (${BASE_DELAY_SEC}) must not exceed VERIFY_MODERATION_MAX_DELAY_SEC (${MAX_DELAY_SEC})" >&2
     exit 2
@@ -129,7 +154,7 @@ main() {
   fi
 
   local endpoint="v1/tiles/${workspace}/${tile}/versions/${version}"
-  local delay="$BASE_DELAY_SEC" elapsed=0 attempts=0
+  local delay="$BASE_DELAY_SEC" elapsed=0 attempts=0 fetch_failures=0
   err_file=$(mktemp) || { echo "error: mktemp failed — cannot run verify-moderation-cleared.sh without writable TMPDIR" >&2; exit 2; }
   # Named handler ending `return 0` — the EXIT trap's final command status
   # becomes the script's exit status, so a failing `rm` would rewrite the
@@ -142,9 +167,28 @@ main() {
     # Separate stdout (the JSON body) from stderr so a tessl warning can't
     # poison the parsed payload — same capture discipline as
     # verify-publish-landed.sh.
+    # A non-zero `tessl api` exit is retried, not fatal: an outdated CLI's
+    # version-check blip or a momentary network drop must not abort a wait
+    # for a release that already published (issue #304). Escalate to exit 2
+    # only after FETCH_RETRY_MAX CONSECUTIVE failures, or if the budget runs
+    # out first — a persistent tool/auth/network fault, not a missing version.
     local body
-    body=$(tessl api "$endpoint" 2>"$err_file") \
-      || { local err; err=$(cat "$err_file"); echo "error: 'tessl api ${endpoint}' failed: ${err} — verify (1) tessl CLI is installed and on PATH ('command -v tessl'), (2) the workspace/plugin/version slug is correct, (3) you have network access to the registry, then re-run; the version was already confirmed on the registry by verify-publish-landed.sh, so a persistent failure here is a tool/auth/network problem, not a missing version" >&2; exit 2; }
+    if ! body=$(tessl api "$endpoint" 2>"$err_file"); then
+      local err; err=$(cat "$err_file")
+      fetch_failures=$(( fetch_failures + 1 ))
+      if (( fetch_failures >= FETCH_RETRY_MAX )); then
+        echo "error: 'tessl api ${endpoint}' failed ${fetch_failures} consecutive time(s): ${err} — verify (1) tessl CLI is installed and on PATH ('command -v tessl'), (2) the workspace/plugin/version slug is correct, (3) you have network access to the registry, then re-run; the version was already confirmed on the registry by verify-publish-landed.sh, so a persistent failure here is a tool/auth/network problem, not a missing version" >&2
+        exit 2
+      fi
+      if (( elapsed + delay > BUDGET_SEC )); then
+        echo "error: 'tessl api ${endpoint}' kept failing (${fetch_failures} consecutive) and the ${BUDGET_SEC}s budget is exhausted: ${err} — treat as a tool/auth/network failure, not a moderation verdict; re-run once tessl is reachable" >&2
+        exit 2
+      fi
+      echo "verify-moderation-cleared.sh: warning: 'tessl api ${endpoint}' failed (attempt ${fetch_failures}/${FETCH_RETRY_MAX}), retrying after backoff" >&2
+      advance_backoff
+      continue
+    fi
+    fetch_failures=0
 
     # Validate the payload ONCE, explicitly, before extracting fields.
     # Each extraction previously carried `2>/dev/null || true`, collapsing
@@ -212,10 +256,7 @@ main() {
         "$status" "$version" "$attempts" "$elapsed" 1
     fi
 
-    sleep "$delay"
-    elapsed=$(( elapsed + delay ))
-    delay=$(( delay * 2 ))
-    (( delay > MAX_DELAY_SEC )) && delay="$MAX_DELAY_SEC"
+    advance_backoff
   done
 }
 


### PR DESCRIPTION
Closes #304.

## Problem

`skills/release/verify-moderation-cleared.sh` treated **any** non-zero `tessl api` exit as a terminal tool failure (`exit 2`) with no retry:

```sh
body=$(tessl api "$endpoint" 2>"$err_file") || { ...; exit 2; }
```

During the 0.3.165 release the local `tessl` CLI (a version behind the registry's latest) intermittently exited non-zero on its version-check path, so the **first** moderation poll aborted the entire wait — even though the release had published cleanly. An immediate re-run cleared on attempt 1.

## Fix

- A failed fetch is now retried inside the existing backoff loop up to `FETCH_RETRY_MAX` (default **3**) **consecutive** times, resetting the counter on any successful fetch.
- Escalate to `exit 2` only on a **persistent** failure (cap reached) or **budget exhaustion** — a genuine tool/auth/network fault, distinguished from a momentary blip. The fail-loud-at-budget contract is unchanged; an unconfirmed release is still never reported as success.
- Factor the sleep/backoff into a shared `advance_backoff` helper so the pending-poll and transient-retry paths use one schedule instead of duplicating it.
- New override `VERIFY_MODERATION_FETCH_RETRY_MAX`.

## Tests

Five new cases in `test_verify_moderation_cleared.sh` (now 22, all green):
- persistent failure → retried to the cap, then exit 2
- transient failure then success → retried and cleared, exit 0
- cap is `FETCH_RETRY_MAX` (override bounds the retries)
- persistent failure hits the budget before a high cap → exit 2 with budget diagnostic
- `FETCH_RETRY_MAX=0` → env-validation exit 2

Pre-handoff gate run locally: `run-diagnostics.sh` (shellcheck 64 scripts + pyright) clean, `run-tests.sh` 32/32 suites pass.

No rule/skill prose change — the script owns its constants (`rules/script-as-black-box.md`) and the fail-loud-at-budget contract those artifacts reference is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)